### PR TITLE
Enhance German backend translation

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
@@ -1948,7 +1948,7 @@ return [
                     'title' => 'Suchen',
                 ],
                 'manage-columns' => [
-                    'title' => 'Kolonne',
+                    'title' => 'Spalten',
                 ],
                 'pagination' => [
                     'first-page'    => 'Erste Seite',


### PR DESCRIPTION
"Kolonne" means convoys, not (table-)columns