### PR TITLE
Fix: remove undefined providers override from integration key generation

### DIFF
--- a/packages/Webkul/AdminApi/src/Console/ApiClientCommand.php
+++ b/packages/Webkul/AdminApi/src/Console/ApiClientCommand.php
@@ -65,8 +65,6 @@ class ApiClientCommand extends Passport
 
         $provider = config('auth.guards.api.provider', 'admins');
 
-        $provider = $providers[0];
-
         $client = $clients->createPasswordGrantClient(
             $user->id, $name, 'http://localhost', $provider
         );

--- a/packages/Webkul/AdminApi/src/Traits/OauthClientGenerator.php
+++ b/packages/Webkul/AdminApi/src/Traits/OauthClientGenerator.php
@@ -14,7 +14,6 @@ trait OauthClientGenerator
     public function generateClientIdAndSecretKey(int $user_id, string $name)
     {
         $provider = config('auth.guards.api.provider', 'admins');
-        $provider = $providers[0];
 
         $client = $this->clients->createPasswordGrantClient(
             $user_id,


### PR DESCRIPTION
**Title**
`Fix integration API key generation failing with undefined $providers`

**Summary**
This PR fixes the Integration API key generation flow in the Admin API module.

When generating API credentials from `Configuration -> Integrations`, the request failed with:
`Undefined variable $providers`

The issue was caused by a stray overwrite of the resolved auth provider in the OAuth client generation logic.

**Root cause**
Both of these files resolved the provider correctly from config:
[OauthClientGenerator.php](/home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-Laravel-12-Beta-Test-1/packages/Webkul/AdminApi/src/Traits/OauthClientGenerator.php)
[ApiClientCommand.php](/home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-Laravel-12-Beta-Test-1/packages/Webkul/AdminApi/src/Console/ApiClientCommand.php)

But immediately after, the code reassigned it using:
`$provider = $providers[0];`

Since `$providers` was never defined, integration key generation crashed before the OAuth client could be created.

**Changes made**
- Removed the invalid `$provider = $providers[0];` line from the shared OAuth client generator trait
- Removed the same invalid line from the related CLI command
- Kept the provider source as `config('auth.guards.api.provider', 'admins')`

**Impact**
- Fixes Generate API Keys action in the Integration edit screen
- Fixes the related CLI password grant client creation path
- Restores expected OAuth client creation behavior without changing the configured provider logic

**Verification**
- Ran `./vendor/bin/pint`
- Ran `./vendor/bin/pest packages/Webkul/Admin/tests/Feature/Configuration/IntegrationSectionTest.php`
- Ran - `php artisan unopim:translations:check`
