### PR TITLE
fix: image removed when saving the user info

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/account/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/account/edit.blade.php
@@ -46,7 +46,7 @@
                     <x-admin::form.control-group>
                         <x-admin::media.images
                             name="image"
-                            :uploaded-images="$user->image ? [['id' => 'image', 'url' => $user->image_url]] : []"
+                            :uploaded-images="$user->image ? [['id' => 'image', 'url' => $user->image_url, 'value' => $user->image]] : []"
                         />
                     </x-admin::form.control-group>
 


### PR DESCRIPTION
## How To Test This?
* Save the user information in my account tab, without changing the profile picture, now it will be saved earlier it was being removed