### PR TITLE
feat: configuration for attribute and category field types

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeDataGrid.php
@@ -7,6 +7,16 @@ use Webkul\DataGrid\DataGrid;
 
 class AttributeDataGrid extends DataGrid
 {
+    protected array $typeConfig = [];
+
+    /**
+     * Initialize the config value
+     */
+    public function __construct()
+    {
+        $this->typeConfig = config('attribute_types');
+    }
+
     /**
      * Prepare query builder.
      *
@@ -68,7 +78,7 @@ class AttributeDataGrid extends DataGrid
             'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
-            'closure'    => fn ($row) => trans('admin::app.catalog.attributes.create.'.$row->type),
+            'closure'    => fn ($row) => trans($this->typeConfig[$row->type]['name'] ?? "[$row->type]"),
         ]);
 
         $this->addColumn([

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryFieldDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryFieldDataGrid.php
@@ -17,6 +17,16 @@ class CategoryFieldDataGrid extends DataGrid
      */
     protected $sortOrder = 'desc';
 
+    protected array $typeConfig = [];
+
+    /**
+     * Initialize the config value
+     */
+    public function __construct()
+    {
+        $this->typeConfig = config('category_field_types');
+    }
+
     /**
      * Prepare query builder.
      *
@@ -116,7 +126,7 @@ class CategoryFieldDataGrid extends DataGrid
             'label'      => trans('admin::app.catalog.category_fields.index.datagrid.type'),
             'type'       => 'string',
             'searchable' => true,
-            'closure'    => fn ($row) => trans('admin::app.catalog.category_fields.create.'.$row->type),
+            'closure'    => fn ($row) => trans($this->typeConfig[$row->type]['name'] ?? "[$row->type]"),
             'filterable' => true,
             'sortable'   => true,
         ]);

--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/create.blade.php
@@ -101,14 +101,14 @@
                                 </x-admin::form.control-group.label>
 
                                 @php
-                                    $supportedTypes = ['text', 'textarea', 'price', 'boolean', 'select', 'multiselect', 'datetime', 'date', 'image', 'gallery', 'file', 'checkbox'];
+                                    $supportedTypes = config('attribute_types');
 
                                     $attributeTypes = [];
 
                                     foreach($supportedTypes as $type) {
                                         $attributeTypes[] = [
-                                            'id'    => $type,
-                                            'label' => trans('admin::app.catalog.attributes.create.'. $type)
+                                            'id'    => $type['key'],
+                                            'label' => trans($type['name'])
                                         ];
                                     }
 

--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
@@ -101,14 +101,14 @@
                                 </x-admin::form.control-group.label>
 
                                 @php
-                                    $supportedTypes = ['text', 'textarea', 'price', 'boolean', 'select', 'multiselect', 'datetime', 'date', 'image', 'gallery', 'file', 'checkbox'];
+                                    $supportedTypes = config('attribute_types');
 
                                     $attributeTypes = [];
 
-                                    foreach($supportedTypes as $type) {
+                                    foreach($supportedTypes as $key => $type) {
                                         $attributeTypes[] = [
-                                            'id'    => $type,
-                                            'label' => trans('admin::app.catalog.attributes.edit.'. $type)
+                                            'id'    => $key,
+                                            'label' => trans($type['name'])
                                         ];
                                     }
 
@@ -486,13 +486,7 @@
                                         for="is_unique"
                                     >
                                         @lang('admin::app.catalog.attributes.edit.is-unique')
-                                    </label>    
-
-                                    <x-admin::form.control-group.control
-                                        type="hidden"
-                                        :name="$type"
-                                        :value="$attribute->is_unique"
-                                    />
+                                    </label>
                                 </x-admin::form.control-group>
                             </x-slot>
                         </x-admin::accordion>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/field/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/field/create.blade.php
@@ -101,24 +101,18 @@
 
                                  
                                     @php
-                                        $supportedTypes = ['text', 'textarea', 'boolean', 'select', 'multiselect', 'datetime', 'date', 'image', 'file', 'checkbox'];
+                                        $supportedTypes = config('category_field_types');
 
                                         $fieldTypes = [];
 
-                                        foreach($supportedTypes as $type) {
+                                        foreach($supportedTypes as $key => $type) {
                                             $fieldTypes[] = [
-                                                'id'    => $type,
-                                                'label' => trans('admin::app.catalog.category_fields.create.'. $type)
+                                                'id'    => $key,
+                                                'label' => trans($type['name'])
                                             ];
                                         }
 
                                         $fieldTypesJson = json_encode($fieldTypes);
-
-                                        $selectedType = [
-                                            'id'    => old('type'),
-                                            'label' => trans('admin::app.catalog.category_fields.create.'. old('type'))
-                                        ];
-
                                     @endphp
                                     
                                     <x-admin::form.control-group.control

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/field/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/field/edit.blade.php
@@ -100,16 +100,21 @@
 
                                 
                                 @php
-                                    $selectedOption = json_encode(['id' => $categoryField->type, 'label' => trans('admin::app.catalog.category_fields.create.'.$categoryField->type)]);
+                                    $supportedTypes = config('category_field_types');
 
-                                    $supportedTypes = ['text', 'textarea', 'boolean', 'select', 'multiselect', 'datetime', 'date', 'image', 'file', 'checkbox'];
+                                    $fieldType = $categoryField->type;
+
+                                    $selectedOption = json_encode([
+                                        'id'    => $fieldType,
+                                        'label' => trans($supportedTypes[$fieldType]['name'] ?? '')
+                                    ]);
 
                                     $attributeTypes = [];
 
-                                    foreach($supportedTypes as $type) {
+                                    foreach($supportedTypes as $key => $type) {
                                         $attributeTypes[] = [
-                                            'id'    => $type,
-                                            'label' => trans('admin::app.catalog.category_fields.create.'. $type)
+                                            'id'    => $key,
+                                            'label' => trans($type['name'])
                                         ];
                                     }
 
@@ -122,7 +127,6 @@
                                     class="cursor-not-allowed"
                                     name="type"
                                     rules="required"
-                                    :value="$selectedOption"
                                     v-model="categoryField.type"
                                     disabled
                                     :label="trans('admin::app.catalog.category_fields.edit.type')"
@@ -490,12 +494,6 @@
                                     >
                                         @lang('admin::app.catalog.category_fields.edit.is-unique')
                                     </label>    
-
-                                    <x-admin::form.control-group.control
-                                        type="hidden"
-                                        :name="$type"
-                                        :value="$categoryField->is_unique"
-                                    />
                                 </x-admin::form.control-group>
                             </x-slot>
                         </x-admin::accordion>

--- a/packages/Webkul/Admin/src/Resources/views/components/categories/dynamic-fields.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/categories/dynamic-fields.blade.php
@@ -30,7 +30,11 @@
         $fieldLabel = $field->translate($currentLocaleCode)['name'] ?? '';
 
         $fieldLabel = empty($fieldLabel) ? '['.$field->code.']' : $fieldLabel;
+
+        $fieldType = $field->type;
     @endphp
+
+    {!! view_render_event('unopim.admin.categories.dynamic-fields.field.before', ['field' => $field]) !!}
 
     <x-admin::form.control-group>
         <div class="inline-flex justify-between w-full">
@@ -51,7 +55,9 @@
             </div>
         </div>
 
-        @switch ($field->type)
+        {!! view_render_event('unopim.admin.categories.dynamic-fields.control.'.$fieldType.'.before', ['field' => $field, 'value' => $value, 'fieldName' => $fieldName]) !!}
+
+        @switch ($fieldType)
             @case ('checkbox')
                 @if (! empty($value))
                     <input type="hidden" name="{{ $fieldName }}" value="">
@@ -121,6 +127,7 @@
                     :id="$field->code"
                     ::rules="{{ $field->getValidationsField() }}"
                     :uploaded-images="! empty($value) ? [$savedImage] : []"
+                    width='210px'
                 />
                 @break
             @case('file')
@@ -173,7 +180,7 @@
                         ];
                     }
 
-                    if ('select' == $field->type) {
+                    if ('select' == $fieldType) {
                         $selectedValue = ! empty($selectedValue[0]) ? $selectedValue[0] : $selectedValue;
                     }
 
@@ -181,7 +188,7 @@
                 @endphp
             @default
                 <x-admin::form.control-group.control
-                    :type="$field->type"
+                    :type="$fieldType"
                     :id="$field->code"
                     :name="$fieldName"
                     ::rules="{{ $field->getValidationsField() }}"
@@ -206,6 +213,10 @@
             />
         @endIf
 
+        {!! view_render_event('unopim.admin.categories.dynamic-fields.control.'.$fieldType.'.after', ['field' => $field, 'value' => $value, 'fieldName' => $fieldName]) !!}
+
         <x-admin::form.control-group.error :control-name="$fieldName" />
     </x-admin::form.control-group>
+
+    {!! view_render_event('unopim.admin.categories.dynamic-fields.field.after', ['fieldType' => $fieldType]) !!}
 @endforeach

--- a/packages/Webkul/Admin/src/Resources/views/components/products/dynamic-attribute-fields.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/products/dynamic-attribute-fields.blade.php
@@ -37,7 +37,11 @@
         $fieldLabel = $field->translate($currentLocaleCode)['name'] ?? '';
 
         $fieldLabel = empty($fieldLabel) ? '['.$field->code.']' : $fieldLabel;
+
+        $fieldType = $field->type;
     @endphp
+
+    {!! view_render_event('unopim.admin.products.dynamic-attribute-fields.field.before', ['field' => $field]) !!}
 
     <x-admin::form.control-group>
         <div class="inline-flex justify-between w-full">
@@ -63,7 +67,9 @@
             </div>
         </div>
 
-        @switch ($field->type)
+        {!! view_render_event('unopim.admin.products.dynamic-attribute-fields.control.'.$fieldType.'.before', ['field' => $field, 'value' => $value, 'fieldName' => $fieldName]) !!}
+
+        @switch ($fieldType)
             @case ('checkbox')
                 @if (! empty($value))
                     <input type="hidden" name="{{ $fieldName }}" value="">
@@ -241,7 +247,7 @@
                         ];
                     }
 
-                    if ('select' == $field->type) {
+                    if ('select' == $fieldType) {
                         $selectedValue = ! empty($selectedValue[0]) ? $selectedValue[0] : $selectedValue;
                     }
 
@@ -249,7 +255,7 @@
                 @endphp
             @default
                 <x-admin::form.control-group.control
-                    :type="$field->type"
+                    :type="$fieldType"
                     :id="$field->code"
                     :name="$fieldName"
                     ::rules="{{ $field->getValidationsField() }}"
@@ -280,6 +286,10 @@
             />
         @endIf
 
+        {!! view_render_event('unopim.admin.products.dynamic-attribute-fields.control.'.$fieldType.'.after', ['field' => $field, 'value' => $value, 'fieldName' => $fieldName]) !!}
+
         <x-admin::form.control-group.error :control-name="$fieldName" />
     </x-admin::form.control-group>
+
+    {!! view_render_event('unopim.admin.products.dynamic-attribute-fields.field.after', ['fieldType' => $fieldType]) !!}
 @endforeach

--- a/packages/Webkul/Attribute/src/Config/attribute_types.php
+++ b/packages/Webkul/Attribute/src/Config/attribute_types.php
@@ -1,0 +1,63 @@
+<?php
+
+return [
+    'text' => [
+        'key'  => 'text',
+        'name' => 'admin::app.catalog.attributes.create.text',
+    ],
+
+    'textarea' => [
+        'key'  => 'textarea',
+        'name' => 'admin::app.catalog.attributes.create.textarea',
+    ],
+
+    'price' => [
+        'key'  => 'price',
+        'name' => 'admin::app.catalog.attributes.create.price',
+    ],
+
+    'boolean' => [
+        'key'  => 'boolean',
+        'name' => 'admin::app.catalog.attributes.create.boolean',
+    ],
+
+    'select' => [
+        'key'  => 'select',
+        'name' => 'admin::app.catalog.attributes.create.select',
+    ],
+
+    'multiselect' => [
+        'key'  => 'multiselect',
+        'name' => 'admin::app.catalog.attributes.create.multiselect',
+    ],
+
+    'datetime' => [
+        'key'  => 'datetime',
+        'name' => 'admin::app.catalog.attributes.create.datetime',
+    ],
+
+    'date' => [
+        'key'  => 'date',
+        'name' => 'admin::app.catalog.attributes.create.date',
+    ],
+
+    'image' => [
+        'key'  => 'image',
+        'name' => 'admin::app.catalog.attributes.create.image',
+    ],
+
+    'gallery' => [
+        'key'  => 'gallery',
+        'name' => 'admin::app.catalog.attributes.create.gallery',
+    ],
+
+    'file' => [
+        'key'  => 'file',
+        'name' => 'admin::app.catalog.attributes.create.file',
+    ],
+
+    'checkbox' => [
+        'key'  => 'checkbox',
+        'name' => 'admin::app.catalog.attributes.create.checkbox',
+    ],
+];

--- a/packages/Webkul/Attribute/src/Providers/AttributeServiceProvider.php
+++ b/packages/Webkul/Attribute/src/Providers/AttributeServiceProvider.php
@@ -12,5 +12,15 @@ class AttributeServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
+
+        $this->registerConfig();
+    }
+
+    /**
+     * Register configuration.
+     */
+    public function registerConfig(): void
+    {
+        $this->mergeConfigFrom(dirname(__DIR__).'/Config/attribute_types.php', 'attribute_types');
     }
 }

--- a/packages/Webkul/Attribute/src/Rules/AttributeTypes.php
+++ b/packages/Webkul/Attribute/src/Rules/AttributeTypes.php
@@ -35,7 +35,7 @@ class AttributeTypes implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! in_array($value, self::ATTRIBUTE_TYPES)) {
+        if (! in_array($value, array_keys(config('attribute_types')))) {
             $fail('core::validation.type')->translate();
         }
     }

--- a/packages/Webkul/Category/src/Config/category_field_types.php
+++ b/packages/Webkul/Category/src/Config/category_field_types.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+    'text' => [
+        'key'  => 'text',
+        'name' => 'admin::app.catalog.attributes.create.text',
+    ],
+
+    'textarea' => [
+        'key'  => 'textarea',
+        'name' => 'admin::app.catalog.attributes.create.textarea',
+    ],
+
+    'boolean' => [
+        'key'  => 'boolean',
+        'name' => 'admin::app.catalog.attributes.create.boolean',
+    ],
+
+    'select' => [
+        'key'  => 'select',
+        'name' => 'admin::app.catalog.attributes.create.select',
+    ],
+
+    'multiselect' => [
+        'key'  => 'multiselect',
+        'name' => 'admin::app.catalog.attributes.create.multiselect',
+    ],
+
+    'datetime' => [
+        'key'  => 'datetime',
+        'name' => 'admin::app.catalog.attributes.create.datetime',
+    ],
+
+    'date' => [
+        'key'  => 'date',
+        'name' => 'admin::app.catalog.attributes.create.date',
+    ],
+
+    'image' => [
+        'key'  => 'image',
+        'name' => 'admin::app.catalog.attributes.create.image',
+    ],
+
+    'file' => [
+        'key'  => 'file',
+        'name' => 'admin::app.catalog.attributes.create.file',
+    ],
+
+    'checkbox' => [
+        'key'  => 'checkbox',
+        'name' => 'admin::app.catalog.attributes.create.checkbox',
+    ],
+];

--- a/packages/Webkul/Category/src/Providers/CategoryServiceProvider.php
+++ b/packages/Webkul/Category/src/Providers/CategoryServiceProvider.php
@@ -16,5 +16,15 @@ class CategoryServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
 
         CategoryProxy::observe(CategoryObserver::class);
+
+        $this->registerConfig();
+    }
+
+    /**
+     * Register configuration.
+     */
+    public function registerConfig(): void
+    {
+        $this->mergeConfigFrom(dirname(__DIR__).'/Config/category_field_types.php', 'category_field_types');
     }
 }

--- a/packages/Webkul/Category/src/Rules/FieldTypes.php
+++ b/packages/Webkul/Category/src/Rules/FieldTypes.php
@@ -25,7 +25,7 @@ class FieldTypes implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! in_array($value, self::FILED_TYPES)) {
+        if (! in_array($value, array_keys(config('category_field_types')))) {
             $fail('core::validation.type')->translate();
         }
     }


### PR DESCRIPTION

## Description
In this PR, I refactor the way attribute types and category field types are defined in the system. Previously, these configurations were written directly into the view. With this update, I have moved these configurations into a separate, configuration file that can be extended by other packages.

### Changes:
- Moved the attribute types and category field types configuration from the view files to a configuration file.
- Updated the views to load these configurations dynamically, so new attribute types or category field types can be added by other packages.
- Refactored related logic and validations for these types.
  
## How To Test This?

**Verify Default Attribute and Category field functionality**:
   - Check that the default configurations for attribute types and category field types are loaded correctly from the new configuration files.
   - All attribute and category field types are present during creation. Create and update should be working correctly.

## Documentation
- This pull request requires an update on the documentation repository.

### Documentation Changes:
- The documentation for how to add new attribute types and category field types should be updated.
- A new section explaining the configuration files and how packages can extend them should be added.
