### PR TITLE
Fix job profile deletion error in importer, which could impact further development of connectors.

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -219,9 +219,12 @@ class ImportController extends Controller
     {
         $import = $this->jobInstancesRepository->findOrFail($id);
         try {
-            if($import?->file_path){
+            if (! empty($export->file_path)) {
                 Storage::disk('private')->delete($import->file_path);
-                Storage::disk('private')->delete($import->error_file_path ?? '');
+            }
+
+            if (! empty($import->error_file_path)) {
+                Storage::disk('private')->delete($import->error_file_path);
             }
 
             $this->jobInstancesRepository->delete($id);


### PR DESCRIPTION
Corrected the deletion logic in the importer job profile controller. Previously, the system attempted to delete files from storage even when `file_path` or `error_file_path` were `null`, which caused the following error:

`($location) must be of type string, null given`

Added checks to ensure the file paths are not empty before attempting deletion from the private storage disk. This prevents runtime errors when a job profile does not have associated files.

**Changes:**
* Added `!empty()` validation before calling `Storage::disk('private')->delete()`.
* Prevents passing `null` to the filesystem delete method.
* Ensures safe cleanup of `file_path` and `error_file_path` during job profile deletion.


<img width="1354" height="604" alt="Screenshot from 2026-03-11 11-42-32" src="https://github.com/user-attachments/assets/2f61c3cb-ad38-4add-af08-e7665d8390f2" />

<img width="1352" height="573" alt="bugreport" src="https://github.com/user-attachments/assets/ae8a6466-f4d1-4c37-bef7-c40fc06b984b" />

