### PR TITLE
Fix: fixed the products import from CSV with large count of attributes

### DIFF
--- a/packages/Webkul/DataTransfer/src/Helpers/Import.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Import.php
@@ -601,8 +601,11 @@ class Import
             $importerConfig = config('importers.'.$jobInstance->entity_type);
             $this->typeImporter = app()->make($importerConfig['importer'])
                 ->setImport($this->import)
-                ->setLogger($this->jobLogger)
                 ->setErrorHelper($this->errorHelper);
+
+            if ($this->jobLogger) {
+                $this->typeImporter->setLogger($this->jobLogger);
+            }
         }
 
         return $this->typeImporter;

--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/CSV.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/CSV.php
@@ -29,7 +29,7 @@ class CSV extends AbstractSource
         try {
             $this->reader = fopen(Storage::disk('private')->path($filePath), 'r');
 
-            $this->columnNames = fgetcsv($this->reader, 4096, $delimiter);
+            $this->columnNames = fgetcsv($this->reader, 0, $delimiter);
 
             $this->totalColumns = count($this->columnNames);
         } catch (\Exception $e) {
@@ -83,7 +83,7 @@ class CSV extends AbstractSource
      */
     protected function getNextRow(): array
     {
-        $parsed = fgetcsv($this->reader, 4096, $this->delimiter);
+        $parsed = fgetcsv($this->reader, 0, $this->delimiter);
 
         if (is_array($parsed) && count($parsed) != $this->totalColumns) {
             foreach ($parsed as $element) {


### PR DESCRIPTION
## Issue Reference
Fixes Issue - #182 

## Description

- **Data Truncation**: CSV imports were failing or corrupting data when rows exceeded 4096 characters. This was due to a hardcoded length limit in the fgetcsv() function, which caused "Required columns not found" errors for products with a large number of attributes.

- **Validation Crash**: Manually triggering import validation from the UI could cause a fatal error if the logger instance was not explicitly provided to the Importer helper.

## Solution

- **CSV Source**: Updated `Webkul\DataTransfer\Helpers\Sources\CSV` to use 0 as the length parameter in fgetcsv(), which allows reading lines of unlimited length (PHP 5.1.0+).

- **Import Helper**: Added a conditional check in `Webkul\DataTransfer\Helpers\Import` to ensure the setLogger() call only occurs if a logger instance is actually present, preventing TypeError during manual validation.

 ## Verification Results
- **Tests**: Added a new test case to 
`packages/Webkul/Admin/tests/Feature/DataTransfer/ImportTest.php`
 simulating a product import with 1,100 columns to verify the end-to-end validation flow.
- Confirmed that large product datasets (like those exported from Bagisto) are now parsed correctly without truncation.