### PR TITLE
chore: add test-results to .gitignore and removed it from the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ package-lock.json
 /vendor
 yarn.lock
 yarn-error.log
+/test-results

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Issue Reference
N/A

## Changes
- Updated `.gitignore` to include `test-results/`
- Removed the `test-results/` directory from version control using `git rm --cached`

## Reason
Test result artifacts are generated during testing and should not be tracked in the repository.