### PR TITLE
Datagrid improvement

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
@@ -261,6 +261,10 @@
                             newPage = this.available.meta.current_page - 1;
                         } else if (directionOrPageNumber === 'next') {
                             newPage = this.available.meta.current_page + 1;
+                        } else if (directionOrPageNumber === 'first') {
+                            newPage = 1;
+                        } else if (directionOrPageNumber === 'last') {
+                            newPage = this.available.meta.last_page;
                         } else {
                             console.warn('Invalid Direction Provided : ' + directionOrPageNumber);
 

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/toolbar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/toolbar.blade.php
@@ -129,7 +129,7 @@
         </div>
 
         <!-- Right Toolbar -->
-        <div class="flex gap-x-4">
+        <div class="flex items-center gap-x-4">
             <!-- Filters Activation Button -->
             <x-admin::drawer width="350px" ref="filterDrawer">
                 <x-slot:toggle>

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/toolbar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/toolbar.blade.php
@@ -221,17 +221,29 @@
                 <!-- Pagination -->
                 <div class="flex items-center gap-1">
                     <div
+                        class="inline-flex w-full max-w-max cursor-pointer appearance-none items-center justify-between gap-x-1 rounded-md border border-transparent text-center text-gray-600 dark:text-gray-300 transition-all marker:shadow hover:bg-violet-100 dark:hover:bg-gray-800 active:border-gray-300"
+                        @click="changePage('first')"
+                    >
+                        <span class="text-2xl">&#171;</span>
+                    </div>
+                    <div
                         class="inline-flex w-full max-w-max cursor-pointer appearance-none items-center justify-between gap-x-1 rounded-md border border-transparent p-1.5 text-center text-gray-600 dark:text-gray-300 transition-all marker:shadow hover:bg-violet-100 dark:hover:bg-gray-800 active:border-gray-300"
                         @click="changePage('previous')"
                     >
-                        <span class="icon-chevron-left text-2xl"></span>
+                        <span class="text-2xl">&#8249;</span>
                     </div>
 
                     <div
                         class="inline-flex w-full max-w-max cursor-pointer appearance-none items-center justify-between gap-x-1 rounded-md border border-transparent p-1.5 text-center text-gray-600 dark:text-gray-300 transition-all marker:shadow hover:bg-violet-100 dark:hover:bg-gray-800 active:border-gray-300"
                         @click="changePage('next')"
                     >
-                        <span class="icon-chevron-right text-2xl"></span>
+                        <span class="text-2xl">&#8250;</span>
+                    </div>
+                    <div
+                        class="inline-flex w-full max-w-max cursor-pointer appearance-none items-center justify-between gap-x-1 rounded-md border border-transparent text-center text-gray-600 dark:text-gray-300 transition-all marker:shadow hover:bg-violet-100 dark:hover:bg-gray-800 active:border-gray-300"
+                        @click="changePage('last')"
+                    >
+                        <span class="text-2xl">&#187;</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Issue Reference
The first and the last page action are missing in the pagination af datagrids

## Description
The possibity to go directly to the first or to the last page of a datagrid has been added without to have to type the page number in the paginator. It prevents user to go back to the keyboard while navigating throw recordsets
![image](https://github.com/user-attachments/assets/90a48899-f280-476e-bcfe-bba97f3c1555)

1. Go to the first page
2. Go to the last page
