### PR TITLE
[MariaDB compatibility] Update CategoryDataGrid.php

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
@@ -170,14 +170,14 @@ class CategoryDataGrid extends DataGrid
         return DB::table(DB::raw("(WITH RECURSIVE tree_view AS (
             SELECT id,
                 parent_id,
-                (CASE WHEN additional_data->'$.locale_specific.".$locales.".name' IS NOT NULL THEN REPLACE(additional_data->'$.locale_specific.".$locales.".name', '\"', '') ELSE CONCAT('[', code, ']') END) as name
+                (CASE WHEN JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name') IS NOT NULL THEN REPLACE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name'), '\"', '') ELSE CONCAT('[', code, ']') END) as name
             FROM ".$tablePrefix."categories
             WHERE parent_id IS NULL
             UNION ALL
 
             SELECT parent.id,
                 parent.parent_id,
-                CONCAT(tree_view.name, ' / ', (CASE WHEN additional_data->'$.locale_specific.".$locales.".name' IS NOT NULL THEN REPLACE(additional_data->'$.locale_specific.".$locales.".name', '\"', '') ELSE CONCAT('[', code, ']') END)) AS name
+                CONCAT(tree_view.name, ' / ', (CASE WHEN JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name') IS NOT NULL THEN REPLACE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name'), '\"', '') ELSE CONCAT('[', code, ']') END)) AS name
             FROM ".$tablePrefix.'categories parent
             JOIN tree_view ON parent.parent_id = tree_view.id
         )


### PR DESCRIPTION
## Issue Reference
#3 

## Description
The case is the the same of channels. When a query builder use the -> operator instead of json_extract function to query a json variable, the datagrid can't show the datagrid as the query failed. This is due to the incompatibility of the operator -> with MariaDB
