### PR TITLE
fix: fix playwright tests crashing on fork pull requests

### DIFF
--- a/.github/workflows/playwright_test.yml
+++ b/.github/workflows/playwright_test.yml
@@ -2,7 +2,6 @@ name: Playwright Tests
 
 on: [push, pull_request]
 
-
 permissions:
   contents: read
 
@@ -14,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-systems: [ubuntu-latest]
-        php-versions: ['8.2']
+        php-versions: ["8.2"]
 
     services:
       mysql:
@@ -31,13 +30,13 @@ jobs:
           --health-retries=5
 
     env:
-      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      GROQ_INVALID_KEY: ${{ secrets.GROQ_INVALID_KEY }}
-      UNOPIM_URL: ${{ secrets.UNOPIM_URL }}
-      ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
-      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
-      INVALID_ADMIN_EMAIL: ${{ secrets.INVALID_ADMIN_EMAIL }}
-      INVALID_ADMIN_PASSWORD: ${{ secrets.INVALID_ADMIN_PASSWORD }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY || 'dummy_api_key' }}
+      GROQ_INVALID_KEY: ${{ secrets.GROQ_INVALID_KEY || 'dummy_invalid_key' }}
+      UNOPIM_URL: ${{ secrets.UNOPIM_URL || 'http://127.0.0.1:8000' }}
+      ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME || 'admin@example.com' }}
+      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD || 'admin123' }}
+      INVALID_ADMIN_EMAIL: ${{ secrets.INVALID_ADMIN_EMAIL || 'invalid@example.com' }}
+      INVALID_ADMIN_PASSWORD: ${{ secrets.INVALID_ADMIN_PASSWORD || 'invalid123' }}
 
     steps:
       - name: Checkout
@@ -78,7 +77,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install Playwright dependencies
         run: |


### PR DESCRIPTION
## Description
This Pull Request fixes an issue where Playwright tests fail consistently on GitHub Actions whenever a Pull Request originates from a forked repository. 

**The Root Cause:**
By design, GitHub Actions [prevents repository secrets from being exposed](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow) to `pull_request` workflows originating from forks for security reasons. As a result, variables like `secrets.GROQ_API_KEY`, `secrets.ADMIN_USERNAME`, and `secrets.UNOPIM_URL` were evaluating to empty values. This caused `process.env.GROQ_API_KEY` to be `undefined`, throwing `page.fill(undefined)` exceptions in the Playwright test suite.

**The Fix:**
Added fallback dummy values (e.g., `|| 'dummy_api_key'`) to the environment variables injected into the workflow.
- If the workflow executes safely from the main repo (like during a `push`), it will continue to map and use the real repository secrets as normal. 
- During a PR from a fork, rather than triggering `undefined` test crashes, it seamlessly falls back to mapping dummy strings.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested these changes
- [x] My changes do not generate any new warnings/errors in the CI
