### PR TITLE
fix: updated the dropdown with standard unopim dropdown component

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/platform/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/platform/index.blade.php
@@ -127,17 +127,28 @@
                                 <x-admin::form.control-group.label class="required">
                                     @lang('admin::app.configuration.platform.fields.provider')
                                 </x-admin::form.control-group.label>
-                                <select
+                                @php
+                                    $providerOptions = collect(\Webkul\MagicAI\Enums\AiProvider::cases())
+                                        ->map(fn ($provider) => [
+                                            'id'    => $provider->value,
+                                            'label' => $provider->label(),
+                                        ])
+                                        ->values();
+                                @endphp
+
+                                <x-admin::form.control-group.control
+                                    type="select"
                                     name="provider"
-                                    v-model="form.provider"
-                                    @change="onProviderChange()"
-                                    class="w-full py-2.5 px-3 border rounded-md text-sm text-gray-600 dark:text-gray-300 transition-all hover:border-gray-400 dark:bg-cherry-800 dark:border-cherry-800 dark:hover:border-gray-400"
+                                    rules="required"
+                                    ::value="form.provider"
+                                    :label="trans('admin::app.configuration.platform.fields.provider')"
+                                    :placeholder="trans('admin::app.configuration.platform.fields.select-provider')"
+                                    :options="json_encode($providerOptions)"
+                                    track-by="id"
+                                    label-by="label"
+                                    @input="onProviderChange($event)"
                                 >
-                                    <option value="">@lang('admin::app.configuration.platform.fields.select-provider')</option>
-                                    @foreach(\Webkul\MagicAI\Enums\AiProvider::cases() as $provider)
-                                        <option value="{{ $provider->value }}">{{ $provider->label() }}</option>
-                                    @endforeach
-                                </select>
+                                </x-admin::form.control-group.control>
                                 <x-admin::form.control-group.error control-name="provider" />
                             </x-admin::form.control-group>
 
@@ -388,7 +399,17 @@
                         this.fetchError = '';
                     },
 
-                    onProviderChange() {
+                    onProviderChange(value = null) {
+                        if (value !== null) {
+                            try {
+                                let selectedProvider = typeof value === 'string' ? JSON.parse(value) : value;
+
+                                this.form.provider = selectedProvider?.id ?? selectedProvider ?? '';
+                            } catch (error) {
+                                this.form.provider = value ?? '';
+                            }
+                        }
+
                         if (!this.isEditing) {
                             this.form.label = this.providerLabels[this.form.provider] || this.form.provider;
                         }


### PR DESCRIPTION
**Title**

Use core admin select component for Magic AI platform provider field

**Description**

This PR replaces the custom provider `<select>` in the Magic AI platform configuration modal with the shared core admin form select component.

The change keeps the existing provider-selection behavior intact while aligning the field with the admin panel’s standard form components. During the refactor, the provider binding was updated so Vue continues to manage the selected value correctly without Blade trying to evaluate `form.provider` on the server side.

**What Changed**

- Replaced the raw provider dropdown in [index.blade.php](/home/users/prince.sahni/www/html/Unopim-Update-Laravel-12/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/platform/index.blade.php) with `x-admin::form.control-group.control` using `type="select"`.
- Mapped `AiProvider::cases()` into the core select’s expected `id` / `label` options format.
- Updated the provider change handler to normalize the emitted select value and keep existing auto-fill logic working for:
  - provider label
  - default API URL
  - model reset/fetch flow
- Fixed the Blade/Vue binding issue that caused:
  - `Undefined constant "form"`