### PR TITLE
Allow AND and OR conditions for all query filters

### DIFF
--- a/packages/Webkul/AdminApi/src/ApiDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource.php
@@ -113,9 +113,11 @@ abstract class ApiDataSource
             $this->setDefaultFilters($scopeQueryBuilder);
 
             foreach ($requestedFilters as $requestedColumn => $requestedValues) {
-                foreach ($requestedValues as $value) {
-                    $scopeQueryBuilder = $this->operatorByFilter($scopeQueryBuilder, $requestedColumn, $value);
-                }
+                $scopeQueryBuilder->where(function ($query) use ($requestedValues, $requestedColumn) {
+                    foreach ($requestedValues as $value) {
+                        $query = $this->operatorByFilter($query, $requestedColumn, $value);
+                    }
+                });
             }
 
             return $scopeQueryBuilder;

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/CategoryDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/CategoryDataSource.php
@@ -115,20 +115,20 @@ class CategoryDataSource extends ApiDataSource
         if ($this->operators['EQUALS'] == $value['operator']) {
             // Apply the 'equals' operator to the query builder.
             if ($requestedColumn == 'parent') {
-                $scopeQueryBuilder->where($filterTable.'parent_id', $this->getParentIdByCode($scopeQueryBuilder, $value['value']));
+                $scopeQueryBuilder->orWhere($filterTable.'parent_id', $this->getParentIdByCode($scopeQueryBuilder, $value['value']));
             } else {
-                $scopeQueryBuilder->where($filterTable.$requestedColumn, $value['value']);
+                $scopeQueryBuilder->orWhere($filterTable.$requestedColumn, $value['value']);
             }
         }
 
         if ($this->operators['IN_LIST'] == $value['operator']) {
             // Apply the 'in list' operator to the query builder.
-            $scopeQueryBuilder->whereIn($filterTable.$requestedColumn, $value['value']);
+            $scopeQueryBuilder->orWhereIn($filterTable.$requestedColumn, $value['value']);
         }
 
         if ($this->operators['NOT_IN_LIST'] == $value['operator']) {
             // Apply the 'not in list' operator to the query builder.
-            $scopeQueryBuilder->hereNotIn($filterTable.$requestedColumn, $value['value']);
+            $scopeQueryBuilder->orWhereNotIn($filterTable.$requestedColumn, $value['value']);
         }
 
         // Return the updated query builder instance.

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/ProductDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/ProductDataSource.php
@@ -151,7 +151,7 @@ class ProductDataSource extends ApiDataSource
 
         switch ($requestedColumn) {
             case 'parent':
-                $scopeQueryBuilder->where($filterTable.'parent_id', $this->getParentIdByCode($scopeQueryBuilder, $value['value']));
+                $scopeQueryBuilder->orWhere($filterTable.'parent_id', $this->getParentIdByCode($scopeQueryBuilder, $value['value']));
                 break;
             case 'family':
                 $scopeQueryBuilder = $this->filterByFamily($scopeQueryBuilder, $value['operator'], $value['value']);
@@ -160,7 +160,7 @@ class ProductDataSource extends ApiDataSource
                 $scopeQueryBuilder = $this->filterByCategories($scopeQueryBuilder, $value['operator'], $filterTable, $value['value']);
                 break;
             default:
-                $scopeQueryBuilder->where($filterTable.$requestedColumn, $value['value']);
+                $scopeQueryBuilder->orWhere($filterTable.$requestedColumn, $value['value']);
                 break;
         }
 
@@ -201,9 +201,9 @@ class ProductDataSource extends ApiDataSource
     {
         $scopeQueryBuilder->whereHas('attribute_family', function ($query) use ($operator, $code) {
             if ($this->operators['IN_LIST'] == $operator) {
-                $query->whereIn('attribute_families.code', $code);
+                $query->orWhereIn('attribute_families.code', $code);
             } else {
-                $query->whereNotIn('attribute_families.code', $code);
+                $query->orWhereNotIn('attribute_families.code', $code);
             }
 
             return $query;
@@ -221,9 +221,9 @@ class ProductDataSource extends ApiDataSource
     protected function filterByCategories(Builder $scopeQueryBuilder, string $operator, string $filterTable, array $value)
     {
         if ($this->operators['IN_LIST'] == $operator) {
-            $scopeQueryBuilder->whereJsonContains($filterTable.'values->categories', $value);
+            $scopeQueryBuilder->orWhereJsonContains($filterTable.'values->categories', $value);
         } else {
-            $scopeQueryBuilder->whereJsonDoesntContain($filterTable.'values->categories', $value);
+            $scopeQueryBuilder->orWhereJsonDoesntContain($filterTable.'values->categories', $value);
         }
 
         return $scopeQueryBuilder;


### PR DESCRIPTION
## Description

Entity filters actually not allow the use of OR and AND in conditions. For example:

GET {url}/api/v1/rest/products?filters=...

```
{
   "filters":{
      "categories":[
         {
            "operator":"IN",
            "value":[
               "beers"
            ]
         }
      ],
      "sku":[
         {
            "operator":"=",
            "value":"BEER001"
         },
         {
            "operator":"=",
            "value":"BEER002"
         }
      ]
   }
}
```

**Result:**

```
SELECT count(*) as aggregate from `products`
WHERE `products`.`type` = 'simple' AND
    json_contains(`products`.`values`, '[\"beers\"]', '$."categories"') AND
    `products`.`sku` = 'BEER001' AND
    `products`.`sku` = 'BEER002'
```

**Excepted:**

```
SELECT count(*) as aggregate from `products`
WHERE `products`.`type` = 'simple' AND
    json_contains(`products`.`values`, '[\"beers\"]', '$."categories"') AND
    (`products`.`sku` = 'BEER001' OR `products`.`sku` = 'BEER002')
```

It is the same for all entity filters.

## How To Test This?

- Create a category with "beer" as code
- Create 2 products with "BEER001" and "BEER002" skus.
- Execute the GET request with filters

```
curl --location --globoff 'http://localhost.unopim/api/v1/rest/pages?filters={"filters":{"categories":[{"operator":"IN","value":["beers"]}],"sku":[{"operator":"=","value":"BEER001"},{"operator":"=","value":"BEER002"}]},"limit":1}' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer {token}'
```

**Excepted:** The request returns result.