### PR TITLE
chore: bump dev dependencies

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,7 +2,28 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\TrimStrings;
+use App\Http\Middleware\TrustProxies;
+use App\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
+use Illuminate\Auth\Middleware\Authorize;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Middleware\SetCacheHeaders;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ValidateSignature;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Webkul\Core\Http\Middleware\CheckForMaintenanceMode;
+use Webkul\Core\Http\Middleware\SecureHeaders;
+use Webkul\Installer\Http\Middleware\CanInstall;
 
 class Kernel extends HttpKernel
 {
@@ -14,13 +35,13 @@ class Kernel extends HttpKernel
      * @var array<int, class-string|string>
      */
     protected $middleware = [
-        \App\Http\Middleware\TrimStrings::class,
-        \App\Http\Middleware\TrustProxies::class,
-        \Illuminate\Http\Middleware\HandleCors::class,
-        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \Webkul\Core\Http\Middleware\SecureHeaders::class,
-        \Webkul\Core\Http\Middleware\CheckForMaintenanceMode::class,
-        \Webkul\Installer\Http\Middleware\CanInstall::class,
+        TrimStrings::class,
+        TrustProxies::class,
+        HandleCors::class,
+        ValidatePostSize::class,
+        SecureHeaders::class,
+        CheckForMaintenanceMode::class,
+        CanInstall::class,
     ];
 
     /**
@@ -30,17 +51,17 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\VerifyCsrfToken::class,
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            EncryptCookies::class,
+            AddQueuedCookiesToResponse::class,
+            StartSession::class,
+            ShareErrorsFromSession::class,
+            VerifyCsrfToken::class,
+            SubstituteBindings::class,
         ],
 
         'api' => [
-            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            ThrottleRequests::class.':api',
+            SubstituteBindings::class,
         ],
     ];
 
@@ -52,13 +73,13 @@ class Kernel extends HttpKernel
      * @var array<string, class-string|string>
      */
     protected $middlewareAliases = [
-        'auth'          => \Illuminate\Auth\Middleware\Authenticate::class,
-        'auth.basic'    => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'auth.session'  => \Illuminate\Session\Middleware\AuthenticateSession::class,
-        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
-        'can'           => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest'         => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'signed'        => \Illuminate\Routing\Middleware\ValidateSignature::class,
-        'throttle'      => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'auth'          => Authenticate::class,
+        'auth.basic'    => AuthenticateWithBasicAuth::class,
+        'auth.session'  => AuthenticateSession::class,
+        'cache.headers' => SetCacheHeaders::class,
+        'can'           => Authorize::class,
+        'guest'         => RedirectIfAuthenticated::class,
+        'signed'        => ValidateSignature::class,
+        'throttle'      => ThrottleRequests::class,
     ];
 }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -13,7 +13,7 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next, string ...$guards): Response
     {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,10 @@
 <?php
 
+use App\Exceptions\Handler;
+use App\Http\Kernel;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Application;
+
 /*
 |--------------------------------------------------------------------------
 | Create The Application
@@ -11,7 +16,7 @@
 |
 */
 
-$app = new Illuminate\Foundation\Application(
+$app = new Application(
     realpath(__DIR__.'/../')
 );
 
@@ -28,7 +33,7 @@ $app = new Illuminate\Foundation\Application(
 
 $app->singleton(
     Illuminate\Contracts\Http\Kernel::class,
-    App\Http\Kernel::class
+    Kernel::class
 );
 
 $app->singleton(
@@ -37,8 +42,8 @@ $app->singleton(
 );
 
 $app->singleton(
-    Illuminate\Contracts\Debug\ExceptionHandler::class,
-    App\Exceptions\Handler::class
+    ExceptionHandler::class,
+    Handler::class
 );
 
 /*

--- a/composer.lock
+++ b/composer.lock
@@ -11433,16 +11433,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.27.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "c67b4195b75491e4dfc6b00b1c78b68d86f54c90"
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/c67b4195b75491e4dfc6b00b1c78b68d86f54c90",
-                "reference": "c67b4195b75491e4dfc6b00b1c78b68d86f54c90",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/bdec963f53172c5e36330f3a400604c69bf02d39",
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39",
                 "shasum": ""
             },
             "require": {
@@ -11453,13 +11453,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.92.4",
-                "illuminate/view": "^12.44.0",
-                "larastan/larastan": "^3.8.1",
-                "laravel-zero/framework": "^12.0.4",
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "illuminate/view": "^12.54.1",
+                "larastan/larastan": "^3.9.3",
+                "laravel-zero/framework": "^12.0.5",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.4"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.0"
             },
             "bin": [
                 "builds/pint"
@@ -11496,7 +11497,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-01-05T16:49:17+00:00"
+            "time": "2026-03-12T15:51:39+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -14420,5 +14421,5 @@
         "ext-tokenizer": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -1,7 +1,46 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
+use App\Providers\EventServiceProvider;
+use App\Providers\RouteServiceProvider;
+use Astrotomic\Translatable\TranslatableServiceProvider;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\ServiceProvider;
+use Intervention\Image\Facades\Image;
+use Intervention\Image\ImageServiceProvider;
+use Konekt\Concord\ConcordServiceProvider;
+use Konekt\Concord\Facades\Concord;
+use Konekt\Concord\Facades\Helper;
+use Maatwebsite\Excel\ExcelServiceProvider;
+use Maatwebsite\Excel\Facades\Excel;
+use OwenIt\Auditing\AuditingServiceProvider;
+use Prettus\Repository\Providers\RepositoryServiceProvider;
+use Webkul\Admin\Providers\AdminServiceProvider;
+use Webkul\AdminApi\Providers\AdminApiServiceProvider;
+use Webkul\Attribute\Providers\AttributeServiceProvider;
+use Webkul\Category\Providers\CategoryServiceProvider;
+use Webkul\Completeness\Providers\CompletenessServiceProvider;
+use Webkul\Core\Facades\Core;
+use Webkul\Core\Providers\CoreServiceProvider;
+use Webkul\Core\Providers\EnvValidatorServiceProvider;
+use Webkul\DataGrid\Providers\DataGridServiceProvider;
+use Webkul\DataTransfer\Providers\DataTransferServiceProvider;
+use Webkul\DebugBar\Providers\DebugBarServiceProvider;
+use Webkul\ElasticSearch\Providers\ElasticSearchServiceProvider;
+use Webkul\FPC\Providers\FPCServiceProvider;
+use Webkul\HistoryControl\Providers\HistoryControlServiceProvider;
+use Webkul\Installer\Providers\InstallerServiceProvider;
+use Webkul\MagicAI\Providers\MagicAIServiceProvider;
+use Webkul\Notification\Providers\NotificationServiceProvider;
+use Webkul\Product\Facades\ProductImage;
+use Webkul\Product\Facades\ProductVideo;
+use Webkul\Product\Providers\ProductServiceProvider;
+use Webkul\Theme\Providers\ThemeServiceProvider;
+use Webkul\User\Providers\UserServiceProvider;
+use Webkul\Webhook\Providers\WebhookServiceProvider;
 
 return [
     /*
@@ -159,45 +198,45 @@ return [
         /**
          * Package service providers.
          */
-        Astrotomic\Translatable\TranslatableServiceProvider::class,
+        TranslatableServiceProvider::class,
         Barryvdh\DomPDF\ServiceProvider::class,
-        Intervention\Image\ImageServiceProvider::class,
-        Konekt\Concord\ConcordServiceProvider::class,
-        Maatwebsite\Excel\ExcelServiceProvider::class,
-        Prettus\Repository\Providers\RepositoryServiceProvider::class,
-        OwenIt\Auditing\AuditingServiceProvider::class,
+        ImageServiceProvider::class,
+        ConcordServiceProvider::class,
+        ExcelServiceProvider::class,
+        RepositoryServiceProvider::class,
+        AuditingServiceProvider::class,
 
         /**
          * Application service providers.
          */
-        App\Providers\AppServiceProvider::class,
-        App\Providers\AuthServiceProvider::class,
-        App\Providers\EventServiceProvider::class,
-        App\Providers\RouteServiceProvider::class,
+        AppServiceProvider::class,
+        AuthServiceProvider::class,
+        EventServiceProvider::class,
+        RouteServiceProvider::class,
 
         /**
          * Webkul package service providers.
          */
-        Webkul\AdminApi\Providers\AdminApiServiceProvider::class,
-        Webkul\Admin\Providers\AdminServiceProvider::class,
-        Webkul\Attribute\Providers\AttributeServiceProvider::class,
-        Webkul\Category\Providers\CategoryServiceProvider::class,
-        Webkul\Core\Providers\CoreServiceProvider::class,
-        Webkul\Core\Providers\EnvValidatorServiceProvider::class,
-        Webkul\DataGrid\Providers\DataGridServiceProvider::class,
-        Webkul\DataTransfer\Providers\DataTransferServiceProvider::class,
-        Webkul\DebugBar\Providers\DebugBarServiceProvider::class,
-        Webkul\FPC\Providers\FPCServiceProvider::class,
-        Webkul\HistoryControl\Providers\HistoryControlServiceProvider::class,
-        Webkul\Installer\Providers\InstallerServiceProvider::class,
-        Webkul\MagicAI\Providers\MagicAIServiceProvider::class,
-        Webkul\Notification\Providers\NotificationServiceProvider::class,
-        Webkul\Product\Providers\ProductServiceProvider::class,
-        Webkul\Theme\Providers\ThemeServiceProvider::class,
-        Webkul\User\Providers\UserServiceProvider::class,
-        Webkul\ElasticSearch\Providers\ElasticSearchServiceProvider::class,
-        Webkul\Webhook\Providers\WebhookServiceProvider::class,
-        Webkul\Completeness\Providers\CompletenessServiceProvider::class,
+        AdminApiServiceProvider::class,
+        AdminServiceProvider::class,
+        AttributeServiceProvider::class,
+        CategoryServiceProvider::class,
+        CoreServiceProvider::class,
+        EnvValidatorServiceProvider::class,
+        DataGridServiceProvider::class,
+        DataTransferServiceProvider::class,
+        DebugBarServiceProvider::class,
+        FPCServiceProvider::class,
+        HistoryControlServiceProvider::class,
+        InstallerServiceProvider::class,
+        MagicAIServiceProvider::class,
+        NotificationServiceProvider::class,
+        ProductServiceProvider::class,
+        ThemeServiceProvider::class,
+        UserServiceProvider::class,
+        ElasticSearchServiceProvider::class,
+        WebhookServiceProvider::class,
+        CompletenessServiceProvider::class,
     ])->toArray(),
 
     /*
@@ -212,14 +251,14 @@ return [
     */
 
     'aliases' => Facade::defaultAliases()->merge([
-        'Concord'      => Konekt\Concord\Facades\Concord::class,
-        'Core'         => Webkul\Core\Facades\Core::class,
-        'Excel'        => Maatwebsite\Excel\Facades\Excel::class,
-        'Helper'       => Konekt\Concord\Facades\Helper::class,
-        'Image'        => Intervention\Image\Facades\Image::class,
-        'PDF'          => Barryvdh\DomPDF\Facade\Pdf::class,
-        'ProductImage' => Webkul\Product\Facades\ProductImage::class,
-        'ProductVideo' => Webkul\Product\Facades\ProductVideo::class,
-        'Redis'        => Illuminate\Support\Facades\Redis::class,
+        'Concord'      => Concord::class,
+        'Core'         => Core::class,
+        'Excel'        => Excel::class,
+        'Helper'       => Helper::class,
+        'Image'        => Image::class,
+        'PDF'          => Pdf::class,
+        'ProductImage' => ProductImage::class,
+        'ProductVideo' => ProductVideo::class,
+        'Redis'        => Redis::class,
     ])->toArray(),
 ];

--- a/config/audit.php
+++ b/config/audit.php
@@ -1,5 +1,13 @@
 <?php
 
+use OwenIt\Auditing\Models\Audit;
+use OwenIt\Auditing\Resolvers\IpAddressResolver;
+use OwenIt\Auditing\Resolvers\UrlResolver;
+use OwenIt\Auditing\Resolvers\UserAgentResolver;
+use OwenIt\Auditing\Resolvers\UserResolver;
+use Webkul\HistoryControl\Resolvers\PrimaryIdResolver;
+use Webkul\User\Models\Admin;
+
 return [
 
     'enabled' => env('AUDITING_ENABLED', true),
@@ -13,7 +21,7 @@ return [
     |
     */
 
-    'implementation' => OwenIt\Auditing\Models\Audit::class,
+    'implementation' => Audit::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -27,8 +35,8 @@ return [
     'user'      => [
         'primary_key' => 'id',
         'foreign_key' => 'user_id', // Adjust this if your foreign key is different
-        'model'       => Webkul\User\Models\Admin::class, // Change this to your Admin model
-        'resolver'    => OwenIt\Auditing\Resolvers\UserResolver::class,
+        'model'       => Admin::class, // Change this to your Admin model
+        'resolver'    => UserResolver::class,
         'guards'      => [
             'admin',
         ],
@@ -43,10 +51,10 @@ return [
     |
     */
     'resolvers' => [
-        'ip_address' => OwenIt\Auditing\Resolvers\IpAddressResolver::class,
-        'user_agent' => OwenIt\Auditing\Resolvers\UserAgentResolver::class,
-        'url'        => OwenIt\Auditing\Resolvers\UrlResolver::class,
-        'history_id' => Webkul\HistoryControl\Resolvers\PrimaryIdResolver::class,
+        'ip_address' => IpAddressResolver::class,
+        'user_agent' => UserAgentResolver::class,
+        'url'        => UrlResolver::class,
+        'history_id' => PrimaryIdResolver::class,
     ],
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use Webkul\User\Models\Admin;
+
 return [
     'defaults' => [
         'guard'     => 'admin',
@@ -21,7 +23,7 @@ return [
     'providers' => [
         'admins' => [
             'driver' => 'eloquent',
-            'model'  => Webkul\User\Models\Admin::class,
+            'model'  => Admin::class,
         ],
     ],
 

--- a/config/breadcrumbs.php
+++ b/config/breadcrumbs.php
@@ -1,5 +1,8 @@
 <?php
 
+use Diglactic\Breadcrumbs\Generator;
+use Diglactic\Breadcrumbs\Manager;
+
 return [
 
     /*
@@ -67,9 +70,9 @@ return [
     */
 
     // Manager
-    'manager-class' => Diglactic\Breadcrumbs\Manager::class,
+    'manager-class' => Manager::class,
 
     // Generator
-    'generator-class' => Diglactic\Breadcrumbs\Generator::class,
+    'generator-class' => Generator::class,
 
 ];

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -88,7 +90,7 @@ return [
 
     'prefix' => env(
         'CACHE_PREFIX',
-        \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'
     ),
 
 ];

--- a/config/concord.php
+++ b/config/concord.php
@@ -1,8 +1,11 @@
 <?php
 
+use Webkul\Admin\Providers\ModuleServiceProvider;
+use Webkul\Core\CoreConvention;
+
 return [
 
-    'convention' => Webkul\Core\CoreConvention::class,
+    'convention' => CoreConvention::class,
 
     'modules' => [
 
@@ -11,15 +14,15 @@ return [
          * VendorA\ModuleX\Providers\ModuleServiceProvider::class,
          * VendorB\ModuleY\Providers\ModuleServiceProvider::class
          */
-        \Webkul\Admin\Providers\ModuleServiceProvider::class,
-        \Webkul\Attribute\Providers\ModuleServiceProvider::class,
-        \Webkul\Category\Providers\ModuleServiceProvider::class,
-        \Webkul\Core\Providers\ModuleServiceProvider::class,
-        \Webkul\DataTransfer\Providers\ModuleServiceProvider::class,
-        \Webkul\HistoryControl\Providers\ModuleServiceProvider::class,
-        \Webkul\Notification\Providers\ModuleServiceProvider::class,
-        \Webkul\Product\Providers\ModuleServiceProvider::class,
-        \Webkul\User\Providers\ModuleServiceProvider::class,
-        \Webkul\MagicAI\Providers\ModuleServiceProvider::class,
+        ModuleServiceProvider::class,
+        Webkul\Attribute\Providers\ModuleServiceProvider::class,
+        Webkul\Category\Providers\ModuleServiceProvider::class,
+        Webkul\Core\Providers\ModuleServiceProvider::class,
+        Webkul\DataTransfer\Providers\ModuleServiceProvider::class,
+        Webkul\HistoryControl\Providers\ModuleServiceProvider::class,
+        Webkul\Notification\Providers\ModuleServiceProvider::class,
+        Webkul\Product\Providers\ModuleServiceProvider::class,
+        Webkul\User\Providers\ModuleServiceProvider::class,
+        Webkul\MagicAI\Providers\ModuleServiceProvider::class,
     ],
 ];

--- a/config/repository.php
+++ b/config/repository.php
@@ -1,5 +1,7 @@
 <?php
 
+use League\Fractal\Serializer\DataArraySerializer;
+
 /*
 |--------------------------------------------------------------------------
 | Prettus Repository Config
@@ -35,7 +37,7 @@ return [
         'params'     => [
             'include' => 'include',
         ],
-        'serializer' => League\Fractal\Serializer\DataArraySerializer::class,
+        'serializer' => DataArraySerializer::class,
     ],
 
     /*

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -1,5 +1,10 @@
 <?php
 
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
+use Spatie\ResponseCache\Replacers\CsrfTokenReplacer;
+use Spatie\ResponseCache\Serializers\DefaultSerializer;
+use Webkul\FPC\Hasher\DefaultHasher;
+
 return [
     /*
      * Determine if the response cache middleware should be enabled.
@@ -13,7 +18,7 @@ return [
      *  You can provide your own class given that it implements the
      *  CacheProfile interface.
      */
-    'cache_profile' => Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests::class,
+    'cache_profile' => CacheAllSuccessfulGetRequests::class,
 
     /*
      *  Optionally, you can specify a header that will force a cache bypass.
@@ -69,7 +74,7 @@ return [
      * Each replacer must implement the Replacer interface.
      */
     'replacers' => [
-        \Spatie\ResponseCache\Replacers\CsrfTokenReplacer::class,
+        CsrfTokenReplacer::class,
     ],
 
     /*
@@ -85,10 +90,10 @@ return [
      * This class is responsible for generating a hash for a request. This hash
      * is used to look up a cached response.
      */
-    'hasher' => \Webkul\FPC\Hasher\DefaultHasher::class,
+    'hasher' => DefaultHasher::class,
 
     /*
      * This class is responsible for serializing responses.
      */
-    'serializer' => \Spatie\ResponseCache\Serializers\DefaultSerializer::class,
+    'serializer' => DefaultSerializer::class,
 ];

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\VerifyCsrfToken;
 use Laravel\Sanctum\Sanctum;
 
 return [
@@ -60,8 +62,8 @@ return [
     */
 
     'middleware' => [
-        'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
-        'encrypt_cookies'   => App\Http\Middleware\EncryptCookies::class,
+        'verify_csrf_token' => VerifyCsrfToken::class,
+        'encrypt_cookies'   => EncryptCookies::class,
     ],
 
 ];

--- a/config/session.php
+++ b/config/session.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -124,7 +126,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
     ),
 
     /*

--- a/config/translatable.php
+++ b/config/translatable.php
@@ -1,5 +1,7 @@
 <?php
 
+use Astrotomic\Translatable\Validation\RuleFactory;
+
 return [
 
     /*
@@ -142,7 +144,7 @@ return [
      *
      */
     'rule_factory' => [
-        'format' => \Astrotomic\Translatable\Validation\RuleFactory::FORMAT_ARRAY,
+        'format' => RuleFactory::FORMAT_ARRAY,
         'prefix' => '%',
         'suffix' => '%',
     ],

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -34,7 +34,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the model's email address should be unverified.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return Factory
      */
     public function unverified()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Catalog;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -20,7 +21,7 @@ class AttributeDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeFamilyDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeFamilyDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Catalog;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -10,7 +11,7 @@ class AttributeFamilyDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeGroupDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeGroupDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Catalog;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -10,7 +11,7 @@ class AttributeGroupDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeOptionDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeOptionDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Catalog;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -30,7 +31,7 @@ class AttributeOptionDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryFieldDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryFieldDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Catalog;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -30,7 +31,7 @@ class CategoryFieldDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/MagicAI/MagicAISystemPromptGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/MagicAI/MagicAISystemPromptGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\MagicAI;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -17,7 +18,7 @@ class MagicAISystemPromptGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/MagicAI/MagicPromptGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/MagicAI/MagicPromptGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\MagicAI;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -17,7 +18,7 @@ class MagicPromptGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/ChannelDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/ChannelDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -10,7 +11,7 @@ class ChannelDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/CurrencyDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/CurrencyDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -19,7 +20,7 @@ class CurrencyDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ExportDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ExportDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings\DataTransfer;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -20,7 +21,7 @@ class ExportDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ImportDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ImportDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings\DataTransfer;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -20,7 +21,7 @@ class ImportDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/JobTrackerGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/JobTrackerGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings\DataTransfer;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 use Webkul\DataTransfer\Helpers\Import;
@@ -21,7 +22,7 @@ class JobTrackerGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/LocalesDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/LocalesDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -19,7 +20,7 @@ class LocalesDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/RolesDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/RolesDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -10,7 +11,7 @@ class RolesDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/DataGrids/Settings/UserDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/UserDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids\Settings;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Webkul\DataGrid\DataGrid;
@@ -18,7 +19,7 @@ class UserDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeController.php
@@ -3,8 +3,10 @@
 namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\AttributeDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
@@ -42,7 +44,7 @@ class AttributeController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -56,7 +58,7 @@ class AttributeController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -66,7 +68,7 @@ class AttributeController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -106,7 +108,7 @@ class AttributeController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -122,7 +124,7 @@ class AttributeController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {
@@ -236,7 +238,7 @@ class AttributeController extends Controller
     /**
      * Get super attributes of product.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function productSuperAttributes(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeFamilyController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeFamilyController.php
@@ -3,7 +3,9 @@
 namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\AttributeFamilyDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Attribute\Models\AttributeFamily;
@@ -30,7 +32,7 @@ class AttributeFamilyController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -44,7 +46,7 @@ class AttributeFamilyController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -98,7 +100,7 @@ class AttributeFamilyController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -121,7 +123,7 @@ class AttributeFamilyController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -150,7 +152,7 @@ class AttributeFamilyController extends Controller
     /**
      * Show the form for copy the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function copy(int $id)
     {
@@ -163,7 +165,7 @@ class AttributeFamilyController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeGroupController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeGroupController.php
@@ -3,7 +3,9 @@
 namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\AttributeGroupDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Attribute\Repositories\AttributeGroupRepository;
@@ -27,7 +29,7 @@ class AttributeGroupController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -41,7 +43,7 @@ class AttributeGroupController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -51,7 +53,7 @@ class AttributeGroupController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -75,7 +77,7 @@ class AttributeGroupController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -89,7 +91,7 @@ class AttributeGroupController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeOptionController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeOptionController.php
@@ -3,7 +3,9 @@
 namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\AttributeOptionDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\AttributeOptionForm;
@@ -26,7 +28,7 @@ class AttributeOptionController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index(int $id)
     {
@@ -36,7 +38,7 @@ class AttributeOptionController extends Controller
     /**
      * Store a newly created option.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store(int $attributeId, AttributeOptionForm $request): JsonResponse
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/CategoryController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/CategoryController.php
@@ -4,9 +4,11 @@ namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\CategoryDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\CategoryRequest;
@@ -34,7 +36,7 @@ class CategoryController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -48,7 +50,7 @@ class CategoryController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -66,7 +68,7 @@ class CategoryController extends Controller
     /**
      * Maps each category in the collection to a new value using the provided callback.
      *
-     * @param  \Illuminate\Support\Collection  $categories  Collection of category objects.
+     * @param  Collection  $categories  Collection of category objects.
      */
     public function transformCategoryTree(Collection $categories): array
     {
@@ -85,7 +87,7 @@ class CategoryController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store(CategoryRequest $categoryRequest)
     {
@@ -117,7 +119,7 @@ class CategoryController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -141,7 +143,7 @@ class CategoryController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(CategoryRequest $categoryRequest, int $id)
     {
@@ -273,7 +275,7 @@ class CategoryController extends Controller
     /**
      * Get all categories in tree format.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function tree(Request $request)
     {
@@ -328,7 +330,7 @@ class CategoryController extends Controller
     /**
      * Result of search customer.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function search()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/CategoryFieldController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/CategoryFieldController.php
@@ -3,7 +3,9 @@
 namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\CategoryFieldDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
@@ -30,7 +32,7 @@ class CategoryFieldController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -44,7 +46,7 @@ class CategoryFieldController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -54,7 +56,7 @@ class CategoryFieldController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -82,7 +84,7 @@ class CategoryFieldController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -95,7 +97,7 @@ class CategoryFieldController extends Controller
     /**
      * Get attribute options associated with attribute.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function getCategoryFieldOptions(int $id)
     {
@@ -107,7 +109,7 @@ class CategoryFieldController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/ProductBulkEditController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/ProductBulkEditController.php
@@ -4,10 +4,12 @@ namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
+use Illuminate\View\View;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\BulkEditRequest;
 use Webkul\Attribute\Repositories\AttributeFamilyRepository;
@@ -46,7 +48,7 @@ class ProductBulkEditController extends Controller
     /**
      * Apply filters for bulk edit and store filtered product & attribute IDs in session.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function filters(BulkEditRequest $bulkEditRequest)
     {
@@ -78,7 +80,7 @@ class ProductBulkEditController extends Controller
     /**
      * Show the bulk edit page with filtered products and attributes.
      *
-     * @return \Illuminate\View\View|\Illuminate\Http\RedirectResponse
+     * @return View|RedirectResponse
      */
     public function index()
     {
@@ -108,7 +110,7 @@ class ProductBulkEditController extends Controller
     /**
      * Store uploaded product media for a given attribute.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function storeProductMedia()
     {
@@ -168,7 +170,7 @@ class ProductBulkEditController extends Controller
     /**
      * Return a formatted JSON response for validation errors.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     protected function validateErrorResponse(mixed $validator, string $message = 'Validation failed.', int $code = 422)
     {
@@ -184,7 +186,7 @@ class ProductBulkEditController extends Controller
     /**
      * Handle bulk save of product updates via queued job.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handleBulkSave()
     {
@@ -234,7 +236,7 @@ class ProductBulkEditController extends Controller
     /**
      * Retrieve attributes for bulk edit.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getAttributes(Request $request)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/ProductController.php
@@ -3,9 +3,11 @@
 namespace Webkul\Admin\Http\Controllers\Catalog;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Catalog\ProductDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
@@ -43,7 +45,7 @@ class ProductController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -57,7 +59,7 @@ class ProductController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function store()
     {
@@ -131,7 +133,7 @@ class ProductController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -154,7 +156,7 @@ class ProductController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(ProductForm $request, int $id)
     {
@@ -224,7 +226,7 @@ class ProductController extends Controller
     /**
      * Copy a given Product.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function copy(int $id)
     {
@@ -322,7 +324,7 @@ class ProductController extends Controller
     /**
      * To be manually invoked when data is seeded into products.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function sync()
     {
@@ -334,7 +336,7 @@ class ProductController extends Controller
     /**
      * Result of search product.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function search()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/ConfigurationController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/ConfigurationController.php
@@ -3,8 +3,11 @@
 namespace Webkul\Admin\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Webkul\Admin\Http\Requests\ConfigurationForm;
 use Webkul\Core\Contracts\Validator\ConfigValidator;
 use Webkul\Core\Repositories\CoreConfigRepository;
@@ -15,7 +18,7 @@ class ConfigurationController extends Controller
     /**
      * Tree instance.
      *
-     * @var \Webkul\Core\Tree
+     * @var Tree
      */
     protected $configTree;
 
@@ -50,7 +53,7 @@ class ConfigurationController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -76,7 +79,7 @@ class ConfigurationController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function search()
     {
@@ -90,7 +93,7 @@ class ConfigurationController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function store(ConfigurationForm $request)
     {
@@ -125,7 +128,7 @@ class ConfigurationController extends Controller
     /**
      * Download the file for the specified resource.
      *
-     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     * @return StreamedResponse
      */
     public function download()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Controller.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Controller.php
@@ -5,6 +5,7 @@ namespace Webkul\Admin\Http\Controllers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
@@ -14,7 +15,7 @@ class Controller extends BaseController
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function redirectToLogin()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/DashboardController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/DashboardController.php
@@ -2,6 +2,8 @@
 
 namespace Webkul\Admin\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
 use Webkul\Admin\Helpers\Dashboard;
 
 class DashboardController extends Controller
@@ -26,7 +28,7 @@ class DashboardController extends Controller
     /**
      * Dashboard page.
      *
-     * @return \Illuminate\View\View|\Illuminate\Http\JsonResponse
+     * @return View|JsonResponse
      */
     public function index()
     {
@@ -38,7 +40,7 @@ class DashboardController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function stats()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/NotificationController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Controllers;
 
+use Illuminate\View\View;
 use Webkul\Notification\Repositories\NotificationRepository;
 
 class NotificationController extends Controller
@@ -16,7 +17,7 @@ class NotificationController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -50,10 +51,10 @@ class NotificationController extends Controller
      * Update the notification is reade or not.
      *
      * @param  int  $id
-     * @return \Illuminate\View\View
-     *                               Returns a view for redirection if the notification has a route.//+
-     *                               Returns a back redirect if no route is associated with the notification.//+
-     *                               Returns a 404 error if the notification does not exist
+     * @return View
+     *              Returns a view for redirection if the notification has a route.//+
+     *              Returns a back redirect if no route is associated with the notification.//+
+     *              Returns a 404 error if the notification does not exist
      */
     public function viewedNotifications($id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/ChannelController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/ChannelController.php
@@ -3,10 +3,14 @@
 namespace Webkul\Admin\Http\Controllers\Settings;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\ChannelDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Core\Repositories\ChannelRepository;
+use Webkul\Core\Rules\Code;
+use Webkul\Core\Rules\ConvertToArrayIfNeeded;
 
 class ChannelController extends Controller
 {
@@ -20,7 +24,7 @@ class ChannelController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -34,7 +38,7 @@ class ChannelController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -44,17 +48,17 @@ class ChannelController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
         $locales = core()->getAllActiveLocales();
 
         $rules = [
-            'code'              => ['required', 'unique:channels,code', new \Webkul\Core\Rules\Code],
+            'code'              => ['required', 'unique:channels,code', new Code],
             'root_category_id'  => 'required',
-            'locales'           => ['required', new \Webkul\Core\Rules\ConvertToArrayIfNeeded],
-            'currencies'        => ['required', new \Webkul\Core\Rules\ConvertToArrayIfNeeded],
+            'locales'           => ['required', new ConvertToArrayIfNeeded],
+            'currencies'        => ['required', new ConvertToArrayIfNeeded],
         ];
 
         foreach ($locales as $locale) {
@@ -79,7 +83,7 @@ class ChannelController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -91,7 +95,7 @@ class ChannelController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {
@@ -99,8 +103,8 @@ class ChannelController extends Controller
 
         $rules = [
             'root_category_id'  => 'required',
-            'locales'           => ['required', new \Webkul\Core\Rules\ConvertToArrayIfNeeded],
-            'currencies'        => ['required', new \Webkul\Core\Rules\ConvertToArrayIfNeeded],
+            'locales'           => ['required', new ConvertToArrayIfNeeded],
+            'currencies'        => ['required', new ConvertToArrayIfNeeded],
         ];
 
         foreach ($locales as $locale) {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/CurrencyController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/CurrencyController.php
@@ -3,11 +3,13 @@
 namespace Webkul\Admin\Http\Controllers\Settings;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\CurrencyDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
 use Webkul\Admin\Http\Requests\MassUpdateRequest;
 use Webkul\Core\Repositories\CurrencyRepository;
+use Webkul\Core\Rules\Code;
 
 class CurrencyController extends Controller
 {
@@ -21,7 +23,7 @@ class CurrencyController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -76,7 +78,7 @@ class CurrencyController extends Controller
         $id = request('id');
 
         $this->validate(request(), [
-            'code'      => ['required', 'unique:currencies,code,'.$id, new \Webkul\Core\Rules\Code],
+            'code'      => ['required', 'unique:currencies,code,'.$id, new Code],
             'status'    => 'boolean',
         ]);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/AbstractJobInstanceController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/AbstractJobInstanceController.php
@@ -3,8 +3,10 @@
 namespace Webkul\Admin\Http\Controllers\Settings\DataTransfer;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\DataTransfer\ImportDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\DataTransfer\Helpers\Import;
@@ -27,7 +29,7 @@ abstract class AbstractJobInstanceController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -41,7 +43,7 @@ abstract class AbstractJobInstanceController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -51,7 +53,7 @@ abstract class AbstractJobInstanceController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -104,7 +106,7 @@ abstract class AbstractJobInstanceController extends Controller
     /**
      * Show the form for editing a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -116,7 +118,7 @@ abstract class AbstractJobInstanceController extends Controller
     /**
      * Update a resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {
@@ -186,7 +188,7 @@ abstract class AbstractJobInstanceController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy($id)
     {
@@ -213,7 +215,7 @@ abstract class AbstractJobInstanceController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function import(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
@@ -3,9 +3,11 @@
 namespace Webkul\Admin\Http\Controllers\Settings\DataTransfer;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\DataTransfer\ExportDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\DataTransfer\Contracts\Validator\JobInstances\JobValidator;
@@ -33,7 +35,7 @@ class ExportController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -47,7 +49,7 @@ class ExportController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -59,7 +61,7 @@ class ExportController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -114,7 +116,7 @@ class ExportController extends Controller
     /**
      * Show the form for editing a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -128,7 +130,7 @@ class ExportController extends Controller
     /**
      * Update a resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {
@@ -196,7 +198,7 @@ class ExportController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy($id)
     {
@@ -232,7 +234,7 @@ class ExportController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function exportView(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -3,8 +3,10 @@
 namespace Webkul\Admin\Http\Controllers\Settings\DataTransfer;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\DataTransfer\ImportDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\DataTransfer\Contracts\Validator\JobInstances\JobValidator;
@@ -35,7 +37,7 @@ class ImportController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -49,7 +51,7 @@ class ImportController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -61,7 +63,7 @@ class ImportController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -127,7 +129,7 @@ class ImportController extends Controller
     /**
      * Show the form for editing a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -141,7 +143,7 @@ class ImportController extends Controller
     /**
      * Update a resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {
@@ -212,7 +214,7 @@ class ImportController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy($id)
     {
@@ -239,7 +241,7 @@ class ImportController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function importView(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/TrackerController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/TrackerController.php
@@ -3,6 +3,7 @@
 namespace Webkul\Admin\Http\Controllers\Settings\DataTransfer;
 
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\DataTransfer\JobTrackerGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\DataTransfer\Helpers\Export;
@@ -29,7 +30,7 @@ class TrackerController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -43,7 +44,7 @@ class TrackerController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function view($batchId = null)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/LocaleController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/LocaleController.php
@@ -3,11 +3,13 @@
 namespace Webkul\Admin\Http\Controllers\Settings;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\LocalesDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
 use Webkul\Admin\Http\Requests\MassUpdateRequest;
 use Webkul\Core\Repositories\LocaleRepository;
+use Webkul\Core\Rules\Code;
 
 class LocaleController extends Controller
 {
@@ -21,7 +23,7 @@ class LocaleController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -38,7 +40,7 @@ class LocaleController extends Controller
     public function store(): JsonResponse
     {
         $this->validate(request(), [
-            'code'        => ['required', 'unique:locales,code', new \Webkul\Core\Rules\Code],
+            'code'        => ['required', 'unique:locales,code', new Code],
         ]);
 
         $this->localeRepository->create(request()->only([

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/RoleController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/RoleController.php
@@ -3,7 +3,9 @@
 namespace Webkul\Admin\Http\Controllers\Settings;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\RolesDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\User\Repositories\AdminRepository;
@@ -24,7 +26,7 @@ class RoleController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -38,7 +40,7 @@ class RoleController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -48,7 +50,7 @@ class RoleController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -79,7 +81,7 @@ class RoleController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -91,7 +93,7 @@ class RoleController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update(int $id)
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
@@ -3,10 +3,13 @@
 namespace Webkul\Admin\Http\Controllers\Settings;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\UserDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Requests\UserForm;
@@ -30,7 +33,7 @@ class UserController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -117,7 +120,7 @@ class UserController extends Controller
 
         $data = $this->prepareUserData($request, $id);
 
-        if ($data instanceof \Illuminate\Http\RedirectResponse) {
+        if ($data instanceof RedirectResponse) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.users.update-success'),
             ]);
@@ -193,7 +196,7 @@ class UserController extends Controller
      * Show the form for confirming the user password.
      *
      * @param  int  $id
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function confirm($id)
     {
@@ -205,7 +208,7 @@ class UserController extends Controller
     /**
      * Destroy current after confirming.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function destroySelf(): JsonResponse
     {
@@ -239,7 +242,7 @@ class UserController extends Controller
      * Prepare user data.
      *
      * @param  int  $id
-     * @return array|\Illuminate\Http\RedirectResponse
+     * @return array|RedirectResponse
      */
     private function prepareUserData(UserForm $request, $id)
     {
@@ -294,7 +297,7 @@ class UserController extends Controller
     /**
      * Cannot change redirect response.
      */
-    private function cannotChangeRedirectResponse(string $columnName): \Illuminate\Http\RedirectResponse
+    private function cannotChangeRedirectResponse(string $columnName): RedirectResponse
     {
         session()->flash('error', trans('admin::app.settings.users.cannot-change', [
             'name' => $columnName,

--- a/packages/Webkul/Admin/src/Http/Controllers/User/AccountController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/AccountController.php
@@ -3,8 +3,10 @@
 namespace Webkul\Admin\Http\Controllers\User;
 
 use Hash;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Core\Filesystem\FileStorer;
 
@@ -20,7 +22,7 @@ class AccountController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit()
     {
@@ -32,7 +34,7 @@ class AccountController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function update()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/User/ForgetPasswordController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/ForgetPasswordController.php
@@ -2,7 +2,10 @@
 
 namespace Webkul\Admin\Http\Controllers\User;
 
+use Illuminate\Contracts\Auth\PasswordBroker;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Password;
+use Illuminate\View\View;
 use Webkul\Admin\Http\Controllers\Controller;
 
 class ForgetPasswordController extends Controller
@@ -10,7 +13,7 @@ class ForgetPasswordController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -32,7 +35,7 @@ class ForgetPasswordController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -67,7 +70,7 @@ class ForgetPasswordController extends Controller
     /**
      * Get the broker to be used during password reset.
      *
-     * @return \Illuminate\Contracts\Auth\PasswordBroker
+     * @return PasswordBroker
      */
     public function broker()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/User/ResetPasswordController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/ResetPasswordController.php
@@ -3,10 +3,15 @@
 namespace Webkul\Admin\Http\Controllers\User;
 
 use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Contracts\Auth\CanResetPassword;
+use Illuminate\Contracts\Auth\PasswordBroker;
+use Illuminate\Contracts\View\Factory;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use Webkul\Admin\Http\Controllers\Controller;
 
 class ResetPasswordController extends Controller
@@ -19,7 +24,7 @@ class ResetPasswordController extends Controller
      * If no token is present, display the link request form.
      *
      * @param  string|null  $token
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     * @return Factory|View
      */
     public function create($token = null)
     {
@@ -32,7 +37,7 @@ class ResetPasswordController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -68,7 +73,7 @@ class ResetPasswordController extends Controller
     /**
      * Reset the given admin's password.
      *
-     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $admin
+     * @param  CanResetPassword  $admin
      * @param  string  $password
      * @return void
      */
@@ -88,7 +93,7 @@ class ResetPasswordController extends Controller
     /**
      * Get the broker to be used during password reset.
      *
-     * @return \Illuminate\Contracts\Auth\PasswordBroker
+     * @return PasswordBroker
      */
     public function broker()
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/User/SessionController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/SessionController.php
@@ -2,6 +2,8 @@
 
 namespace Webkul\Admin\Http\Controllers\User;
 
+use Illuminate\Http\Response;
+use Illuminate\View\View;
 use Webkul\Admin\Http\Controllers\Controller;
 
 class SessionController extends Controller
@@ -9,7 +11,7 @@ class SessionController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -31,7 +33,7 @@ class SessionController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -63,7 +65,7 @@ class SessionController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function destroy()
     {

--- a/packages/Webkul/Admin/src/Http/Requests/UserForm.php
+++ b/packages/Webkul/Admin/src/Http/Requests/UserForm.php
@@ -67,7 +67,7 @@ class UserForm extends FormRequest
      *
      * @return void
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     protected function failedValidation(Validator $validator)
     {

--- a/packages/Webkul/Admin/src/Http/Resources/AttributeOptionResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/AttributeOptionResource.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Resources;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttributeOptionResource extends JsonResource
@@ -9,7 +10,7 @@ class AttributeOptionResource extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  Request
      * @return array
      */
     public function toArray($request)

--- a/packages/Webkul/Admin/src/Http/Resources/AttributeResource.php
+++ b/packages/Webkul/Admin/src/Http/Resources/AttributeResource.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Resources;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttributeResource extends JsonResource
@@ -9,7 +10,7 @@ class AttributeResource extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  Request
      * @return array
      */
     public function toArray($request)

--- a/packages/Webkul/Admin/src/Mail/Admin/ResetPasswordNotification.php
+++ b/packages/Webkul/Admin/src/Mail/Admin/ResetPasswordNotification.php
@@ -11,7 +11,7 @@ class ResetPasswordNotification extends ResetPassword
      * Build the mail representation of the notification.
      *
      * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return MailMessage
      */
     public function toMail($notifiable)
     {

--- a/packages/Webkul/Admin/src/Mail/Mailable.php
+++ b/packages/Webkul/Admin/src/Mail/Mailable.php
@@ -5,6 +5,7 @@ namespace Webkul\Admin\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable as BaseMailable;
+use Illuminate\Mail\Message;
 use Illuminate\Queue\SerializesModels;
 
 class Mailable extends BaseMailable implements ShouldQueue
@@ -14,7 +15,7 @@ class Mailable extends BaseMailable implements ShouldQueue
     /**
      * Add the sender to the message.
      *
-     * @param  \Illuminate\Mail\Message  $message
+     * @param  Message  $message
      */
     protected function buildFrom($message): Mailable
     {

--- a/packages/Webkul/Admin/tests/Feature/Acl/Configuration/IntegrationAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/Configuration/IntegrationAclTest.php
@@ -84,7 +84,7 @@ it('should delete an integration if has permission', function () {
         ->assertOk()
         ->assertDontSeeText('Unauthorized');
 
-    $this->assertDatabaseHas($this->getFullTableName(ApiKey::class), [
+    $this->assertDatabaseHas($this->getFullTableName(Apikey::class), [
         'id'      => $apiKey->id,
         'revoked' => 1,
     ]);

--- a/packages/Webkul/Admin/tests/Feature/Acl/Settings/ChannelAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/Settings/ChannelAclTest.php
@@ -58,7 +58,7 @@ it('should not be able to delete channel if does not have permission', function 
     $this->delete(route('admin.settings.channels.delete', ['id' => $channel->id]))
         ->assertSeeText('Unauthorized');
 
-    $this->assertDatabaseHas($this->getFullTableName(channel::class), ['id' => $channel->id]);
+    $this->assertDatabaseHas($this->getFullTableName(Channel::class), ['id' => $channel->id]);
 });
 
 it('should be able to delete channel if have permission', function () {

--- a/packages/Webkul/Admin/tests/Feature/Configuration/IntegrationSectionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Configuration/IntegrationSectionTest.php
@@ -64,9 +64,9 @@ it('should create the integration with permission custom sucessfully', function 
 
     $response->assertSessionHas('success', trans('admin::app.configuration.integrations.create-success'));
 
-    $apiKey = ApiKey::where('name', 'Test Custom Integration')->where('admin_id', $userId)->where('permission_type', 'custom')->first();
+    $apiKey = Apikey::where('name', 'Test Custom Integration')->where('admin_id', $userId)->where('permission_type', 'custom')->first();
 
-    $this->assertTrue($apiKey instanceof ApiKey, 'Api Key not Found');
+    $this->assertTrue($apiKey instanceof Apikey, 'Api Key not Found');
 
     $this->assertEquals($permissions, $apiKey->permissions);
 });
@@ -74,7 +74,7 @@ it('should create the integration with permission custom sucessfully', function 
 it('should return validation error when integration already exists for a user', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
 
     $this->post(route('admin.configuration.integrations.store'), [
         'name'            => 'Test Integration',
@@ -86,7 +86,7 @@ it('should return validation error when integration already exists for a user', 
 it('should return the integration edit page', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
 
     $this->get(route('admin.configuration.integrations.edit', $apiKey->id))
         ->assertOk()
@@ -97,7 +97,7 @@ it('should return the integration edit page', function () {
 it('should return validation messages for name and premission_type on update integration', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
 
     $this->put(route('admin.configuration.integrations.update', $apiKey->id), [
         'name'            => '',
@@ -109,7 +109,7 @@ it('should return validation messages for name and premission_type on update int
 it('should update the integration with permission type all sucessfully', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
 
     $apiKeyId = $apiKey->id;
 
@@ -122,7 +122,7 @@ it('should update the integration with permission type all sucessfully', functio
     $response->assertSessionHas('success', trans('admin::app.configuration.integrations.update-success'))
         ->assertRedirect(route('admin.configuration.integrations.edit', $apiKeyId));
 
-    $this->assertDatabaseHas($this->getFullTableName(ApiKey::class), [
+    $this->assertDatabaseHas($this->getFullTableName(Apikey::class), [
         'name'            => 'Test Integration',
         'admin_id'        => $userId,
         'permission_type' => 'custom',
@@ -134,7 +134,7 @@ it('should update the integration with permission type custom sucessfully', func
 
     $permissions = ['api.catalog', 'api.catalog.products', 'api.catalog.products.create'];
 
-    $apiKey = ApiKey::factory()->create(['permission_type' => 'custom', 'permissions' => $permissions, 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['permission_type' => 'custom', 'permissions' => $permissions, 'admin_id' => $userId]);
 
     $permissions[] = 'api.catalog.products.edit';
 
@@ -147,9 +147,9 @@ it('should update the integration with permission type custom sucessfully', func
 
     $response->assertSessionHas('success', trans('admin::app.configuration.integrations.update-success'));
 
-    $apiKey = ApiKey::where('name', 'Test Custom Integration')->where('admin_id', $userId)->where('permission_type', 'custom')->first();
+    $apiKey = Apikey::where('name', 'Test Custom Integration')->where('admin_id', $userId)->where('permission_type', 'custom')->first();
 
-    $this->assertTrue($apiKey instanceof ApiKey, 'Api Key not Found');
+    $this->assertTrue($apiKey instanceof Apikey, 'Api Key not Found');
 
     $this->assertEquals($permissions, $apiKey->permissions);
 });
@@ -157,7 +157,7 @@ it('should update the integration with permission type custom sucessfully', func
 it('should generate secret key and client id for a integration', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['name' => 'Test', 'permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['name' => 'Test', 'permission_type' => 'all', 'admin_id' => $userId]);
 
     $response = $this->post(route('admin.configuration.integrations.generate_key'), [
         'name'     => $apiKey->name,
@@ -180,7 +180,7 @@ it('should generate secret key and client id for a integration', function () {
 it('should regenerate secret key for a integration', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['name' => 'Test', 'permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['name' => 'Test', 'permission_type' => 'all', 'admin_id' => $userId]);
 
     $response = $this->post(route('admin.configuration.integrations.generate_key'), [
         'name'     => $apiKey->name,
@@ -205,13 +205,13 @@ it('should regenerate secret key for a integration', function () {
 it('should revoke the integration succesfully on delete', function () {
     $userId = $this->loginAsAdmin()->id;
 
-    $apiKey = ApiKey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
+    $apiKey = Apikey::factory()->create(['permission_type' => 'all', 'admin_id' => $userId]);
 
     $this->delete(route('admin.configuration.integrations.delete', $apiKey->id))
         ->assertOk()
         ->assertJsonFragment(['message' => trans('admin::app.configuration.integrations.delete-success')]);
 
-    $this->assertDatabaseHas($this->getFullTableName(ApiKey::class), [
+    $this->assertDatabaseHas($this->getFullTableName(Apikey::class), [
         'id'      => $apiKey->id,
         'revoked' => 1,
     ]);

--- a/packages/Webkul/AdminApi/src/ApiDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\AdminApi;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Webkul\AdminApi\Checker\QueryParametersChecker;
@@ -105,7 +106,7 @@ abstract class ApiDataSource
     /**
      * Process all requested filters.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function processRequestedFilters(array $requestedFilters)
     {
@@ -220,10 +221,10 @@ abstract class ApiDataSource
     /**
      * Applies the specified operator to the query builder based on the given column and value.
      *
-     * @param  \Illuminate\Database\Query\Builder  $scopeQueryBuilder  The query builder instance to apply the operator to.
+     * @param  Builder  $scopeQueryBuilder  The query builder instance to apply the operator to.
      * @param  string  $requestedColumn  The column to apply the operator to.
      * @param  array  $value  The value and operator to apply.
-     * @return \Illuminate\Database\Query\Builder The updated query builder instance.
+     * @return Builder The updated query builder instance.
      */
     public function operatorByFilter($scopeQueryBuilder, $requestedColumn, $value)
     {
@@ -249,7 +250,7 @@ abstract class ApiDataSource
     /**
      * Process requested sorting.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function processRequestedSorting($requestedSort)
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/AttributeDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/AttributeDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Attribute\Repositories\AttributeRepository;
 
@@ -18,7 +19,7 @@ class AttributeDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the attribute repository.
+     * @return Builder The query builder for the attribute repository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/AttributeFamilyDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/AttributeFamilyDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Attribute\Repositories\AttributeFamilyRepository;
 use Webkul\Attribute\Repositories\AttributeGroupRepository;
@@ -22,7 +23,7 @@ class AttributeFamilyDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the attribute  familyrepository.
+     * @return Builder The query builder for the attribute  familyrepository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/AttributeGroupDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/AttributeGroupDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Attribute\Repositories\AttributeGroupRepository;
 
@@ -18,7 +19,7 @@ class AttributeGroupDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the attribute group repository.
+     * @return Builder The query builder for the attribute group repository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/CategoryDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/CategoryDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Category\Repositories\CategoryRepository;
 
@@ -27,7 +28,7 @@ class CategoryDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the category repository.
+     * @return Builder The query builder for the category repository.
      */
     public function prepareApiQueryBuilder()
     {
@@ -105,10 +106,10 @@ class CategoryDataSource extends ApiDataSource
     /**
      * Applies the specified operator to the query builder based on the given column and value.
      *
-     * @param  \Illuminate\Database\Query\Builder  $scopeQueryBuilder  The query builder instance to apply the operator to.
+     * @param  Builder  $scopeQueryBuilder  The query builder instance to apply the operator to.
      * @param  string  $requestedColumn  The column to apply the operator to.
      * @param  array  $value  The value and operator to apply.
-     * @return \Illuminate\Database\Query\Builder The updated query builder instance.
+     * @return Builder The updated query builder instance.
      */
     public function operatorByFilter($scopeQueryBuilder, $requestedColumn, $value)
     {
@@ -140,7 +141,7 @@ class CategoryDataSource extends ApiDataSource
     /**
      * Retrieves the ID of a product based on its code.
      *
-     * @param \Illuminate\Database\Query\Builder
+     * @param Builder
      * @return int|null The ID of the product if found, otherwise null.
      */
     private function getParentIdByCode($queryBuilder, string $code)

--- a/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/CategoryFieldDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/Catalog/CategoryFieldDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Category\Repositories\CategoryFieldRepository;
 
@@ -18,7 +19,7 @@ class CategoryFieldDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the CategoryField repository.
+     * @return Builder The query builder for the CategoryField repository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/ChannelDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/ChannelDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Core\Repositories\ChannelRepository;
 
@@ -18,7 +19,7 @@ class ChannelDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the channel repository.
+     * @return Builder The query builder for the channel repository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/CurrencyDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/CurrencyDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Core\Repositories\CurrencyRepository;
 
@@ -18,7 +19,7 @@ class CurrencyDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the currency repository.
+     * @return Builder The query builder for the currency repository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/ApiDataSource/LocaleDataSource.php
+++ b/packages/Webkul/AdminApi/src/ApiDataSource/LocaleDataSource.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\ApiDataSource;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Query\Builder;
 use Webkul\AdminApi\ApiDataSource;
 use Webkul\Core\Repositories\LocaleRepository;
 
@@ -18,7 +19,7 @@ class LocaleDataSource extends ApiDataSource
     /**
      * Prepares the query builder for API requests.
      *
-     * @return \Illuminate\Database\Query\Builder The query builder for the locale repository.
+     * @return Builder The query builder for the locale repository.
      */
     public function prepareApiQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/DataGrids/Integrations/ApiKeysDataGrid.php
+++ b/packages/Webkul/AdminApi/src/DataGrids/Integrations/ApiKeysDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\AdminApi\DataGrids\Integrations;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\AdminApi\Traits\OauthClientGenerator;
 use Webkul\DataGrid\DataGrid;
@@ -20,7 +21,7 @@ class ApiKeysDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/AttributeController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/AttributeController.php
@@ -57,7 +57,7 @@ class AttributeController extends ApiController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function store()
     {
@@ -111,7 +111,7 @@ class AttributeController extends ApiController
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function update(string $code)
     {
@@ -141,7 +141,7 @@ class AttributeController extends ApiController
     /**
      * Display a single result of the resource.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getOptions(string $code)
     {
@@ -155,7 +155,7 @@ class AttributeController extends ApiController
     /**
      * Store a newly attribute option in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function storeOption(string $attributeCode)
     {
@@ -198,7 +198,7 @@ class AttributeController extends ApiController
     /**
      * Updates an attribute option in the storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function updateOption(string $attributeCode)
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/CategoryController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/CategoryController.php
@@ -96,7 +96,7 @@ class CategoryController extends ApiController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function store()
     {
@@ -134,7 +134,7 @@ class CategoryController extends ApiController
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function update(string $code)
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/CategoryFieldController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/CategoryFieldController.php
@@ -55,7 +55,7 @@ class CategoryFieldController extends ApiController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function store()
     {
@@ -109,7 +109,7 @@ class CategoryFieldController extends ApiController
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function update(string $code)
     {
@@ -160,7 +160,7 @@ class CategoryFieldController extends ApiController
     /**
      * Display a single result of the resource.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getOptions($code)
     {
@@ -174,7 +174,7 @@ class CategoryFieldController extends ApiController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function storeOption(string $fieldCode)
     {
@@ -219,7 +219,7 @@ class CategoryFieldController extends ApiController
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function updateOption(string $fieldCode)
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/ConfigurableProductController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/ConfigurableProductController.php
@@ -39,7 +39,7 @@ class ConfigurableProductController extends ProductController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function store()
     {
@@ -102,7 +102,7 @@ class ConfigurableProductController extends ProductController
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function update(string $sku)
     {
@@ -161,7 +161,7 @@ class ConfigurableProductController extends ProductController
     /**
      * Patch the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function partialUpdate(string $sku)
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/MediaFileController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/MediaFileController.php
@@ -3,9 +3,11 @@
 namespace Webkul\AdminApi\Http\Controllers\API\Catalog;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
 use Symfony\Component\HttpFoundation\Response;
 use Webkul\AdminApi\Http\Controllers\API\ApiController;
 use Webkul\Attribute\Repositories\AttributeOptionRepository;
@@ -37,7 +39,7 @@ class MediaFileController extends ApiController
     /**
      * Handles the storage of media files for products.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function storeProductMedia()
     {
@@ -98,7 +100,7 @@ class MediaFileController extends ApiController
     /**
      * Handles the storage of media files for categories.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function storeCategoryMedia()
     {
@@ -119,7 +121,7 @@ class MediaFileController extends ApiController
 
         $validator = $this->categoryMediaValidator->validate($requestData, $categoryId);
 
-        if ($validator instanceof \Illuminate\Validation\Validator && $validator->fails()) {
+        if ($validator instanceof Validator && $validator->fails()) {
             return $this->validateErrorResponse($validator);
         }
 
@@ -151,7 +153,7 @@ class MediaFileController extends ApiController
     /**
      * Handles the storage of media files for swatch attribute.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function storeSwatchMedia()
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/ProductController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/ProductController.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\Http\Controllers\API\Catalog;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
@@ -36,7 +37,7 @@ class ProductController extends ApiController
      *
      * @param  array  $data  The data to be used for updating the product.
      * @param  Product  $id  The unique identifier of the product to be updated.
-     * @return \Webkul\Product\Models\Product The updated product model.
+     * @return Product The updated product model.
      */
     protected function updateProduct(array $data, Product $product): Product
     {
@@ -236,7 +237,7 @@ class ProductController extends ApiController
      * Creates or updates a variant product based on the provided data.
      *
      * @param  array  $data  The input data containing variant and super attribute information.
-     * @return \Webkul\Product\Models\Product The updated or created variant product.
+     * @return Product The updated or created variant product.
      */
     protected function createOrUpdateVariant(array $data): mixed
     {
@@ -282,7 +283,7 @@ class ProductController extends ApiController
     /**
      * Prepares variant data for product update.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $product  The parent product model.
+     * @param  Model  $product  The parent product model.
      * @param  array  $data  The input data containing variant and super attribute information.
      * @param  string  $sku  The SKU of the product.
      * @return array The prepared variant data array.
@@ -416,7 +417,7 @@ class ProductController extends ApiController
      * Retrieves an attribute family by its code and throws a ModelNotFoundException if not found.
      *
      * @param  string  $code  The unique code of the attribute family to be retrieved.
-     * @return \Webkul\Attribute\Models\AttributeFamily The found attribute family.
+     * @return AttributeFamily The found attribute family.
      *
      * @throws ModelNotFoundException If the attribute family is not found.
      */

--- a/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/SimpleProductController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/API/Catalog/SimpleProductController.php
@@ -64,7 +64,7 @@ class SimpleProductController extends ProductController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function store()
     {
@@ -138,7 +138,7 @@ class SimpleProductController extends ProductController
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function update(string $sku)
     {
@@ -195,7 +195,7 @@ class SimpleProductController extends ProductController
     /**
      * Partial Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function partialUpdate(string $sku)
     {

--- a/packages/Webkul/AdminApi/src/Http/Controllers/Integrations/ApiKeysController.php
+++ b/packages/Webkul/AdminApi/src/Http/Controllers/Integrations/ApiKeysController.php
@@ -4,8 +4,11 @@ namespace Webkul\AdminApi\Http\Controllers\Integrations;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
 use Laravel\Passport\ClientRepository;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\AdminApi\DataGrids\Integrations\ApiKeysDataGrid;
@@ -31,7 +34,7 @@ class ApiKeysController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -45,7 +48,7 @@ class ApiKeysController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function create()
     {
@@ -62,7 +65,7 @@ class ApiKeysController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store()
     {
@@ -93,7 +96,7 @@ class ApiKeysController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function edit(int $id)
     {
@@ -105,9 +108,9 @@ class ApiKeysController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      *
-     * @throws \Illuminate\Validation\ValidationException If the required parameters are not provided.
+     * @throws ValidationException If the required parameters are not provided.
      */
     public function update(int $id)
     {
@@ -162,9 +165,9 @@ class ApiKeysController extends Controller
      * for the specified admin user and API key. The client ID and secret key are then
      * associated with the API key in the database.
      *
-     * @return \Illuminate\Http\JsonResponse The JSON response containing the new client ID and secret key.
+     * @return JsonResponse The JSON response containing the new client ID and secret key.
      *
-     * @throws \Illuminate\Validation\ValidationException If the required parameters are not provided.
+     * @throws ValidationException If the required parameters are not provided.
      */
     public function generateKey()
     {
@@ -207,7 +210,7 @@ class ApiKeysController extends Controller
      * finds the corresponding client in the database, and then regenerates its secret key.
      * If the client is not found, it returns a JSON response with a 404 status code and an error message.
      *
-     * @return \Illuminate\Http\JsonResponse The JSON response containing the regenerated secret key.
+     * @return JsonResponse The JSON response containing the regenerated secret key.
      */
     public function regenerateSecretKey()
     {
@@ -229,7 +232,7 @@ class ApiKeysController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy(int $id)
     {

--- a/packages/Webkul/AdminApi/src/Models/Apikey.php
+++ b/packages/Webkul/AdminApi/src/Models/Apikey.php
@@ -5,6 +5,7 @@ namespace Webkul\AdminApi\Models;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Webkul\AdminApi\Contracts\Apikey as ApikeyContract;
 use Webkul\AdminApi\Database\Factories\ApiKeyFactory;
 use Webkul\HistoryControl\Contracts\HistoryAuditable as HistoryContract;
@@ -65,7 +66,7 @@ class Apikey extends Model implements ApikeyContract, HistoryContract
     /**
      * Get the admins.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function admins()
     {
@@ -75,7 +76,7 @@ class Apikey extends Model implements ApikeyContract, HistoryContract
     /**
      * Get the oauthClients.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function oauthClients()
     {

--- a/packages/Webkul/AdminApi/src/Models/Client.php
+++ b/packages/Webkul/AdminApi/src/Models/Client.php
@@ -3,6 +3,7 @@
 namespace Webkul\AdminApi\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Laravel\Passport\Client as PassportClient;
 use Webkul\User\Models\AdminProxy;
 
@@ -17,7 +18,7 @@ class Client extends PassportClient
     /**
      * Get the admins.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function admins()
     {

--- a/packages/Webkul/AdminApi/src/Providers/AdminApiServiceProvider.php
+++ b/packages/Webkul/AdminApi/src/Providers/AdminApiServiceProvider.php
@@ -6,8 +6,13 @@ use Carbon\Carbon;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Webkul\AdminApi\Console\ApiClientCommand;
+use Webkul\AdminApi\Http\Middleware\EnsureAcceptsJson;
+use Webkul\AdminApi\Http\Middleware\LocaleMiddleware;
+use Webkul\AdminApi\Http\Middleware\ScopeMiddleware;
+use Webkul\AdminApi\Models\Client;
 use Webkul\Core\Tree;
 
 class AdminApiServiceProvider extends ServiceProvider
@@ -18,9 +23,9 @@ class AdminApiServiceProvider extends ServiceProvider
      * @var array
      */
     protected $middlewareAliases = [
-        'accept.json'    => \Webkul\AdminApi\Http\Middleware\EnsureAcceptsJson::class,
-        'request.locale' => \Webkul\AdminApi\Http\Middleware\LocaleMiddleware::class,
-        'api.scope'      => \Webkul\AdminApi\Http\Middleware\ScopeMiddleware::class,
+        'accept.json'    => EnsureAcceptsJson::class,
+        'request.locale' => LocaleMiddleware::class,
+        'api.scope'      => ScopeMiddleware::class,
     ];
 
     /**
@@ -105,7 +110,7 @@ class AdminApiServiceProvider extends ServiceProvider
         Passport::loadKeysFrom(__DIR__.'/../Secrets/Oauth');
 
         Passport::$passwordGrantEnabled = true;
-        Passport::useClientModel(\Webkul\AdminApi\Models\Client::class);
+        Passport::useClientModel(Client::class);
 
         // Set access token TTL
         Passport::tokensExpireIn(Carbon::now()->addSeconds(config('api.access_token_ttl')));
@@ -113,7 +118,7 @@ class AdminApiServiceProvider extends ServiceProvider
         // Set refresh token TTL
         Passport::refreshTokensExpireIn(Carbon::now()->addSeconds(config('api.refresh_token_ttl')));
 
-        $this->app->bind(\Laravel\Passport\ClientRepository::class, \Webkul\AdminApi\Repositories\ClientRepository::class);
+        $this->app->bind(ClientRepository::class, \Webkul\AdminApi\Repositories\ClientRepository::class);
     }
 
     /**

--- a/packages/Webkul/AdminApi/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/AdminApi/src/Providers/ModuleServiceProvider.php
@@ -3,10 +3,11 @@
 namespace Webkul\AdminApi\Providers;
 
 use Konekt\Concord\BaseModuleServiceProvider;
+use Webkul\AdminApi\Models\Apikey;
 
 class ModuleServiceProvider extends BaseModuleServiceProvider
 {
     protected $models = [
-        \Webkul\AdminApi\Models\Apikey::class,
+        Apikey::class,
     ];
 }

--- a/packages/Webkul/AdminApi/src/Repositories/ClientRepository.php
+++ b/packages/Webkul/AdminApi/src/Repositories/ClientRepository.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\AdminApi\Repositories;
 
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository as BaseClientRepository;
 use Laravel\Passport\Passport;
 
@@ -11,7 +12,7 @@ class ClientRepository extends BaseClientRepository
      * Get a client by the given ID.
      *
      * @param  int|string  $id
-     * @return \Laravel\Passport\Client|null
+     * @return Client|null
      */
     public function find($id)
     {
@@ -34,7 +35,7 @@ class ClientRepository extends BaseClientRepository
      * Get an active client by the given ID.
      *
      * @param  int|string  $id
-     * @return \Laravel\Passport\Client|null
+     * @return Client|null
      */
     public function findActive($id)
     {

--- a/packages/Webkul/AdminApi/src/Traits/ApiResponse.php
+++ b/packages/Webkul/AdminApi/src/Traits/ApiResponse.php
@@ -3,7 +3,10 @@
 namespace Webkul\AdminApi\Traits;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 trait ApiResponse
@@ -11,7 +14,7 @@ trait ApiResponse
     /**
      * This function is responsible for creating a success response in JSON format.
      *
-     * @return \Illuminate\Http\JsonResponse *
+     * @return JsonResponse *
      */
     protected function successResponse(string $message = 'Operation completed successfully', int $code = 200, array $data = [])
     {
@@ -30,7 +33,7 @@ trait ApiResponse
     /**
      * This function is used to return a JSON response when a requested model is not found.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     protected function modelNotFoundResponse(string $message = 'Data not found.', int $code = 404)
     {
@@ -43,11 +46,11 @@ trait ApiResponse
     /**
      * Handles and returns a validation error response.
      *
-     * @return \Illuminate\Http\JsonResponse .
+     * @return JsonResponse .
      */
     protected function validateErrorResponse(mixed $validator, string $message = 'Validation failed.', int $code = 422)
     {
-        $errors = $validator instanceof \Illuminate\Validation\Validator ? (new \Illuminate\Validation\ValidationException($validator))->errors() : $validator;
+        $errors = $validator instanceof Validator ? (new ValidationException($validator))->errors() : $validator;
 
         return response()->json([
             'success' => false,

--- a/packages/Webkul/AdminApi/tests/Feature/Catalog/ApiAttributeTest.php
+++ b/packages/Webkul/AdminApi/tests/Feature/Catalog/ApiAttributeTest.php
@@ -162,8 +162,8 @@ it('should create attributes with certain attribute types', function () {
                 ->assertJsonFragment(['success' => true, 'message' => trans('admin::app.catalog.attributes.create-success')]);
 
             $this->assertDatabaseHas($this->getFullTableName(Attribute::class), $data);
-        } catch (\Exception $e) {
-            throw new \Exception('Failed with attribute code: '.$code.'. '.$e->getMessage());
+        } catch (Exception $e) {
+            throw new Exception('Failed with attribute code: '.$code.'. '.$e->getMessage());
         }
     }
 });
@@ -259,8 +259,8 @@ it('should not create attributes with certain codes', function () {
             unset($data['labels']);
 
             $this->assertDatabaseMissing($this->getFullTableName(Attribute::class), $data);
-        } catch (\Exception $e) {
-            throw new \Exception('Failed with attribute code: '.$code.'. '.$e->getMessage());
+        } catch (Exception $e) {
+            throw new Exception('Failed with attribute code: '.$code.'. '.$e->getMessage());
         }
     }
 });
@@ -372,8 +372,8 @@ it('should create text attribute with these validation types', function () {
                 ->assertCreated();
 
             $this->assertDatabaseHas($this->getFullTableName(Attribute::class), $data);
-        } catch (\Exception $e) {
-            throw new \Exception('Failed with validation type code: '.$validation.'. '.$e->getMessage());
+        } catch (Exception $e) {
+            throw new Exception('Failed with validation type code: '.$validation.'. '.$e->getMessage());
         }
     }
 });

--- a/packages/Webkul/AdminApi/tests/Feature/Catalog/ApiCategoryFieldTest.php
+++ b/packages/Webkul/AdminApi/tests/Feature/Catalog/ApiCategoryFieldTest.php
@@ -164,8 +164,8 @@ it('should create category fields with certain types', function () {
                 ->assertJsonFragment(['success' => true, 'message' => trans('admin::app.catalog.category_fields.create-success')]);
 
             $this->assertDatabaseHas($this->getFullTableName(CategoryField::class), $data);
-        } catch (\Exception $e) {
-            throw new \Exception('Failed with categoryField code: '.$code.'. '.$e->getMessage());
+        } catch (Exception $e) {
+            throw new Exception('Failed with categoryField code: '.$code.'. '.$e->getMessage());
         }
     }
 });
@@ -253,8 +253,8 @@ it('should not create category fields with certain codes', function () {
             unset($data['labels']);
 
             $this->assertDatabaseMissing($this->getFullTableName(CategoryField::class), $data);
-        } catch (\Exception $e) {
-            throw new \Exception('Failed with categoryField code: '.$code.'. '.$e->getMessage());
+        } catch (Exception $e) {
+            throw new Exception('Failed with categoryField code: '.$code.'. '.$e->getMessage());
         }
     }
 });
@@ -362,8 +362,8 @@ it('should create text category field with these validation types', function () 
                 ->assertCreated();
 
             $this->assertDatabaseHas($this->getFullTableName(CategoryField::class), $data);
-        } catch (\Exception $e) {
-            throw new \Exception('Failed with validation type code: '.$validation.'. '.$e->getMessage());
+        } catch (Exception $e) {
+            throw new Exception('Failed with validation type code: '.$validation.'. '.$e->getMessage());
         }
     }
 });

--- a/packages/Webkul/Attribute/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Attribute/src/Providers/ModuleServiceProvider.php
@@ -2,19 +2,28 @@
 
 namespace Webkul\Attribute\Providers;
 
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeFamily;
+use Webkul\Attribute\Models\AttributeFamilyGroupMapping;
+use Webkul\Attribute\Models\AttributeFamilyTranslation;
+use Webkul\Attribute\Models\AttributeGroup;
+use Webkul\Attribute\Models\AttributeGroupTranslation;
+use Webkul\Attribute\Models\AttributeOption;
+use Webkul\Attribute\Models\AttributeOptionTranslation;
+use Webkul\Attribute\Models\AttributeTranslation;
 use Webkul\Core\Providers\CoreModuleServiceProvider;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\Attribute\Models\Attribute::class,
-        \Webkul\Attribute\Models\AttributeFamily::class,
-        \Webkul\Attribute\Models\AttributeGroup::class,
-        \Webkul\Attribute\Models\AttributeOption::class,
-        \Webkul\Attribute\Models\AttributeOptionTranslation::class,
-        \Webkul\Attribute\Models\AttributeTranslation::class,
-        \Webkul\Attribute\Models\AttributeGroupTranslation::class,
-        \Webkul\Attribute\Models\AttributeFamilyTranslation::class,
-        \Webkul\Attribute\Models\AttributeFamilyGroupMapping::class,
+        Attribute::class,
+        AttributeFamily::class,
+        AttributeGroup::class,
+        AttributeOption::class,
+        AttributeOptionTranslation::class,
+        AttributeTranslation::class,
+        AttributeGroupTranslation::class,
+        AttributeFamilyTranslation::class,
+        AttributeFamilyGroupMapping::class,
     ];
 }

--- a/packages/Webkul/Attribute/src/Repositories/AttributeFamilyRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeFamilyRepository.php
@@ -3,7 +3,9 @@
 namespace Webkul\Attribute\Repositories;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Event;
+use Webkul\Attribute\Contracts\AttributeFamily;
 use Webkul\Core\Eloquent\Repository;
 
 class AttributeFamilyRepository extends Repository
@@ -31,7 +33,7 @@ class AttributeFamilyRepository extends Repository
     }
 
     /**
-     * @return \Webkul\Attribute\Contracts\AttributeFamily
+     * @return AttributeFamily
      */
     public function create(array $data)
     {
@@ -72,7 +74,7 @@ class AttributeFamilyRepository extends Repository
     /**
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Attribute\Contracts\AttributeFamily
+     * @return AttributeFamily
      */
     public function update(array $data, $id, $attribute = 'id')
     {
@@ -219,7 +221,7 @@ class AttributeFamilyRepository extends Repository
      * This function returns a query builder instance for the family model.
      * It eager loads the 'translations' relationship for the family.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function queryBuilder()
     {

--- a/packages/Webkul/Attribute/src/Repositories/AttributeGroupRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeGroupRepository.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Attribute\Repositories;
 
+use Illuminate\Database\Eloquent\Builder;
 use Webkul\Core\Eloquent\Repository;
 
 class AttributeGroupRepository extends Repository
@@ -18,7 +19,7 @@ class AttributeGroupRepository extends Repository
      * This function returns a query builder instance for the AttributeGroup model.
      * It eager loads the 'translations' relationship for the attribute groups.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function queryBuilder()
     {

--- a/packages/Webkul/Attribute/src/Repositories/AttributeOptionRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeOptionRepository.php
@@ -5,6 +5,7 @@ namespace Webkul\Attribute\Repositories;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Webkul\Attribute\Contracts\AttributeOption;
 use Webkul\Core\Eloquent\Repository;
 
 class AttributeOptionRepository extends Repository
@@ -18,7 +19,7 @@ class AttributeOptionRepository extends Repository
     }
 
     /**
-     * @return \Webkul\Attribute\Contracts\AttributeOption
+     * @return AttributeOption
      */
     public function create(array $data)
     {
@@ -40,7 +41,7 @@ class AttributeOptionRepository extends Repository
     /**
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Attribute\Contracts\AttributeOption
+     * @return AttributeOption
      */
     public function update(array $data, $id)
     {

--- a/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
@@ -3,6 +3,8 @@
 namespace Webkul\Attribute\Repositories;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Webkul\Attribute\Contracts\Attribute;
 use Webkul\Attribute\Models\AttributeFamily;
@@ -35,7 +37,7 @@ class AttributeRepository extends Repository
     /**
      * Create attribute.
      *
-     * @return \Webkul\Attribute\Contracts\Attribute
+     * @return Attribute
      */
     public function create(array $data)
     {
@@ -63,7 +65,7 @@ class AttributeRepository extends Repository
      *
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Attribute\Contracts\Attribute
+     * @return Attribute
      */
     public function update(array $data, $id, $attribute = 'id')
     {
@@ -115,7 +117,7 @@ class AttributeRepository extends Repository
      * Get product default attributes.
      *
      * @param  array  $codes
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return Collection
      */
     public function getProductDefaultAttributes($codes = null)
     {
@@ -155,7 +157,7 @@ class AttributeRepository extends Repository
      * Get family attributes.
      *
      * @param  \Webkul\Attribute\Contracts\AttributeFamily  $attributeFamily
-     * @return \Webkul\Attribute\Contracts\Attribute
+     * @return Attribute
      */
     public function getFamilyAttributes($attributeFamily)
     {
@@ -214,7 +216,7 @@ class AttributeRepository extends Repository
      * This function returns a query builder instance for the Attribute model.
      * It eager loads the 'translations' relationship for the Attribute.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function queryBuilder()
     {

--- a/packages/Webkul/Category/src/Database/Eloquent/Builder.php
+++ b/packages/Webkul/Category/src/Database/Eloquent/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Category\Database\Eloquent;
 
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Kalnoy\Nestedset\QueryBuilder as BaseBuilder;
 
@@ -17,7 +18,7 @@ class Builder extends BaseBuilder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @return LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */

--- a/packages/Webkul/Category/src/Models/Category.php
+++ b/packages/Webkul/Category/src/Models/Category.php
@@ -89,7 +89,7 @@ class Category extends Model implements CategoryContract, HistoryContract, Prese
      * Overrides the default Eloquent query builder.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Webkul\Category\Database\Eloquent\Builder
+     * @return Builder
      */
     public function newEloquentBuilder($query)
     {

--- a/packages/Webkul/Category/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Category/src/Providers/ModuleServiceProvider.php
@@ -2,16 +2,21 @@
 
 namespace Webkul\Category\Providers;
 
+use Webkul\Category\Models\Category;
+use Webkul\Category\Models\CategoryField;
+use Webkul\Category\Models\CategoryFieldOption;
+use Webkul\Category\Models\CategoryFieldOptionTranslation;
+use Webkul\Category\Models\CategoryFieldTranslation;
 use Webkul\Core\Providers\CoreModuleServiceProvider;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\Category\Models\Category::class,
-        \Webkul\Category\Models\CategoryField::class,
-        \Webkul\Category\Models\CategoryFieldOption::class,
-        \Webkul\Category\Models\CategoryFieldOptionTranslation::class,
-        \Webkul\Category\Models\CategoryFieldTranslation::class,
+        Category::class,
+        CategoryField::class,
+        CategoryFieldOption::class,
+        CategoryFieldOptionTranslation::class,
+        CategoryFieldTranslation::class,
 
     ];
 }

--- a/packages/Webkul/Category/src/Repositories/CategoryRepository.php
+++ b/packages/Webkul/Category/src/Repositories/CategoryRepository.php
@@ -4,6 +4,7 @@ namespace Webkul\Category\Repositories;
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
 use Webkul\Category\Contracts\Category;
 use Webkul\Core\Eloquent\Repository;
 use Webkul\Core\Filesystem\FileStorer;
@@ -58,7 +59,7 @@ class CategoryRepository extends Repository
     /**
      * Create category.
      *
-     * @return \Webkul\Category\Contracts\Category
+     * @return Category
      */
     public function create(array $data, bool $withoutFormattingValues = false)
     {
@@ -85,7 +86,7 @@ class CategoryRepository extends Repository
      *
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Category\Contracts\Category
+     * @return Category
      */
     public function update(array $data, $id, $attribute = 'id', bool $withoutFormattingValues = false)
     {
@@ -109,7 +110,7 @@ class CategoryRepository extends Repository
      * Specify category tree.
      *
      * @param  int  $id
-     * @return \Webkul\Category\Contracts\Category
+     * @return Category
      */
     public function getCategoryTree($id = null)
     {
@@ -122,7 +123,7 @@ class CategoryRepository extends Repository
      * Specify category tree.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getCategoryTreeWithoutDescendant($id = null)
     {
@@ -174,7 +175,7 @@ class CategoryRepository extends Repository
     /**
      * Get root categories.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getRootCategories()
     {
@@ -186,7 +187,7 @@ class CategoryRepository extends Repository
     /**
      * Get child categories.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getChildCategories(int $parentId, int $categoryId = 0)
     {
@@ -203,7 +204,7 @@ class CategoryRepository extends Repository
      * get visible category tree.
      *
      * @param  int  $id
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getVisibleCategoryTree($id = null)
     {

--- a/packages/Webkul/Category/src/Validator/Catalog/CategoryValidator.php
+++ b/packages/Webkul/Category/src/Validator/Catalog/CategoryValidator.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Category\Validator\Catalog;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Webkul\Category\Repositories\CategoryFieldRepository;
 use Webkul\Category\Repositories\CategoryRepository;
@@ -177,7 +178,7 @@ class CategoryValidator extends FieldValidator
      * If no requested fields are provided, it fetches all active category fields.
      *
      * @param  array  $requestedFields  An optional array containing the codes of requested category fields.
-     * @return \Illuminate\Support\Collection A collection of category fields.
+     * @return Collection A collection of category fields.
      */
     protected function getCategoryFields($requestedFields = [])
     {

--- a/packages/Webkul/Completeness/src/DataGrids/AttributeCompletenessDataGrid.php
+++ b/packages/Webkul/Completeness/src/DataGrids/AttributeCompletenessDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Completeness\DataGrids;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -19,7 +20,7 @@ class AttributeCompletenessDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Completeness/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Completeness/src/Providers/ModuleServiceProvider.php
@@ -2,11 +2,12 @@
 
 namespace Webkul\Completeness\Providers;
 
+use Webkul\Completeness\Models\CompletenessSetting;
 use Webkul\Core\Providers\CoreModuleServiceProvider;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\Completeness\Models\CompletenessSetting::class,
+        CompletenessSetting::class,
     ];
 }

--- a/packages/Webkul/Core/src/Config/concord.php
+++ b/packages/Webkul/Core/src/Config/concord.php
@@ -1,8 +1,11 @@
 <?php
 
+use Webkul\Admin\Providers\ModuleServiceProvider;
+use Webkul\Core\CoreConvention;
+
 return [
 
-    'convention' => Webkul\Core\CoreConvention::class,
+    'convention' => CoreConvention::class,
 
     'modules' => [
 
@@ -11,14 +14,14 @@ return [
          * VendorA\ModuleX\Providers\ModuleServiceProvider::class,
          * VendorB\ModuleY\Providers\ModuleServiceProvider::class
          */
-        \Webkul\Admin\Providers\ModuleServiceProvider::class,
-        \Webkul\Attribute\Providers\ModuleServiceProvider::class,
-        \Webkul\Category\Providers\ModuleServiceProvider::class,
-        \Webkul\Core\Providers\ModuleServiceProvider::class,
-        \Webkul\DataTransfer\Providers\ModuleServiceProvider::class,
-        \Webkul\Notification\Providers\ModuleServiceProvider::class,
-        \Webkul\Product\Providers\ModuleServiceProvider::class,
-        \Webkul\User\Providers\ModuleServiceProvider::class,
-        \Webkul\AdminApi\Providers\ModuleServiceProvider::class,
+        ModuleServiceProvider::class,
+        Webkul\Attribute\Providers\ModuleServiceProvider::class,
+        Webkul\Category\Providers\ModuleServiceProvider::class,
+        Webkul\Core\Providers\ModuleServiceProvider::class,
+        Webkul\DataTransfer\Providers\ModuleServiceProvider::class,
+        Webkul\Notification\Providers\ModuleServiceProvider::class,
+        Webkul\Product\Providers\ModuleServiceProvider::class,
+        Webkul\User\Providers\ModuleServiceProvider::class,
+        Webkul\AdminApi\Providers\ModuleServiceProvider::class,
     ],
 ];

--- a/packages/Webkul/Core/src/Config/repository.php
+++ b/packages/Webkul/Core/src/Config/repository.php
@@ -1,5 +1,7 @@
 <?php
 
+use League\Fractal\Serializer\DataArraySerializer;
+
 /*
 |--------------------------------------------------------------------------
 | Prettus Repository Config
@@ -35,7 +37,7 @@ return [
         'params'     => [
             'include' => 'include',
         ],
-        'serializer' => League\Fractal\Serializer\DataArraySerializer::class,
+        'serializer' => DataArraySerializer::class,
     ],
 
     /*

--- a/packages/Webkul/Core/src/Config/visitor.php
+++ b/packages/Webkul/Core/src/Config/visitor.php
@@ -1,5 +1,8 @@
 <?php
 
+use Shetabit\Visitor\Drivers\JenssegersAgent;
+use Shetabit\Visitor\Drivers\UAParser;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -31,7 +34,7 @@ return [
     |
     */
     'drivers' => [
-        'jenssegers' => \Shetabit\Visitor\Drivers\JenssegersAgent::class,
-        'UAParser'   => \Shetabit\Visitor\Drivers\UAParser::class,
+        'jenssegers' => JenssegersAgent::class,
+        'UAParser'   => UAParser::class,
     ],
 ];

--- a/packages/Webkul/Core/src/Console/Commands/UnoPimPublish.php
+++ b/packages/Webkul/Core/src/Console/Commands/UnoPimPublish.php
@@ -3,6 +3,8 @@
 namespace Webkul\Core\Console\Commands;
 
 use Illuminate\Console\Command;
+use Webkul\Core\Providers\CoreServiceProvider;
+use Webkul\Product\Providers\ProductServiceProvider;
 
 class UnoPimPublish extends Command
 {
@@ -31,11 +33,11 @@ class UnoPimPublish extends Command
          */
         [
             'name'     => 'Core',
-            'provider' => \Webkul\Core\Providers\CoreServiceProvider::class,
+            'provider' => CoreServiceProvider::class,
         ],
         [
             'name'     => 'Product',
-            'provider' => \Webkul\Product\Providers\ProductServiceProvider::class,
+            'provider' => ProductServiceProvider::class,
         ],
     ];
 

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -3,15 +3,18 @@
 namespace Webkul\Core;
 
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Intl\Currencies;
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Webkul\Core\Models\Channel;
+use Webkul\Core\Models\Currency;
 use Webkul\Core\Repositories\ChannelRepository;
 use Webkul\Core\Repositories\CoreConfigRepository;
 use Webkul\Core\Repositories\CurrencyRepository;
 use Webkul\Core\Repositories\LocaleRepository;
+use Webkul\Customer\Models\CustomerGroup;
 
 class Core
 {
@@ -25,42 +28,42 @@ class Core
     /**
      * Current Channel.
      *
-     * @var \Webkul\Core\Models\Channel
+     * @var Channel
      */
     protected $currentChannel;
 
     /**
      * Default Channel.
      *
-     * @var \Webkul\Core\Models\Channel
+     * @var Channel
      */
     protected $defaultChannel;
 
     /**
      * Currency.
      *
-     * @var \Webkul\Core\Models\Currency
+     * @var Currency
      */
     protected $currentCurrency;
 
     /**
      * Base Currency.
      *
-     * @var \Webkul\Core\Models\Currency
+     * @var Currency
      */
     protected $baseCurrency;
 
     /**
      * Current Locale.
      *
-     * @var \Webkul\Core\Models\Locale
+     * @var Models\Locale
      */
     protected $currentLocale;
 
     /**
      * Guest Customer Group
      *
-     * @var \Webkul\Customer\Models\CustomerGroup
+     * @var CustomerGroup
      */
     protected $guestCustomerGroup;
 
@@ -119,7 +122,7 @@ class Core
     /**
      * Returns all channels.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAllChannels()
     {
@@ -137,7 +140,7 @@ class Core
     /**
      * Returns current channel models.
      *
-     * @return \Webkul\Core\Contracts\Channel
+     * @return Contracts\Channel
      */
     public function getCurrentChannel()
     {
@@ -147,7 +150,7 @@ class Core
     /**
      * Returns default channel models.
      *
-     * @return \Webkul\Core\Contracts\Channel
+     * @return Contracts\Channel
      */
     public function getDefaultChannel(): ?Channel
     {
@@ -191,7 +194,7 @@ class Core
     /**
      * Get channel code from request.
      *
-     * @return \Webkul\Core\Contracts\Channel
+     * @return Contracts\Channel
      */
     public function getRequestedChannel()
     {
@@ -240,7 +243,7 @@ class Core
     /**
      * Return all locales.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAllLocales()
     {
@@ -250,7 +253,7 @@ class Core
     /**
      * Return all active locales.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAllActiveLocales()
     {
@@ -260,7 +263,7 @@ class Core
     /**
      * Returns current locale.
      *
-     * @return \Webkul\Core\Contracts\Locale
+     * @return Contracts\Locale
      */
     public function getCurrentLocale()
     {
@@ -334,7 +337,7 @@ class Core
     /**
      * Returns all currencies.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAllCurrencies()
     {
@@ -344,7 +347,7 @@ class Core
     /**
      * Return all active currencies.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAllActiveCurrencies()
     {
@@ -354,7 +357,7 @@ class Core
     /**
      * Returns base channel's currency model.
      *
-     * @return \Webkul\Core\Contracts\Currency
+     * @return Contracts\Currency
      */
     public function getBaseCurrency()
     {
@@ -443,12 +446,12 @@ class Core
     /**
      * Return currency symbol from currency code.
      *
-     * @param  string|\Webkul\Core\Contracts\Currency  $currency
+     * @param  string|Contracts\Currency  $currency
      * @return string
      */
     public function currencySymbol($currency)
     {
-        $code = $currency instanceof \Webkul\Core\Contracts\Currency ? $currency->code : $currency;
+        $code = $currency instanceof Contracts\Currency ? $currency->code : $currency;
 
         $formatter = new \NumberFormatter(app()->getLocale().'@currency='.$code, \NumberFormatter::CURRENCY);
 
@@ -525,7 +528,7 @@ class Core
     /**
      * Get channel timestamp, timestamp will be builded with channel timezone settings.
      *
-     * @param  \Webkul\Core\Contracts\Channel  $channel
+     * @param  Contracts\Channel  $channel
      * @return int
      */
     public function channelTimeStamp($channel)
@@ -628,7 +631,7 @@ class Core
     /**
      * Retrieve all countries.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function countries()
     {

--- a/packages/Webkul/Core/src/Helpers/Database/DatabaseSequenceHelper.php
+++ b/packages/Webkul/Core/src/Helpers/Database/DatabaseSequenceHelper.php
@@ -29,7 +29,7 @@ class DatabaseSequenceHelper
             return;
         }
 
-        $tablePrefix ??= Db::getTablePrefix();
+        $tablePrefix ??= DB::getTablePrefix();
 
         $tableName = $tablePrefix.$table;
 

--- a/packages/Webkul/Core/src/Http/Middleware/CheckForMaintenanceMode.php
+++ b/packages/Webkul/Core/src/Http/Middleware/CheckForMaintenanceMode.php
@@ -5,6 +5,7 @@ namespace Webkul\Core\Http\Middleware;
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as BaseCheckForMaintenanceMode;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Webkul\Installer\Helpers\DatabaseManager;
@@ -14,7 +15,7 @@ class CheckForMaintenanceMode extends BaseCheckForMaintenanceMode
     /**
      * The application implementation.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var Application
      */
     protected $app;
 
@@ -61,10 +62,10 @@ class CheckForMaintenanceMode extends BaseCheckForMaintenanceMode
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return mixed
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     * @throws HttpException
      */
     public function handle($request, Closure $next)
     {
@@ -105,7 +106,7 @@ class CheckForMaintenanceMode extends BaseCheckForMaintenanceMode
     /**
      * Check for the except routes.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return bool
      */
     protected function shouldPassThrough($request)

--- a/packages/Webkul/Core/src/Http/Middleware/SecureHeaders.php
+++ b/packages/Webkul/Core/src/Http/Middleware/SecureHeaders.php
@@ -3,6 +3,8 @@
 namespace Webkul\Core\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 class SecureHeaders
 {
@@ -19,7 +21,7 @@ class SecureHeaders
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return mixed
      */
     public function handle($request, Closure $next)
@@ -36,7 +38,7 @@ class SecureHeaders
     /**
      * Set headers.
      *
-     * @param  \Illuminate\Http\Response  $response
+     * @param  Response  $response
      * @return void
      */
     private function setHeaders($response)

--- a/packages/Webkul/Core/src/Http/helpers.php
+++ b/packages/Webkul/Core/src/Http/helpers.php
@@ -1,10 +1,12 @@
 <?php
 
+use Webkul\Core\Core;
+
 if (! function_exists('core')) {
     /**
      * Core helper.
      *
-     * @return \Webkul\Core\Core
+     * @return Core
      */
     function core()
     {

--- a/packages/Webkul/Core/src/ImageCache/ImageManager.php
+++ b/packages/Webkul/Core/src/ImageCache/ImageManager.php
@@ -5,6 +5,7 @@ namespace Webkul\Core\ImageCache;
 use Intervention\Image\AbstractDriver;
 use Intervention\Image\Exception\NotReadableException;
 use Intervention\Image\Exception\NotSupportedException;
+use Intervention\Image\Image;
 use Intervention\Image\ImageManager as BaseImageManager;
 
 class ImageManager extends BaseImageManager
@@ -13,7 +14,7 @@ class ImageManager extends BaseImageManager
      * Initiates an Image instance from different input types
      *
      * @param  mixed  $data
-     * @return \Intervention\Image\Image
+     * @return Image
      */
     public function make($data)
     {
@@ -31,7 +32,7 @@ class ImageManager extends BaseImageManager
      *
      * @param  mixed  $driver
      * @param  string  $url
-     * @return \Intervention\Image\Image
+     * @return Image
      */
     public function initFromUrl($driver, $url)
     {
@@ -61,7 +62,7 @@ class ImageManager extends BaseImageManager
     /**
      * Creates a driver instance according to config settings
      *
-     * @return \Intervention\Image\AbstractDriver
+     * @return AbstractDriver
      */
     private function createDriver()
     {

--- a/packages/Webkul/Core/src/Jobs/UpdateCreateVisitIndex.php
+++ b/packages/Webkul/Core/src/Jobs/UpdateCreateVisitIndex.php
@@ -4,6 +4,7 @@ namespace Webkul\Core\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -17,7 +18,7 @@ class UpdateCreateVisitIndex implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @param  array  $log
      * @return void
      */

--- a/packages/Webkul/Core/src/Listeners/ResponseCacheHit.php
+++ b/packages/Webkul/Core/src/Listeners/ResponseCacheHit.php
@@ -8,7 +8,7 @@ use Webkul\Core\Jobs\UpdateCreateVisitableIndex;
 class ResponseCacheHit
 {
     /**
-     * @param  \Spatie\ResponseCache\Events\ResponseCacheHit  $request
+     * @param  ResponseCacheHitEvent  $request
      * @return void
      */
     public function handle(ResponseCacheHitEvent $event)

--- a/packages/Webkul/Core/src/Providers/CoreServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/CoreServiceProvider.php
@@ -8,6 +8,10 @@ use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Webkul\Core\Console\Commands\DownCommand;
+use Webkul\Core\Console\Commands\UnoPimPublish;
+use Webkul\Core\Console\Commands\UnoPimVersion;
+use Webkul\Core\Console\Commands\UpCommand;
 use Webkul\Core\Core;
 use Webkul\Core\ElasticSearch;
 use Webkul\Core\Exceptions\Handler;
@@ -54,11 +58,11 @@ class CoreServiceProvider extends ServiceProvider
         });
 
         $this->app->extend('command.down', function () {
-            return new \Webkul\Core\Console\Commands\DownCommand;
+            return new DownCommand;
         });
 
         $this->app->extend('command.up', function () {
-            return new \Webkul\Core\Console\Commands\UpCommand;
+            return new UpCommand;
         });
 
         /**
@@ -125,8 +129,8 @@ class CoreServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                \Webkul\Core\Console\Commands\UnoPimPublish::class,
-                \Webkul\Core\Console\Commands\UnoPimVersion::class,
+                UnoPimPublish::class,
+                UnoPimVersion::class,
             ]);
         }
     }

--- a/packages/Webkul/Core/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/ModuleServiceProvider.php
@@ -2,12 +2,17 @@
 
 namespace Webkul\Core\Providers;
 
+use Webkul\Core\Models\Channel;
+use Webkul\Core\Models\CoreConfig;
+use Webkul\Core\Models\Currency;
+use Webkul\Core\Models\Locale;
+
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\Core\Models\Channel::class,
-        \Webkul\Core\Models\CoreConfig::class,
-        \Webkul\Core\Models\Currency::class,
-        \Webkul\Core\Models\Locale::class,
+        Channel::class,
+        CoreConfig::class,
+        Currency::class,
+        Locale::class,
     ];
 }

--- a/packages/Webkul/Core/src/Repositories/ChannelRepository.php
+++ b/packages/Webkul/Core/src/Repositories/ChannelRepository.php
@@ -2,8 +2,10 @@
 
 namespace Webkul\Core\Repositories;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Webkul\Core\Contracts\Channel;
 use Webkul\Core\Eloquent\Repository;
 
 class ChannelRepository extends Repository
@@ -19,7 +21,7 @@ class ChannelRepository extends Repository
     /**
      * Create.
      *
-     * @return \Webkul\Core\Contracts\Channel
+     * @return Channel
      */
     public function create(array $data)
     {
@@ -57,7 +59,7 @@ class ChannelRepository extends Repository
      *
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Core\Contracts\Channel
+     * @return Channel
      */
     public function update(array $data, $id, $attribute = 'id')
     {
@@ -87,7 +89,7 @@ class ChannelRepository extends Repository
     /**
      * This function returns a query builder instance for further manipulation of the channel model.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function queryBuilder()
     {

--- a/packages/Webkul/Core/src/Repositories/CoreConfigRepository.php
+++ b/packages/Webkul/Core/src/Repositories/CoreConfigRepository.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Webkul\Core\Contracts\CoreConfig;
 use Webkul\Core\Eloquent\Repository;
 use Webkul\Core\Traits\CoreConfigField;
 
@@ -24,7 +25,7 @@ class CoreConfigRepository extends Repository
     /**
      * Create.
      *
-     * @return \Webkul\Core\Contracts\CoreConfig
+     * @return CoreConfig
      */
     public function create(array $data)
     {

--- a/packages/Webkul/Core/src/Repositories/CurrencyRepository.php
+++ b/packages/Webkul/Core/src/Repositories/CurrencyRepository.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Core\Repositories;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Event;
 use Webkul\Core\Contracts\Currency;
 use Webkul\Core\Eloquent\Repository;
@@ -98,7 +99,7 @@ class CurrencyRepository extends Repository
     /**
      * This function returns a query builder instance for further manipulation of the currency model.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function queryBuilder()
     {

--- a/packages/Webkul/Core/src/Repositories/LocaleRepository.php
+++ b/packages/Webkul/Core/src/Repositories/LocaleRepository.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Core\Repositories;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Webkul\Core\Contracts\Locale;
@@ -87,7 +88,7 @@ class LocaleRepository extends Repository
     /**
      * This function returns a query builder instance for further manipulation of the Locale model.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function queryBuilder()
     {

--- a/packages/Webkul/Core/src/Traits/PDFHandler.php
+++ b/packages/Webkul/Core/src/Traits/PDFHandler.php
@@ -2,7 +2,9 @@
 
 namespace Webkul\Core\Traits;
 
+use ArPHP\I18N\Arabic;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 
 trait PDFHandler
@@ -10,7 +12,7 @@ trait PDFHandler
     /**
      * Download PDF.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     protected function downloadPDF(string $html, ?string $fileName = null)
     {
@@ -20,7 +22,7 @@ trait PDFHandler
 
         $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
 
-        return PDF::loadHTML($this->adjustArabicAndPersianContent($html))
+        return Pdf::loadHTML($this->adjustArabicAndPersianContent($html))
             ->setPaper('a4')
             ->download($fileName.'.pdf');
     }
@@ -32,7 +34,7 @@ trait PDFHandler
      */
     protected function adjustArabicAndPersianContent(string $html)
     {
-        $arabic = new \ArPHP\I18N\Arabic;
+        $arabic = new Arabic;
 
         $p = $arabic->arIdentify($html);
 

--- a/packages/Webkul/DataGrid/src/DataGrid.php
+++ b/packages/Webkul/DataGrid/src/DataGrid.php
@@ -2,11 +2,14 @@
 
 namespace Webkul\DataGrid;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Webkul\Admin\Exports\DataGridExport;
 use Webkul\DataGrid\Contracts\ExportableInterface;
 use Webkul\DataGrid\Enums\ColumnTypeEnum;
@@ -225,7 +228,7 @@ abstract class DataGrid
     /**
      * Process all requested filters.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function processRequestedFilters(array $requestedFilters)
     {
@@ -311,7 +314,7 @@ abstract class DataGrid
     /**
      * Process requested sorting.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function processRequestedSorting($requestedSort)
     {
@@ -372,7 +375,7 @@ abstract class DataGrid
     /**
      * Set export file.
      *
-     * @param  \Illuminate\Support\Collection  $records
+     * @param  Collection  $records
      * @param  string  $format
      * @return void
      */
@@ -384,7 +387,7 @@ abstract class DataGrid
     /**
      * Download export file.
      *
-     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     * @return BinaryFileResponse
      */
     public function downloadExportFile()
     {

--- a/packages/Webkul/DataTransfer/src/Helpers/Export.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Export.php
@@ -13,6 +13,7 @@ use Webkul\DataTransfer\Jobs\Export\File\FlatItemBuffer as FileExportFileBuffer;
 use Webkul\DataTransfer\Jobs\Export\File\SpoutWriterFactory;
 use Webkul\DataTransfer\Repositories\JobTrackBatchRepository;
 use Webkul\DataTransfer\Repositories\JobTrackRepository;
+use Webkul\DataTransfer\Services\JobLogger;
 
 class Export
 {
@@ -104,7 +105,7 @@ class Export
     /**
      * Error helper instance.
      *
-     * @var \Webkul\DataTransfer\Helpers\Error
+     * @var Error
      */
     protected $typeExporter;
 
@@ -177,7 +178,7 @@ class Export
     /**
      * Returns error helper instance.
      *
-     * @return \Webkul\DataTransfer\Helpers\Error
+     * @return Error
      */
     public function getErrorHelper()
     {
@@ -316,7 +317,7 @@ class Export
         $this->setExport($export);
 
         if (! $this->jobLogger) {
-            $this->setLogger(\Webkul\DataTransfer\Services\JobLogger::make($this->export->id));
+            $this->setLogger(JobLogger::make($this->export->id));
         }
 
         $this->jobLogger->info('Export resumed — re-dispatching pending batches.');

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/AbstractExporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/AbstractExporter.php
@@ -8,6 +8,8 @@ use Psr\Log\LoggerInterface;
 use Webkul\DataTransfer\Buffer\FileBuffer;
 use Webkul\DataTransfer\Contracts\JobTrack as ExportJobTrackContract;
 use Webkul\DataTransfer\Contracts\JobTrackBatch as JobTrackBatchContract;
+use Webkul\DataTransfer\Helpers\Error;
+use Webkul\DataTransfer\Helpers\Source;
 use Webkul\DataTransfer\Jobs\Export\Completed as CompletedJob;
 use Webkul\DataTransfer\Jobs\Export\ExportBatch as ExportBatchJob;
 use Webkul\DataTransfer\Jobs\Export\File\FlatItemBuffer as FileExportFileBuffer;
@@ -80,7 +82,7 @@ abstract class AbstractExporter
     /**
      * Error helper instance.
      *
-     * @var \Webkul\DataTransfer\Helpers\Error
+     * @var Error
      */
     protected $errorHelper;
 
@@ -92,7 +94,7 @@ abstract class AbstractExporter
     /**
      * Source instance.
      *
-     * @var \Webkul\DataTransfer\Helpers\Source
+     * @var Source
      */
     protected $source;
 
@@ -246,7 +248,7 @@ abstract class AbstractExporter
     /**
      * export instance.
      *
-     * @param  \Webkul\DataTransfer\Helpers\Source  $errorHelper
+     * @param  Source  $errorHelper
      */
     public function setSource($source)
     {
@@ -258,7 +260,7 @@ abstract class AbstractExporter
     /**
      * export instance.
      *
-     * @param  \Webkul\DataTransfer\Helpers\Error  $errorHelper
+     * @param  Error  $errorHelper
      */
     public function setErrorHelper($errorHelper): self
     {
@@ -272,7 +274,7 @@ abstract class AbstractExporter
     /**
      * export instance.
      *
-     * @return \Webkul\DataTransfer\Helpers\Source
+     * @return Source
      */
     public function getSource()
     {

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/Category/Exporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/Category/Exporter.php
@@ -11,6 +11,7 @@ use Webkul\DataTransfer\Helpers\Exporters\AbstractExporter;
 use Webkul\DataTransfer\Helpers\Formatters\EscapeFormulaOperators;
 use Webkul\DataTransfer\Jobs\Export\File\FlatItemBuffer as FileExportFileBuffer;
 use Webkul\DataTransfer\Repositories\JobTrackBatchRepository;
+use Webkul\Product\Models\ProductProxy;
 
 class Exporter extends AbstractExporter
 {
@@ -179,7 +180,7 @@ class Exporter extends AbstractExporter
      */
     protected function productCountsByCategory(string $code): int
     {
-        return \Webkul\Product\Models\ProductProxy::query()
+        return ProductProxy::query()
             ->whereJsonContains('values->categories', $code)
             ->count();
     }

--- a/packages/Webkul/DataTransfer/src/Helpers/Import.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Import.php
@@ -20,6 +20,7 @@ use Webkul\DataTransfer\Helpers\Sources\CSV as CSVSource;
 use Webkul\DataTransfer\Helpers\Sources\Excel as ExcelSource;
 use Webkul\DataTransfer\Repositories\JobTrackBatchRepository;
 use Webkul\DataTransfer\Repositories\JobTrackRepository;
+use Webkul\DataTransfer\Services\JobLogger;
 
 class Import
 {
@@ -116,7 +117,7 @@ class Import
     /**
      * Error helper instance.
      *
-     * @var \Webkul\DataTransfer\Helpers\Error
+     * @var Error
      */
     protected $typeImporter;
 
@@ -175,7 +176,7 @@ class Import
     /**
      * Returns error helper instance.
      *
-     * @return \Webkul\DataTransfer\Helpers\Error
+     * @return Error
      */
     public function getErrorHelper()
     {
@@ -453,7 +454,7 @@ class Import
         $this->setImport($import);
 
         if (! $this->jobLogger) {
-            $this->setLogger(\Webkul\DataTransfer\Services\JobLogger::make($this->import->id));
+            $this->setLogger(JobLogger::make($this->import->id));
         }
 
         $this->jobLogger->info('Import resumed — re-dispatching pending batches.');

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/AbstractImporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/AbstractImporter.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Facades\Event;
 use Psr\Log\LoggerInterface;
 use Webkul\DataTransfer\Contracts\JobTrack as ImportJobTrackContract;
 use Webkul\DataTransfer\Contracts\JobTrackBatch as ImportJobBatchContract;
+use Webkul\DataTransfer\Helpers\Error;
 use Webkul\DataTransfer\Helpers\Import;
+use Webkul\DataTransfer\Helpers\Source;
 use Webkul\DataTransfer\Jobs\Import\Completed as CompletedJob;
 use Webkul\DataTransfer\Jobs\Import\ImportBatch as ImportBatchJob;
 use Webkul\DataTransfer\Jobs\Import\IndexBatch as IndexBatchJob;
@@ -86,7 +88,7 @@ abstract class AbstractImporter
     /**
      * Error helper instance.
      *
-     * @var \Webkul\DataTransfer\Helpers\Error
+     * @var Error
      */
     protected $errorHelper;
 
@@ -98,7 +100,7 @@ abstract class AbstractImporter
     /**
      * Source instance.
      *
-     * @var \Webkul\DataTransfer\Helpers\Source
+     * @var Source
      */
     protected $source;
 
@@ -184,7 +186,7 @@ abstract class AbstractImporter
     /**
      * Import instance.
      *
-     * @param  \Webkul\DataTransfer\Helpers\Source  $errorHelper
+     * @param  Source  $errorHelper
      */
     public function setSource($source)
     {
@@ -196,7 +198,7 @@ abstract class AbstractImporter
     /**
      * Import instance.
      *
-     * @param  \Webkul\DataTransfer\Helpers\Error  $errorHelper
+     * @param  Error  $errorHelper
      */
     public function setErrorHelper($errorHelper): self
     {
@@ -228,7 +230,7 @@ abstract class AbstractImporter
     /**
      * Import instance.
      *
-     * @return \Webkul\DataTransfer\Helpers\Source
+     * @return Source
      */
     public function getSource()
     {

--- a/packages/Webkul/DataTransfer/src/Models/JobTrack.php
+++ b/packages/Webkul/DataTransfer/src/Models/JobTrack.php
@@ -3,6 +3,8 @@
 namespace Webkul\DataTransfer\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Webkul\DataTransfer\Contracts\JobTrack as JobTrackContract;
 
 class JobTrack extends Model implements JobTrackContract
@@ -60,7 +62,7 @@ class JobTrack extends Model implements JobTrackContract
     /**
      * Get the job that owns the job batch.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function batches()
     {
@@ -70,7 +72,7 @@ class JobTrack extends Model implements JobTrackContract
     /**
      * Get the job parent instance.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function jobInstance()
     {

--- a/packages/Webkul/DataTransfer/src/Models/JobTrackBatch.php
+++ b/packages/Webkul/DataTransfer/src/Models/JobTrackBatch.php
@@ -3,6 +3,7 @@
 namespace Webkul\DataTransfer\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Webkul\DataTransfer\Contracts\JobTrackBatch as JobTrackBatchContract;
 
 class JobTrackBatch extends Model implements JobTrackBatchContract
@@ -39,7 +40,7 @@ class JobTrackBatch extends Model implements JobTrackBatchContract
     /**
      * Get the jobTrack that owns the jobTrack batch.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function jobTrack()
     {

--- a/packages/Webkul/DataTransfer/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/DataTransfer/src/Providers/ModuleServiceProvider.php
@@ -3,12 +3,15 @@
 namespace Webkul\DataTransfer\Providers;
 
 use Webkul\Core\Providers\CoreModuleServiceProvider;
+use Webkul\DataTransfer\Models\JobInstances;
+use Webkul\DataTransfer\Models\JobTrack;
+use Webkul\DataTransfer\Models\JobTrackBatch;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\DataTransfer\Models\JobInstances::class,
-        \Webkul\DataTransfer\Models\JobTrackBatch::class,
-        \Webkul\DataTransfer\Models\JobTrack::class,
+        JobInstances::class,
+        JobTrackBatch::class,
+        JobTrack::class,
     ];
 }

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/CSVOptimizationTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/CSVOptimizationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Webkul\DataTransfer\Helpers\Sources\CSV;
 
@@ -77,7 +78,7 @@ describe('Date Formatting Optimization', function () {
         $fastResult = substr($date, 0, 10).'T'.substr($date, 11).'.000000Z';
 
         /** Carbon method – parse as UTC since the fast method assumes UTC (DB dates) */
-        $carbonResult = \Illuminate\Support\Carbon::parse($date, 'UTC')->toJson();
+        $carbonResult = Carbon::parse($date, 'UTC')->toJson();
 
         expect($fastResult)->toBe($carbonResult);
     });

--- a/packages/Webkul/DebugBar/src/DataCollector/ModuleCollector.php
+++ b/packages/Webkul/DebugBar/src/DataCollector/ModuleCollector.php
@@ -8,6 +8,7 @@ use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\DataCollector\PDO\PDOCollector;
 use DebugBar\DataCollector\Renderable;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Str;
 use Konekt\Concord\Facades\Concord;
 
@@ -60,7 +61,7 @@ class ModuleCollector extends DataCollector implements AssetProvider, DataCollec
     }
 
     /**
-     * @param  \Illuminate\Database\Events\QueryExecuted  $query
+     * @param  QueryExecuted  $query
      * @return string
      */
     public function addQueryBindings($query)

--- a/packages/Webkul/FPC/src/Listeners/Channel.php
+++ b/packages/Webkul/FPC/src/Listeners/Channel.php
@@ -3,13 +3,14 @@
 namespace Webkul\FPC\Listeners;
 
 use Spatie\ResponseCache\Facades\ResponseCache;
+use Webkul\Category\Contracts\Category;
 
 class Channel
 {
     /**
      * After category update
      *
-     * @param  \Webkul\Category\Contracts\Category  $category
+     * @param  Category  $category
      * @return void
      */
     public function afterUpdate($category)

--- a/packages/Webkul/HistoryControl/src/DataGrids/HistoryDataGrid.php
+++ b/packages/Webkul/HistoryControl/src/DataGrids/HistoryDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\HistoryControl\DataGrids;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -22,7 +23,7 @@ class HistoryDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/HistoryControl/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/HistoryControl/src/Providers/ModuleServiceProvider.php
@@ -3,10 +3,11 @@
 namespace Webkul\HistoryControl\Providers;
 
 use Webkul\Core\Providers\CoreModuleServiceProvider;
+use Webkul\HistoryControl\Models\History;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\HistoryControl\Models\History::class,
+        History::class,
     ];
 }

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Installer\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -42,7 +43,7 @@ class InstallerController extends Controller
     /**
      * Installer View Root Page
      *
-     * @return \Illuminate\Contracts\View\View
+     * @return View
      */
     public function index()
     {

--- a/packages/Webkul/Installer/src/Http/Middleware/Locale.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/Locale.php
@@ -3,13 +3,14 @@
 namespace Webkul\Installer\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 
 class Locale
 {
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return mixed
      */
     public function handle($request, Closure $next)

--- a/packages/Webkul/MagicAI/src/Database/Factories/MagicPromptFactory.php
+++ b/packages/Webkul/MagicAI/src/Database/Factories/MagicPromptFactory.php
@@ -3,6 +3,7 @@
 namespace Webkul\MagicAI\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Webkul\MagicAI\Models\MagicAISystemPrompt;
 use Webkul\MagicAI\Models\MagicPrompt;
 
 class MagicPromptFactory extends Factory
@@ -15,8 +16,8 @@ class MagicPromptFactory extends Factory
             'title'  => $this->faker->sentence,
             'prompt' => $this->faker->paragraph,
             'type'   => $this->faker->randomElement(['product', 'category']),
-            'tone'   => \Webkul\MagicAI\Models\MagicAISystemPrompt::inRandomOrder()->value('id')
-                     ?? \Webkul\MagicAI\Models\MagicAISystemPrompt::factory()->create()->id,
+            'tone'   => MagicAISystemPrompt::inRandomOrder()->value('id')
+                     ?? MagicAISystemPrompt::factory()->create()->id,
         ];
     }
 }

--- a/packages/Webkul/MagicAI/src/Http/helpers.php
+++ b/packages/Webkul/MagicAI/src/Http/helpers.php
@@ -1,10 +1,12 @@
 <?php
 
+use Webkul\MagicAI\MagicAI;
+
 if (! function_exists('magic_ai')) {
     /**
      * MagicAI helper.
      *
-     * @return \Webkul\MagicAI\MagicAI
+     * @return MagicAI
      */
     function magic_ai()
     {

--- a/packages/Webkul/MagicAI/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/MagicAI/src/Providers/ModuleServiceProvider.php
@@ -3,11 +3,13 @@
 namespace Webkul\MagicAI\Providers;
 
 use Konekt\Concord\BaseModuleServiceProvider;
+use Webkul\MagicAI\Models\MagicAISystemPrompt;
+use Webkul\MagicAI\Models\MagicPrompt;
 
 class ModuleServiceProvider extends BaseModuleServiceProvider
 {
     protected $models = [
-        \Webkul\MagicAI\Models\MagicPrompt::class,
-        \Webkul\MagicAI\Models\MagicAISystemPrompt::class,
+        MagicPrompt::class,
+        MagicAISystemPrompt::class,
     ];
 }

--- a/packages/Webkul/Notification/src/Events/CreateNotification.php
+++ b/packages/Webkul/Notification/src/Events/CreateNotification.php
@@ -15,7 +15,7 @@ class CreateNotification implements ShouldBroadcast
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return \Illuminate\Broadcasting\Channel|array
+     * @return Channel|array
      */
     public function broadcastOn()
     {

--- a/packages/Webkul/Notification/src/Providers/EventServiceProvider.php
+++ b/packages/Webkul/Notification/src/Providers/EventServiceProvider.php
@@ -3,12 +3,14 @@
 namespace Webkul\Notification\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Webkul\Notification\Events\NotificationEvent;
+use Webkul\Notification\Listeners\NotificationListener;
 
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
-        \Webkul\Notification\Events\NotificationEvent::class => [
-            \Webkul\Notification\Listeners\NotificationListener::class,
+        NotificationEvent::class => [
+            NotificationListener::class,
         ],
 
         'data_transfer.export.completed' => [

--- a/packages/Webkul/Notification/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Notification/src/Providers/ModuleServiceProvider.php
@@ -3,10 +3,11 @@
 namespace Webkul\Notification\Providers;
 
 use Webkul\Core\Providers\CoreModuleServiceProvider;
+use Webkul\Notification\Models\Notification;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\Notification\Models\Notification::class,
+        Notification::class,
     ];
 }

--- a/packages/Webkul/Product/src/Database/Eloquent/Builder.php
+++ b/packages/Webkul/Product/src/Database/Eloquent/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Database\Eloquent;
 
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder as BaseBuilder;
 use Illuminate\Pagination\Paginator;
 
@@ -17,7 +18,7 @@ class Builder extends BaseBuilder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @return LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */

--- a/packages/Webkul/Product/src/Factories/ElasticSearch/Cursor/ResultCursorFactory.php
+++ b/packages/Webkul/Product/src/Factories/ElasticSearch/Cursor/ResultCursorFactory.php
@@ -32,11 +32,11 @@ class ResultCursorFactory implements CursorFactoryContract
         ];
 
         try {
-            $results = Elasticsearch::search($requestParam);
+            $results = ElasticSearch::search($requestParam);
         } catch (\Exception $e) {
             if (str_contains($e->getMessage(), 'attribute_family_id')) {
                 try {
-                    $results = Elasticsearch::search($requestParam);
+                    $results = ElasticSearch::search($requestParam);
                 } catch (\Exception $retryException) {
                     throw $retryException;
                 }

--- a/packages/Webkul/Product/src/Helpers/ConfigurableOption.php
+++ b/packages/Webkul/Product/src/Helpers/ConfigurableOption.php
@@ -2,6 +2,9 @@
 
 namespace Webkul\Product\Helpers;
 
+use Illuminate\Support\Collection;
+use Webkul\Attribute\Contracts\Attribute;
+use Webkul\Product\Contracts\Product;
 use Webkul\Product\Facades\ProductImage;
 use Webkul\Product\Facades\ProductVideo;
 
@@ -24,7 +27,7 @@ class ConfigurableOption
     /**
      * Returns the allowed variants.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     public function getAllowedVariants($product)
@@ -77,8 +80,8 @@ class ConfigurableOption
     /**
      * Get allowed attributes.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
-     * @return \Illuminate\Support\Collection
+     * @param  Product  $product
+     * @return Collection
      */
     public function getAllowAttributes($product)
     {
@@ -94,7 +97,7 @@ class ConfigurableOption
     /**
      * Get configurable product options.
      *
-     * @param  \Webkul\Product\Contracts\Product  $currentProduct
+     * @param  Product  $currentProduct
      * @param  array  $allowedProducts
      * @return array
      */
@@ -122,7 +125,7 @@ class ConfigurableOption
     /**
      * Get product attributes.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     public function getAttributesData($product, array $options = [])
@@ -147,7 +150,7 @@ class ConfigurableOption
     /**
      * Get attribute options data.
      *
-     * @param  \Webkul\Attribute\Contracts\Attribute  $attribute
+     * @param  Attribute  $attribute
      * @param  array  $options
      * @return array
      */
@@ -176,7 +179,7 @@ class ConfigurableOption
     /**
      * Get product prices for configurable variations.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     protected function getVariantPrices($product)
@@ -193,7 +196,7 @@ class ConfigurableOption
     /**
      * Get product images for configurable variations.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     protected function getVariantImages($product)
@@ -210,7 +213,7 @@ class ConfigurableOption
     /**
      * Get product videos for configurable variations.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     protected function getVariantVideos($product)

--- a/packages/Webkul/Product/src/Helpers/View.php
+++ b/packages/Webkul/Product/src/Helpers/View.php
@@ -3,13 +3,14 @@
 namespace Webkul\Product\Helpers;
 
 use Webkul\Attribute\Repositories\AttributeOptionRepository;
+use Webkul\Product\Contracts\Product;
 
 class View
 {
     /**
      * Returns the visible custom attributes
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return void|array
      */
     public function getAdditionalData($product)

--- a/packages/Webkul/Product/src/Models/Product.php
+++ b/packages/Webkul/Product/src/Models/Product.php
@@ -56,7 +56,7 @@ class Product extends Model implements HistoryAuditable, PresentableHistoryInter
     /**
      * The type of product.
      *
-     * @var \Webkul\Product\Type\AbstractType
+     * @var AbstractType
      */
     protected $typeInstance;
 
@@ -105,7 +105,7 @@ class Product extends Model implements HistoryAuditable, PresentableHistoryInter
      * Get type instance.
      *
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function getTypeInstance(): AbstractType
     {
@@ -171,7 +171,7 @@ class Product extends Model implements HistoryAuditable, PresentableHistoryInter
      * @param  Group  $group
      * @param  bool  $skipSuperAttribute
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function getEditableAttributes($group = null, $skipSuperAttribute = true): Collection
     {
@@ -290,7 +290,7 @@ class Product extends Model implements HistoryAuditable, PresentableHistoryInter
      * Overrides the default Eloquent query builder.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Webkul\Product\Database\Eloquent\Builder
+     * @return Builder
      */
     public function newEloquentBuilder($query)
     {

--- a/packages/Webkul/Product/src/Observers/ProductObserver.php
+++ b/packages/Webkul/Product/src/Observers/ProductObserver.php
@@ -3,13 +3,14 @@
 namespace Webkul\Product\Observers;
 
 use Illuminate\Support\Facades\Storage;
+use Webkul\Product\Contracts\Product;
 
 class ProductObserver
 {
     /**
      * Handle the Product "deleted" event.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return void
      */
     public function deleted($product)

--- a/packages/Webkul/Product/src/ProductImage.php
+++ b/packages/Webkul/Product/src/ProductImage.php
@@ -5,6 +5,7 @@ namespace Webkul\Product;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Webkul\Customer\Contracts\Wishlist;
+use Webkul\Product\Contracts\Product;
 use Webkul\Product\Repositories\ProductRepository;
 
 class ProductImage
@@ -19,7 +20,7 @@ class ProductImage
     /**
      * Retrieve collection of gallery images.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     public function getGalleryImages($product)
@@ -61,7 +62,7 @@ class ProductImage
     /**
      * Get product variant image if available otherwise product base image.
      *
-     * @param  \Webkul\Customer\Contracts\Wishlist  $item
+     * @param  Wishlist  $item
      * @return array
      */
     public function getProductImage($item)
@@ -83,7 +84,7 @@ class ProductImage
      * This method will first check whether the gallery images are already
      * present or not. If not then it will load from the product.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @param  array
      * @return array
      */
@@ -101,7 +102,7 @@ class ProductImage
     /**
      * Load product's base image.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     protected function otherwiseLoadFromProduct($product)

--- a/packages/Webkul/Product/src/ProductVideo.php
+++ b/packages/Webkul/Product/src/ProductVideo.php
@@ -3,13 +3,14 @@
 namespace Webkul\Product;
 
 use Illuminate\Support\Facades\Storage;
+use Webkul\Product\Contracts\Product;
 
 class ProductVideo
 {
     /**
      * Retrieve collection of videos
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
+     * @param  Product  $product
      * @return array
      */
     public function getVideos($product)

--- a/packages/Webkul/Product/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Product/src/Providers/ModuleServiceProvider.php
@@ -3,10 +3,11 @@
 namespace Webkul\Product\Providers;
 
 use Webkul\Core\Providers\CoreModuleServiceProvider;
+use Webkul\Product\Models\Product;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\Product\Models\Product::class,
+        Product::class,
     ];
 }

--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -4,6 +4,7 @@ namespace Webkul\Product\Repositories;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Core\Eloquent\Repository;
@@ -34,7 +35,7 @@ class ProductRepository extends Repository
     /**
      * Create product.
      *
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function create(array $data)
     {
@@ -50,7 +51,7 @@ class ProductRepository extends Repository
      *
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function update(array $data, $id, $attribute = 'id')
     {
@@ -99,7 +100,7 @@ class ProductRepository extends Repository
      * Copy product.
      *
      * @param  int  $id
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function copy($id)
     {
@@ -154,7 +155,7 @@ class ProductRepository extends Repository
      * Retrieve product from slug without throwing an exception.
      *
      * @param  string  $slug
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function findBySlug($slug)
     {
@@ -165,7 +166,7 @@ class ProductRepository extends Repository
      * Retrieve product from slug.
      *
      * @param  string  $slug
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function findBySlugOrFail($slug)
     {
@@ -187,7 +188,7 @@ class ProductRepository extends Repository
      * good request parameter with an array type as an argument. Make a clean pull request for
      * this to have track record.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAll()
     {
@@ -197,7 +198,7 @@ class ProductRepository extends Repository
     /**
      * Search product from database.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function searchFromDatabase()
     {
@@ -270,8 +271,8 @@ class ProductRepository extends Repository
     /**
      * Returns product's super attribute with options.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
-     * @return \Illuminate\Support\Collection
+     * @param  Product  $product
+     * @return Collection
      */
     public function getSuperAttributes($product)
     {

--- a/packages/Webkul/Product/src/Traits/ProductQueryFilter.php
+++ b/packages/Webkul/Product/src/Traits/ProductQueryFilter.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Traits;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 
 trait ProductQueryFilter
@@ -9,7 +10,7 @@ trait ProductQueryFilter
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {

--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -6,6 +6,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Webkul\Attribute\Contracts\Group;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Attribute\Rules\AttributeTypes;
 use Webkul\Core\Filesystem\FileStorer;
@@ -96,7 +97,7 @@ abstract class AbstractType
     /**
      * Create product.
      *
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function create(array $data)
     {
@@ -114,7 +115,7 @@ abstract class AbstractType
      *
      * @param  int  $id
      * @param  string  $attribute
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      */
     public function update(array $data, $id, $attribute = 'id')
     {
@@ -380,7 +381,7 @@ abstract class AbstractType
     /**
      * Copy product.
      *
-     * @return \Webkul\Product\Contracts\Product
+     * @return Product
      *
      * @throws \Exception
      */
@@ -444,8 +445,8 @@ abstract class AbstractType
     /**
      * Specify type instance product.
      *
-     * @param  \Webkul\Product\Contracts\Product  $product
-     * @return \Webkul\Product\Type\AbstractType
+     * @param  Product  $product
+     * @return AbstractType
      */
     public function setProduct($product)
     {
@@ -495,9 +496,9 @@ abstract class AbstractType
     /**
      * Retrieve product attributes.
      *
-     * @param  \Webkul\Attribute\Contracts\Group  $group
+     * @param  Group  $group
      * @param  bool  $skipSuperAttribute
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getEditableAttributes($group = null, $skipSuperAttribute = true)
     {

--- a/packages/Webkul/Product/src/Type/Configurable.php
+++ b/packages/Webkul/Product/src/Type/Configurable.php
@@ -5,6 +5,7 @@ namespace Webkul\Product\Type;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Webkul\Admin\Validations\ConfigurableUniqueSku;
+use Webkul\Product\Models\Product;
 
 class Configurable extends AbstractType
 {
@@ -49,7 +50,7 @@ class Configurable extends AbstractType
     /**
      * Get default variant.
      *
-     * @return \Webkul\Product\Models\Product
+     * @return Product
      */
     public function getDefaultVariant()
     {
@@ -235,7 +236,7 @@ class Configurable extends AbstractType
     /**
      * Copy relationships.
      *
-     * @param  \Webkul\Product\Models\Product  $product
+     * @param  Product  $product
      * @return void
      */
     protected function copyRelationships($product)

--- a/packages/Webkul/Product/src/Validator/Rule/AttributeValueRule.php
+++ b/packages/Webkul/Product/src/Validator/Rule/AttributeValueRule.php
@@ -5,6 +5,7 @@ namespace Webkul\Product\Validator\Rule;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Translation\PotentiallyTranslatedString;
 use Webkul\Attribute\Contracts\Attribute;
 
 class AttributeValueRule implements ValidationRule
@@ -22,7 +23,7 @@ class AttributeValueRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/packages/Webkul/Product/src/Validator/Rule/ChannelLocalesRule.php
+++ b/packages/Webkul/Product/src/Validator/Rule/ChannelLocalesRule.php
@@ -4,6 +4,7 @@ namespace Webkul\Product\Validator\Rule;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 use Webkul\Product\Type\AbstractType;
 
 class ChannelLocalesRule implements ValidationRule
@@ -16,7 +17,7 @@ class ChannelLocalesRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/packages/Webkul/Product/src/Validator/Rule/KeyExistsRule.php
+++ b/packages/Webkul/Product/src/Validator/Rule/KeyExistsRule.php
@@ -4,6 +4,7 @@ namespace Webkul\Product\Validator\Rule;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 class KeyExistsRule implements ValidationRule
 {
@@ -15,7 +16,7 @@ class KeyExistsRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/packages/Webkul/Theme/src/Exceptions/ThemeAlreadyExists.php
+++ b/packages/Webkul/Theme/src/Exceptions/ThemeAlreadyExists.php
@@ -2,12 +2,14 @@
 
 namespace Webkul\Theme\Exceptions;
 
+use Webkul\Theme\Theme;
+
 class ThemeAlreadyExists extends \Exception
 {
     /**
      * Create an instance.
      *
-     * @param  \Webkul\Theme\Theme  $theme
+     * @param  Theme  $theme
      * @return void
      */
     public function __construct($theme)

--- a/packages/Webkul/Theme/src/Http/helpers.php
+++ b/packages/Webkul/Theme/src/Http/helpers.php
@@ -1,12 +1,13 @@
 <?php
 
+use Webkul\Theme\Themes;
 use Webkul\Theme\ViewRenderEventManager;
 
 if (! function_exists('themes')) {
     /**
      * Themes.
      *
-     * @return \Webkul\Theme\Themes
+     * @return Themes
      */
     function themes()
     {

--- a/packages/Webkul/Theme/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Theme/src/Providers/ModuleServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Webkul\Theme\Providers;
 
 use Webkul\Core\Providers\CoreModuleServiceProvider;
+use Webkul\Theme\Models\ThemeCustomization;
+use Webkul\Theme\Models\ThemeCustomizationTranslation;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
@@ -12,7 +14,7 @@ class ModuleServiceProvider extends CoreModuleServiceProvider
      * @var array
      */
     protected $models = [
-        \Webkul\Theme\Models\ThemeCustomization::class,
-        \Webkul\Theme\Models\ThemeCustomizationTranslation::class,
+        ThemeCustomization::class,
+        ThemeCustomizationTranslation::class,
     ];
 }

--- a/packages/Webkul/Theme/src/Providers/ThemeServiceProvider.php
+++ b/packages/Webkul/Theme/src/Providers/ThemeServiceProvider.php
@@ -5,6 +5,7 @@ namespace Webkul\Theme\Providers;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Webkul\Theme\Themes;
+use Webkul\Theme\ThemeViewFinder;
 
 class ThemeServiceProvider extends ServiceProvider
 {
@@ -34,7 +35,7 @@ class ThemeServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('view.finder', function ($app) {
-            return new \Webkul\Theme\ThemeViewFinder(
+            return new ThemeViewFinder(
                 $app['files'],
                 $app['config']['view.paths'],
                 null

--- a/packages/Webkul/Theme/src/Theme.php
+++ b/packages/Webkul/Theme/src/Theme.php
@@ -9,7 +9,7 @@ class Theme
     /**
      * Contains theme parent.
      *
-     * @var \Webkul\Theme\Theme
+     * @var Theme
      */
     public $parent;
 
@@ -37,7 +37,7 @@ class Theme
     /**
      * Sets the parent.
      *
-     * @param  \Webkul\Theme\Theme
+     * @param  Theme
      * @return void
      */
     public function setParent(Theme $parent)
@@ -48,7 +48,7 @@ class Theme
     /**
      * Return the parent.
      *
-     * @return \Webkul\Theme\Theme
+     * @return Theme
      */
     public function getParent()
     {

--- a/packages/Webkul/Theme/src/Themes.php
+++ b/packages/Webkul/Theme/src/Themes.php
@@ -145,7 +145,7 @@ class Themes
     /**
      * Enable theme.
      *
-     * @return \Webkul\Theme\Theme
+     * @return Theme
      */
     public function set(string $themeName)
     {
@@ -177,7 +177,7 @@ class Themes
     /**
      * Get current theme.
      *
-     * @return \Webkul\Theme\Theme
+     * @return Theme
      */
     public function current()
     {
@@ -197,7 +197,7 @@ class Themes
     /**
      * Find a theme by it's name.
      *
-     * @return \Webkul\Theme\Theme
+     * @return Theme
      */
     public function find(string $themeName)
     {

--- a/packages/Webkul/User/src/Http/Middleware/Bouncer.php
+++ b/packages/Webkul/User/src/Http/Middleware/Bouncer.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\User\Http\Middleware;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 class Bouncer
@@ -9,7 +10,7 @@ class Bouncer
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @param  string|null  $guard
      * @return mixed
      */

--- a/packages/Webkul/User/src/Http/helpers.php
+++ b/packages/Webkul/User/src/Http/helpers.php
@@ -1,8 +1,10 @@
 <?php
 
+use Webkul\User\Bouncer;
+
 if (! function_exists('bouncer')) {
     function bouncer()
     {
-        return app()->make(\Webkul\User\Bouncer::class);
+        return app()->make(Bouncer::class);
     }
 }

--- a/packages/Webkul/User/src/Models/Admin.php
+++ b/packages/Webkul/User/src/Models/Admin.php
@@ -85,7 +85,7 @@ class Admin extends Authenticatable implements AdminContract, AuditableContract
     /**
      * Get the role that owns the admin.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function role()
     {
@@ -95,7 +95,7 @@ class Admin extends Authenticatable implements AdminContract, AuditableContract
     /**
      * Get the api integration that owns the admin.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function apiKey()
     {

--- a/packages/Webkul/User/src/Models/Role.php
+++ b/packages/Webkul/User/src/Models/Role.php
@@ -5,6 +5,7 @@ namespace Webkul\User\Models;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Webkul\HistoryControl\Contracts\HistoryAuditable as HistoryContract;
 use Webkul\HistoryControl\Traits\HistoryTrait;
 use Webkul\User\Contracts\Role as RoleContract;
@@ -51,7 +52,7 @@ class Role extends Model implements HistoryContract, RoleContract
     /**
      * Get the admins.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function admins()
     {

--- a/packages/Webkul/User/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/User/src/Providers/ModuleServiceProvider.php
@@ -3,11 +3,13 @@
 namespace Webkul\User\Providers;
 
 use Webkul\Core\Providers\CoreModuleServiceProvider;
+use Webkul\User\Models\Admin;
+use Webkul\User\Models\Role;
 
 class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
-        \Webkul\User\Models\Admin::class,
-        \Webkul\User\Models\Role::class,
+        Admin::class,
+        Role::class,
     ];
 }

--- a/packages/Webkul/Webhook/src/DataGrids/LogsDataGrid.php
+++ b/packages/Webkul/Webhook/src/DataGrids/LogsDataGrid.php
@@ -2,6 +2,8 @@
 
 namespace Webkul\Webhook\DataGrids;
 
+use Carbon\Carbon;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Webkul\DataGrid\DataGrid;
 
@@ -17,7 +19,7 @@ class LogsDataGrid extends DataGrid
     /**
      * Prepare query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return Builder
      */
     public function prepareQueryBuilder()
     {
@@ -59,7 +61,7 @@ class LogsDataGrid extends DataGrid
                 $timezone = auth('admin')->user()->timezone ?? config('app.timezone');
 
                 try {
-                    $display = \Carbon\Carbon::parse($row->created_at)->setTimezone($timezone)->toDateTimeString();
+                    $display = Carbon::parse($row->created_at)->setTimezone($timezone)->toDateTimeString();
                 } catch (\Exception $e) {
                     $display = $row->created_at;
                 }

--- a/packages/Webkul/Webhook/src/Http/Controllers/WebhookLogsController.php
+++ b/packages/Webkul/Webhook/src/Http/Controllers/WebhookLogsController.php
@@ -3,6 +3,7 @@
 namespace Webkul\Webhook\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
 use Webkul\Admin\Http\Requests\MassDestroyRequest;
 use Webkul\Webhook\DataGrids\LogsDataGrid;
 use Webkul\Webhook\Repositories\LogsRepository;
@@ -16,7 +17,7 @@ class WebhookLogsController
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {

--- a/packages/Webkul/Webhook/src/Http/Controllers/WebhookSettingsController.php
+++ b/packages/Webkul/Webhook/src/Http/Controllers/WebhookSettingsController.php
@@ -4,7 +4,9 @@ namespace Webkul\Webhook\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\View\View;
 use Webkul\Webhook\Models\WebhookSetting;
 use Webkul\Webhook\Repositories\SettingsRepository;
 
@@ -17,7 +19,7 @@ class WebhookSettingsController
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View
+     * @return View
      */
     public function index()
     {
@@ -27,7 +29,7 @@ class WebhookSettingsController
     /**
      * Store a newly created resource in storage.
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function store(Request $request)
     {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,13 @@
 <?php
 
+use Webkul\Admin\Tests\AdminTestCase;
+use Webkul\AdminApi\Tests\ApiTestCase;
+use Webkul\Completeness\Tests\CompletenessTestCase;
+use Webkul\Core\Tests\CoreTestCase;
+use Webkul\DataGrid\Tests\DataGridTestCase;
+use Webkul\Installer\Tests\UserCreateCommandTestCase;
+use Webkul\User\Tests\UserTestCase;
+
 ini_set('memory_limit', '1024M');
 
 /*
@@ -13,15 +21,15 @@ ini_set('memory_limit', '1024M');
 |
 */
 
-uses(Webkul\Core\Tests\CoreTestCase::class)->in('../packages/Webkul/Core/tests');
-uses(Webkul\Admin\Tests\AdminTestCase::class)->in('../packages/Webkul/Admin/tests');
-uses(Webkul\AdminApi\Tests\ApiTestCase::class)->in('../packages/Webkul/AdminApi/tests');
-uses(Webkul\User\Tests\UserTestCase::class)->in('../packages/Webkul/User/tests');
-uses(Webkul\DataGrid\Tests\DataGridTestCase::class)->in('../packages/Webkul/DataGrid/tests');
-uses(Webkul\Installer\Tests\UserCreateCommandTestCase::class)->in('../packages/Webkul/Installer/tests');
-uses(Webkul\Core\Tests\CoreTestCase::class)->in('../packages/Webkul/ElasticSearch/tests');
-uses(Webkul\Admin\Tests\AdminTestCase::class)->in('../packages/Webkul/DataTransfer/tests');
-uses(Webkul\Completeness\Tests\CompletenessTestCase::class)->in('../packages/Webkul/Completeness/tests');
+uses(CoreTestCase::class)->in('../packages/Webkul/Core/tests');
+uses(AdminTestCase::class)->in('../packages/Webkul/Admin/tests');
+uses(ApiTestCase::class)->in('../packages/Webkul/AdminApi/tests');
+uses(UserTestCase::class)->in('../packages/Webkul/User/tests');
+uses(DataGridTestCase::class)->in('../packages/Webkul/DataGrid/tests');
+uses(UserCreateCommandTestCase::class)->in('../packages/Webkul/Installer/tests');
+uses(CoreTestCase::class)->in('../packages/Webkul/ElasticSearch/tests');
+uses(AdminTestCase::class)->in('../packages/Webkul/DataTransfer/tests');
+uses(CompletenessTestCase::class)->in('../packages/Webkul/Completeness/tests');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
### **PR Description**

**Issue Reference**
Bumps all `require-dev` dependencies to their latest compatible versions and adds a new dev dependency `shipfastlabs/agent-detector`.

**Description**
The dev dependencies were outdated and needed to be updated to their latest compatible versions. Running `composer update` pulled in newer patch/minor versions across multiple packages. Additionally, `shipfastlabs/agent-detector` was introduced as a new dev dependency as part of this update.

All changes are scoped to `require-dev` and have no impact on the production environment.

**Changes**

Before
```json
"friendsofphp/php-cs-fixer": "^3.92.4",
"illuminate/view": "^12.44.0",
"larastan/larastan": "^3.8.1",
"laravel-zero/framework": "^12.0.4",
"mockery/mockery": "^1.6.12",
"nunomaduro/termwind": "^2.3.3",
"pestphp/pest": "^3.8.4"
```

After
```json
"friendsofphp/php-cs-fixer": "^3.94.2",
"illuminate/view": "^12.54.1",
"larastan/larastan": "^3.9.3",
"laravel-zero/framework": "^12.0.5",
"mockery/mockery": "^1.6.12",
"nunomaduro/termwind": "^2.4.0",
"pestphp/pest": "^3.8.6",
"shipfastlabs/agent-detector": "^1.1.0"
```

**Impact**
- No impact on production — all changes are in `require-dev` only.
- Keeps dev tooling (static analysis, testing, code style) up to date.
- `shipfastlabs/agent-detector` is now available for use in the dev environment.
