### PR TITLE
Fix: Add missing 'code' field to swatch attribute option tests

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Catalog/AttributeTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/AttributeTest.php
@@ -391,14 +391,16 @@ it('should create attribute option with color swatch_value for select type', fun
     $locale = Locale::where('status', 1)->first();
     $color = fake()->hexColor();
     $label = fake()->word();
+    $optionCode = fake()->word();
     $data = [
         'code'        => $attribute->code,
         'type'        => $attribute->type,
         'swatch_type' => 'color',
         'options'     => [
-            fake()->word() => [
+            'option_1' => [
                 'isNew'         => true,
                 'isDelete'      => false,
+                'code'          => $optionCode,
                 'swatch_value'  => $color,
                 $locale->code   => ['label' => $label],
             ],
@@ -481,6 +483,7 @@ it('should create attribute option with image swatch_value for select type', fun
 
     $imageUrl = fake()->imageUrl(100, 100);
     $label = fake()->word();
+    $optionCode = fake()->word();
 
     $data = [
         'code'        => $attribute->code,
@@ -490,6 +493,7 @@ it('should create attribute option with image swatch_value for select type', fun
             'option_1' => [
                 'isNew'        => true,
                 'isDelete'     => false,
+                'code'         => $optionCode,
                 'swatch_value' => $imageUrl,
                 $locale->code  => ['label' => $label],
             ],


### PR DESCRIPTION
## Issue Reference
N/A - Bug fix discovered during test execution

## Description
While running tests, the swatch attribute option tests in `Catalog/AttributeTest` consistently fail due to missing required `code` field. The `attribute_options` table has a non-nullable `code` column, and the tests were not providing this field when creating new options.

Changes:
- Added `code` field to color swatch attribute option test
- Added `code` field to image swatch attribute option test

## How To Test This?
Run the affected tests:
```bash
./vendor/bin/pest packages/Webkul/Admin/tests/Feature/Catalog/AttributeTest.php --filter="swatch_value for select"
```

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master

## Pint
N/A - Test file changes only

## Tailwind Reordering
N/A - No Tailwind changes