### PR TITLE
Issue/invalid channel locale change

### DIFF
--- a/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
+++ b/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
@@ -9,8 +9,8 @@ use Illuminate\Http\Request;
  * Middleware to validate that the requested locale is available for the current requested channel.
  * If the locale is not available, it redirects to the first available locale for that channel.
  */
-class EnsureChannelLocaleIsValid {
-
+class EnsureChannelLocaleIsValid
+{
     /**
      * Handle the incoming request.
      *
@@ -20,7 +20,7 @@ class EnsureChannelLocaleIsValid {
      *
      * @param  \Illuminate\Http\Request  $request  The HTTP request instance
      * @param  \Closure  $next  The next middleware/handler in the pipeline
-     * @return mixed  Response or redirect
+     * @return mixed Response or redirect
      */
     public function handle(Request $request, Closure $next)
     {
@@ -30,7 +30,7 @@ class EnsureChannelLocaleIsValid {
         $route = $request->route();
 
         // Check that the locale is available in the current channel
-        if($requestedChannel->locales()->where('code', $requestedLocaleCode)->first() === null) {
+        if ($requestedChannel->locales()->where('code', $requestedLocaleCode)->first() === null) {
             // Get all route parameters
             $parameters = $route->parameters();
 
@@ -44,9 +44,9 @@ class EnsureChannelLocaleIsValid {
             $routeName = $route->getName();
 
             // If route has name, redirect with parameters
-            if($routeName !== null) {
+            if ($routeName !== null) {
                 return redirect()->route($routeName, $parameters);
-            } else if($route->getActionName() !== null) {
+            } elseif ($route->getActionName() !== null) {
                 // For routes without names, use the current URL but update query parameters
                 return redirect()->action($route->getActionName(), $parameters);
             } else {
@@ -58,5 +58,4 @@ class EnsureChannelLocaleIsValid {
         // If the locale is valid for this channel, continue with the request
         return $next($request);
     }
-
 }

--- a/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
+++ b/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
@@ -32,7 +32,7 @@ class EnsureChannelLocaleIsValid
 
             if ($routeName !== null) {
                 return redirect()->route($routeName, $parameters);
-            } 
+            }
 
             $actionName = $route->getActionName();
 

--- a/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
+++ b/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Webkul\Admin\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Middleware to validate that the requested locale is available for the current requested channel.
+ * If the locale is not available, it redirects to the first available locale for that channel.
+ */
+class EnsureChannelLocaleIsValid {
+
+    /**
+     * Handle the incoming request.
+     *
+     * This middleware checks if the locale in the request is valid for the current channel.
+     * If not, it redirects to the first available locale for that channel while preserving
+     * other route parameters and query string.
+     *
+     * @param  \Illuminate\Http\Request  $request  The HTTP request instance
+     * @param  \Closure  $next  The next middleware/handler in the pipeline
+     * @return mixed  Response or redirect
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        /** @var \Webkul\Core\Models\Channel $requestedChannel */
+        $requestedChannel = core()->getRequestedChannel();
+        $requestedLocaleCode = core()->getRequestedLocaleCode();
+        $route = $request->route();
+
+        // Check that the locale is available in the current channel
+        if($requestedChannel->locales()->where('code', $requestedLocaleCode)->first() === null) {
+            // Get all route parameters
+            $parameters = $route->parameters();
+
+            // Update the locale parameter to use the first available locale for this channel
+            $parameters['locale'] = $requestedChannel->locales()->first()->code;
+
+            // Ensure channel parameter is set
+            $parameters['channel'] = $requestedChannel->code;
+
+            // Return redirect with route parameters and preserving query parameters
+            $routeName = $route->getName();
+
+            // If route has name, redirect with parameters
+            if($routeName !== null) {
+                return redirect()->route($routeName, $parameters);
+            } else if($route->getActionName() !== null) {
+                // For routes without names, use the current URL but update query parameters
+                return redirect()->action($route->getActionName(), $parameters);
+            } else {
+                // As a last resort, return user back to the previous page
+                return redirect()->back();
+            }
+        }
+
+        // If the locale is valid for this channel, continue with the request
+        return $next($request);
+    }
+
+}

--- a/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
+++ b/packages/Webkul/Admin/src/Http/Middleware/EnsureChannelLocaleIsValid.php
@@ -30,15 +30,18 @@ class EnsureChannelLocaleIsValid
         $route = $request->route();
 
         // Check that the locale is available in the current channel
-        if ($requestedChannel->locales()->where('code', $requestedLocaleCode)->first() === null) {
+        if ($requestedChannel?->locales()?->where('code', $requestedLocaleCode)->first() === null) {
             // Get all route parameters
             $parameters = $route->parameters();
 
-            // Update the locale parameter to use the first available locale for this channel
-            $parameters['locale'] = $requestedChannel->locales()->first()->code;
+            // Get default channel when nonexistent channel is requested
+            $requestedChannel ??= core()->getDefaultChannel();
 
             // Ensure channel parameter is set
             $parameters['channel'] = $requestedChannel->code;
+
+            // Update the locale parameter to use the first available locale for this channel
+            $parameters['locale'] = $requestedChannel->locales()->first()->code;
 
             // Return redirect with route parameters and preserving query parameters
             $routeName = $route->getName();

--- a/packages/Webkul/Admin/src/Routes/catalog-routes.php
+++ b/packages/Webkul/Admin/src/Routes/catalog-routes.php
@@ -9,6 +9,7 @@ use Webkul\Admin\Http\Controllers\Catalog\CategoryFieldController;
 use Webkul\Admin\Http\Controllers\Catalog\Options\AjaxOptionsController;
 use Webkul\Admin\Http\Controllers\Catalog\ProductController;
 use Webkul\Admin\Http\Middleware\EnsureChannelLocaleIsValid;
+
 /**
  * Catalog routes.
  */

--- a/packages/Webkul/Admin/src/Routes/catalog-routes.php
+++ b/packages/Webkul/Admin/src/Routes/catalog-routes.php
@@ -8,7 +8,7 @@ use Webkul\Admin\Http\Controllers\Catalog\CategoryController;
 use Webkul\Admin\Http\Controllers\Catalog\CategoryFieldController;
 use Webkul\Admin\Http\Controllers\Catalog\Options\AjaxOptionsController;
 use Webkul\Admin\Http\Controllers\Catalog\ProductController;
-
+use Webkul\Admin\Http\Middleware\EnsureChannelLocaleIsValid;
 /**
  * Catalog routes.
  */
@@ -142,7 +142,7 @@ Route::group(['middleware' => ['admin'], 'prefix' => config('app.admin_url')], f
 
             Route::get('copy/{id}', 'copy')->name('admin.catalog.products.copy');
 
-            Route::get('edit/{id}', 'edit')->name('admin.catalog.products.edit');
+            Route::get('edit/{id}', 'edit')->name('admin.catalog.products.edit')->middleware(EnsureChannelLocaleIsValid::class);
 
             Route::put('edit/{id}', 'update')->name('admin.catalog.products.update');
 


### PR DESCRIPTION
## Description
This PR adds a new middleware EnsureChannelLocaleIsValid to address an issue where users could attempt to access a locale that doesn't exist for the current channel. The middleware validates that the requested locale is available for the current channel and redirects to a valid locale if necessary.

## Steps to reproduce solved problem

1. Create a new PIM instance with at least 2 locales (tested with en_US and fi_FI).
2. Create a new channel, for example "Test" with a single locale that is not the default en_US (tested with fi_FI).
3. Create a new product
4. First add some placeholder details for default channel (Default) and language (en_US) to required fields.
5. Product should have saved correctly at this point.
6. Change channel to "Test"
7. The UI locale dropdown shows correct locale (as there is only one), but URL GET parameter shows en_US
8. Add some values to required fields and save product.
9. The fields that you filled are empty and they did not save to the database because the locale en_US does not exist for channel "Test".

## How To Test This?
Open product edit view and try to change URL GET parameter locale to something that does not exist. You should be redirected to first available valid locale.

## Documentation
- [ ] My pull request requires an update on the documentation repository.