### PR TITLE
Fix escape encoding with french chars when using JSON_EXTRACT

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
@@ -157,14 +157,14 @@ class CategoryDataGrid extends DataGrid
         return DB::table(DB::raw("(WITH RECURSIVE tree_view AS (
             SELECT id,
                 parent_id,
-                (CASE WHEN JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name') IS NOT NULL THEN REPLACE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name'), '\"', '') ELSE CONCAT('[', code, ']') END) as name
+                (CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name')) IS NOT NULL THEN REPLACE(JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name')), '\"', '') ELSE CONCAT('[', code, ']') END) as name
             FROM ".$tablePrefix."categories
             WHERE parent_id IS NULL
             UNION ALL
 
             SELECT parent.id,
                 parent.parent_id,
-                CONCAT(tree_view.name, ' / ', (CASE WHEN JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name') IS NOT NULL THEN REPLACE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name'), '\"', '') ELSE CONCAT('[', code, ']') END)) AS name
+                CONCAT(tree_view.name, ' / ', (CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name')) IS NOT NULL THEN REPLACE(JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.locale_specific.".$locales.".name')), '\"', '') ELSE CONCAT('[', code, ']') END)) AS name
             FROM ".$tablePrefix.'categories parent
             JOIN tree_view ON parent.parent_id = tree_view.id
         )


### PR DESCRIPTION
## Issue Reference
#105 

## Description
With the JSON_UNQUOTE

![image](https://github.com/user-attachments/assets/b0992988-0100-4a94-a6c9-acc610c17b34)