### PR TITLE
Fix: fixed the alert message on job cancel, with actual unopim standa…

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/tracker/import.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/tracker/import.blade.php
@@ -1161,21 +1161,31 @@
                     },
 
                     cancelImport() {
-                        if (! confirm('@lang("admin::app.settings.data-transfer.tracker.cancel-confirm")')) {
-                            return;
-                        }
-                        this.isActionInProgress = true;
-                        this.$axios.post("{{ route('admin.settings.data_transfer.imports.cancel', $import->id) }}")
-                            .then((response) => {
-                                this.$emitter.emit('add-flash', { type: 'warning', message: response.data.message });
-                                this.getStats();
-                            })
-                            .catch(error => {
-                                this.$emitter.emit('add-flash', { type: 'error', message: error.response?.data?.message || 'Failed to cancel import.' });
-                            })
-                            .finally(() => {
-                                this.isActionInProgress = false;
-                            });
+                        this.$emitter.emit('open-confirm-modal', {
+                            title: '@lang("admin::app.settings.data-transfer.tracker.cancel")',
+                            message: '@lang("admin::app.settings.data-transfer.tracker.cancel-confirm")',
+                            options: {
+                                btnDisagree: '@lang("admin::app.settings.data-transfer.tracker.cancel")',
+                                btnAgree: '@lang("admin::app.components.modal.confirm.agree-btn")',
+                                btnAgreeClass: 'danger-button',
+                                btnDisagreeClass: 'transparent-button',
+                            },
+                            agree: () => {
+                                this.isActionInProgress = true;
+
+                                this.$axios.post("{{ route('admin.settings.data_transfer.imports.cancel', $import->id) }}")
+                                    .then((response) => {
+                                        this.$emitter.emit('add-flash', { type: 'warning', message: response.data.message });
+                                        this.getStats();
+                                    })
+                                    .catch(error => {
+                                        this.$emitter.emit('add-flash', { type: 'error', message: error.response?.data?.message || 'Failed to cancel import.' });
+                                    })
+                                    .finally(() => {
+                                        this.isActionInProgress = false;
+                                    });
+                            },
+                        });
                     },
 
                     getStats() {


### PR DESCRIPTION
**Title**  
Replace browser cancel alert with UnoPim confirmation modal on import tracker

**Description**  
This PR updates the cancel import action on the data transfer tracker page to use UnoPim’s standard confirmation modal instead of the default browser alert.

**Changes**  
- Replaced the native `confirm()` dialog in the cancel import flow
- Wired the cancel action to the shared admin `open-confirm-modal` event
- Added a two-action confirmation experience before sending the cancel request
- Kept the existing cancel API call, flash messages, and tracker refresh behavior unchanged

**Impact**  
- No backend or API changes
- UI-only improvement
- Users now see a proper modal with cancel and confirm actions before cancelling an import