### PR TITLE
fix: gallery image removed

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/media/images.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/images.blade.php
@@ -9,7 +9,7 @@
 
 <v-media-images
     name="{{ $name }}"
-    v-bind:allow-multiple="{{ $allowMultiple ? 'true' : 'false' }}"
+    v-bind:allow-multiple="{{ $allowMultiple ? true : false }}"
     v-bind:show-placeholders="{{ $showPlaceholders ? 'true' : 'false' }}"
     :uploaded-images='{{ json_encode($uploadedImages) }}'
     width="{{ $width }}"
@@ -82,7 +82,7 @@
                 >
                     <template #item="{ element, index }">
                         <v-media-image-item
-                            :allowMultiple="{{ $allowMultiple ? 'true' : 'false' }}"
+                            :allowMultiple="{{ $allowMultiple ? true : false }}"
                             :name="name"
                             :index="index"
                             :image="element"


### PR DESCRIPTION
Steps to reproduce

1. Create or open a product with multiple gallery attributes  inculing with images attribute.
2. Add images to Gallery A then save the product.
3. Add images to Image attribute B for the same then save the product again.
4. Observe that the images in Gallery A are removed after adding images to Image attribute B.
5. Repeat the above steps with different combinations of locales and scopes.
6. Now all images previous and newly added will be shown.

