### PR TITLE
Fix[0.2]: Product datagrid search and sku filter does not work correctly

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -405,7 +405,7 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
 
                 foreach ($values as $value) {
                     $filters['wildcard'] = [
-                        'sku' => '*'.$value.'*',
+                        'sku.keyword' => '*'.$value.'*',
                     ];
                 }
 

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -332,8 +332,9 @@ class Installer extends Command
             default: env('ELASTICSEARCH_ENABLED', 'false')
         ) === 'yes';
 
-        if (!$isElasticEnabled) {
+        if (! $isElasticEnabled) {
             $this->envUpdate('ELASTICSEARCH_ENABLED', 'false');
+
             return;
         }
 
@@ -387,7 +388,6 @@ class Installer extends Command
 
         $this->envUpdate('ELASTICSEARCH_INDEX_PREFIX', $indexPrefix);
     }
-
 
     /**
      * Create a admin credentials.


### PR DESCRIPTION
#### Issue
- Search Filter and SKU filter does not return correct result due to sku being mapped as text instead of keyword on elasticsearch index.