### PR TITLE
Emit custom event for new tag addition in addTag method

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php
@@ -683,9 +683,14 @@
                     const tag = {
                         name: newTag,
                         code: newTag
-                    }
-                    this.formattedOptions.push(tag)
-                    this.selectedValue.push(tag)
+                    };
+                    this.formattedOptions.push(tag);
+                    this.selectedValue.push(tag);
+                    this.$emit('add-option', {
+                        target: {
+                            value: tag
+                        }
+                    });
                 },
                 selectOption(tag) {
                     this.$emit('select-option', {


### PR DESCRIPTION
This PR enhances the addTag method by adding an add-option event emission each time a new tag is added.

Why: This change allows parent components to listen for the add-option event and respond when a new tag is added.
What: Adds $emit('add-option', { target: { value: tag } }) to the addTag method.
Impact: Improves reactivity and extensibility for components using addTag, allowing for better interaction handling in parent components.
Testing:

Verified that the event fires correctly when a new tag is added.
Ensured backward compatibility with existing tag addition functionality.
