### PR TITLE
fix: downloading sample CSV files throws error when default storage is not public

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -553,7 +553,7 @@ class ImportController extends Controller
     {
         $importer = config('importers.'.$type);
 
-        return Storage::download($importer['sample_path']);
+        return Storage::disk('public')->download($importer['sample_path']);
     }
 
     /**


### PR DESCRIPTION
### Issue Reference
* FIxes: #171

### Description
* Specify disk as public when downloading sample CSV files.

### Change Impact
* Very low (Should not affect any other functionality)

