### PR TITLE
Fix: Fixed the UI inconsistency of login form

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/users/reset-password/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/users/reset-password/create.blade.php
@@ -73,7 +73,9 @@
                                 ref="password"
                             />
 
-                            <x-admin::form.control-group.error control-name="password" />
+                            <v-error-message name="password" v-slot="{ message }"> 
+                                <p class="mt-1 text-red-600 italic text-[10px]" v-text="message"></p> 
+                            </v-error-message>
                         </x-admin::form.control-group>
 
                         <!-- Confirm Password -->
@@ -92,8 +94,10 @@
                                 :placeholder="trans('admin::app.users.reset-password.confirm-password')"
                                 ref="password"
                             />
-
-                            <x-admin::form.control-group.error control-name="password_confirmation" />
+                            
+                            <v-error-message name="password_confirmation" v-slot="{ message }"> 
+                                <p class="mt-1 text-red-600 italic text-[10px]" v-text="message"></p> 
+                            </v-error-message>
                         </x-admin::form.control-group>
                     </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/users/sessions/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/users/sessions/create.blade.php
@@ -73,7 +73,10 @@
                             >
                             </span>
 
-                            <x-admin::form.control-group.error control-name="password" />
+                            <v-error-message name="password" v-slot="{ message }"> 
+                                <p class="mt-1 text-red-600 italic text-[10px]" v-text="message"></p> 
+                            </v-error-message>
+
                         </x-admin::form.control-group>
                     </div>
 


### PR DESCRIPTION
## Issue Reference

N/A

## Problem

In the UnoPim login form, when a validation error message is long, the login modal expands and increases its size. This causes an inconsistent UI and affects the layout of the form.

## Solution

Replaced the Blade validation error component with a Vue-based error message component to better control styling and layout.

**Updated code:**

From:

```blade
<x-admin::form.control-group.error control-name="password" />
```

To:

```vue
<v-error-message name="password" v-slot="{ message }">
    <p class="mt-1 text-red-600 italic text-[10px]" v-text="message"></p>
</v-error-message>
```

## Result

* Validation messages are displayed consistently.
* The login modal no longer expands when the validation message is long.
* UI layout remains stable regardless of validation message length.