### PR TITLE
fix: Datagrid improvement #27

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
@@ -278,6 +278,10 @@
                         return;
                     }
 
+                    if (this.applied.pagination.page == newPage) {
+                        return;
+                    }
+
                     /**
                      * Check if the `newPage` is within the valid range.
                      */


### PR DESCRIPTION
- fix: prevent datagrid from loading when clicking first/last page buton while already on first/last page