### PR TITLE
Fix the cumulative filter conditions

### DIFF
--- a/packages/Webkul/DataGrid/src/DataGrid.php
+++ b/packages/Webkul/DataGrid/src/DataGrid.php
@@ -246,6 +246,7 @@ abstract class DataGrid
                                 $scopeQueryBuilder->orWhere($column->getDatabaseColumnName(), 'LIKE', '%'.$value.'%');
                             }
                         });
+                        break;
 
                     case ColumnTypeEnum::INTEGER->value:
                         $this->queryBuilder->where(function ($scopeQueryBuilder) use ($column, $requestedValues) {
@@ -253,6 +254,7 @@ abstract class DataGrid
                                 $scopeQueryBuilder->orWhere($column->getDatabaseColumnName(), $value);
                             }
                         });
+                        break;
 
                     case ColumnTypeEnum::DROPDOWN->value:
                         $this->queryBuilder->where(function ($scopeQueryBuilder) use ($column, $requestedValues) {
@@ -260,7 +262,6 @@ abstract class DataGrid
                                 $scopeQueryBuilder->orWhere($column->getDatabaseColumnName(), $value);
                             }
                         });
-
                         break;
 
                     case ColumnTypeEnum::DATE_RANGE->value:
@@ -272,15 +273,14 @@ abstract class DataGrid
                                 ]);
                             }
                         });
-
                         break;
+
                     case ColumnTypeEnum::DATE_TIME_RANGE->value:
                         $this->queryBuilder->where(function ($scopeQueryBuilder) use ($column, $requestedValues) {
                             foreach ($requestedValues as $value) {
                                 $scopeQueryBuilder->whereBetween($column->getDatabaseColumnName(), [$value[0] ?? '', $value[1] ?? '']);
                             }
                         });
-
                         break;
 
                     default:
@@ -289,7 +289,6 @@ abstract class DataGrid
                                 $scopeQueryBuilder->orWhere($column->getDatabaseColumnName(), 'LIKE', '%'.$value.'%');
                             }
                         });
-
                         break;
                 }
             }


### PR DESCRIPTION
## Description

When a string or integer filter is applied to the admin entity filters, the conditions are accumulating due to the lack of a break.

Actually:

```
where (`code` LIKE '%beer%') and (`code` = 'beer') and (`code` = 'beer')
```

Excepted:

```
where (`code` LIKE '%beer%')
```

## How To Test This?

In the admin category or product data grid, apply a filter on any attribute with a partial string.