### PR TITLE
Fix: ensure format validation is skipped for empty optional attribute…

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Catalog/CategoryValuesTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/CategoryValuesTest.php
@@ -589,3 +589,29 @@ it('should not allow invalid files upload for file type field', function () {
         }
     }
 });
+
+it('should allow empty value for optional category field with regex validation', function () {
+    $this->loginAsAdmin();
+
+    $categoryFieldCode = 'optional_regex_field';
+
+    CategoryField::factory()->create([
+        'status'         => 1,
+        'code'           => $categoryFieldCode,
+        'is_required'    => 0,
+        'validation'     => 'regex',
+        'regex_pattern'  => '^[0-9]+$', // Only numbers
+        'type'           => 'text',
+    ]);
+
+    $category = Category::factory()->create();
+
+    $data = $category->toArray();
+    $data['additional_data']['common'] = [$categoryFieldCode => '']; // Empty value
+
+    $this->put(route('admin.catalog.categories.update', $category->id), $data)
+        ->assertSessionHas('success', trans('admin::app.catalog.categories.update-success'));
+
+    $category->refresh();
+    $this->assertEquals('', ($category->additional_data['common'][$categoryFieldCode] ?? ''));
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductValuesTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductValuesTest.php
@@ -1112,3 +1112,33 @@ it('should store the associations value when updating configurable product', fun
         $this->assertEquals($value, $product->values['associations'][$type] ?? '');
     }
 });
+
+it('should allow empty value for optional attribute with numeric validation', function () {
+    $this->loginAsAdmin();
+
+    $attribute = Attribute::factory()->create([
+        'is_required' => 0,
+        'validation'  => 'number',
+        'type'        => 'text',
+    ]);
+
+    $product = Product::factory()->simple()->create();
+    $product->attribute_family->attributeFamilyGroupMappings->first()?->customAttributes()?->attach($attribute);
+
+    $attributeCode = $attribute->code;
+
+    $data = [
+        'sku'    => $product->sku,
+        'values' => [
+            'common' => [
+                $attributeCode => '', // Empty value
+            ],
+        ],
+    ];
+
+    $this->put(route('admin.catalog.products.update', $product->id), $data)
+        ->assertSessionHas('success', trans('admin::app.catalog.products.update-success'));
+
+    $product->refresh();
+    $this->assertEquals('', $product->values['common'][$attributeCode] ?? '');
+});

--- a/packages/Webkul/Attribute/src/Models/Attribute.php
+++ b/packages/Webkul/Attribute/src/Models/Attribute.php
@@ -136,9 +136,11 @@ class Attribute extends TranslatableModel implements AttributeContract, HistoryC
      */
     public function getValidationRules(?string $currentChannelCode = null, ?string $currentLocaleCode = null, ?int $id = null, bool $withUniqueValidation = true)
     {
-        $validations = $this->fieldTypeValidations();
+        $validations = [
+            $this->is_required ? 'required' : 'nullable',
+        ];
 
-        $validations[] = $this->is_required ? 'required' : 'nullable';
+        $validations = array_merge($validations, $this->fieldTypeValidations());
 
         if ($this->type == 'price') {
             $validations[] = "regex:/^\d+(\.\d+)?$/";
@@ -185,6 +187,8 @@ class Attribute extends TranslatableModel implements AttributeContract, HistoryC
 
         if ($this->is_required) {
             $validations[] = 'required';
+        } else {
+            $validations[] = 'nullable';
         }
 
         if ($this->type === 'file') {

--- a/packages/Webkul/Category/src/Models/CategoryField.php
+++ b/packages/Webkul/Category/src/Models/CategoryField.php
@@ -140,6 +140,8 @@ class CategoryField extends TranslatableModel implements CategoryFieldContract, 
 
         if ($this->is_required) {
             $validations[] = 'required';
+        } else {
+            $validations[] = 'nullable';
         }
 
         if ($this->validation) {
@@ -183,6 +185,8 @@ class CategoryField extends TranslatableModel implements CategoryFieldContract, 
 
         if ($this->is_required) {
             $validations[] = 'required';
+        } else {
+            $validations[] = 'nullable';
         }
 
         if ($this->type === 'file') {


### PR DESCRIPTION
This PR fixes a validation bug where optional (non-required) Attributes and Category Fields with format-related rules (such as `regex`, `numeric`, or `decimal`) would fail validation when left empty.

## Problem

When a new Attribute or Category Field was created as **optional** but included a **format validation**, the system would attempt to validate an empty/null value against those format rules. This happened because:
1. The `nullable` rule was not consistently present in all internal validation arrays.
2. The rules were being added in an order that placed format rules before the `nullable`/`required` check, causing format validation to fail before it should have been skipped.

## Solution

- **Rule Ordering**: Standardized the [getValidationRules()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:235:4-265:5) method in the [Attribute](cci:2://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Attribute/src/Models/Attribute.php:20:0-487:1) model to place the `required` or `nullable` rule at the **beginning** of the rule array. This ensures it is processed first by Laravel’s validator.
- **Consistent Nullability**: Added the `nullable` rule to [getValidationsFieldWithOutMedia()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:133:4-156:5) and [getValidationsFieldOnlyMedia()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:178:4-209:5) in both [Attribute](cci:2://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Attribute/src/Models/Attribute.php:20:0-487:1) and [CategoryField](cci:2://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:15:0-278:1) models when the field is not required.
- **Improved Media Validation**: Specifically ensured media fields (images and files) handle null inputs correctly when optional.

## Changes

### `Webkul\Attribute`
- **Models/Attribute.php**: 
    - Moved `required`/`nullable` rule to the start of the array in [getValidationRules()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:235:4-265:5).
    - Added `nullable` support to [getValidationsOnlyMedia()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Attribute/src/Models/Attribute.php:178:4-214:5).

### `Webkul\Category`
- **Models/CategoryField.php**:
    - Added `nullable` check to [getValidationsFieldWithOutMedia()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:133:4-156:5) and [getValidationsFieldOnlyMedia()](cci:1://file:///home/users/prince.sahni/www/html/Unopim-Laravel-12/Unopim-New-2-Version-Laravel-12/packages/Webkul/Category/src/Models/CategoryField.php:178:4-209:5).

### Tests
- **CategoryValuesTest.php**: Added a test case to verify optional category fields with regex validation allow empty values.
- **ProductValuesTest.php**: Added a test case to verify optional product attributes with numeric validation allow empty values.

## Verification

- [x] Ran PEST tests for Category component (`Packages\Webkul\Admin\tests\Feature\Catalog\CategoryValuesTest`).
- [x] Ran PEST tests for Product component (`Packages\Webkul\Admin\tests\Feature\Catalog\ProductValuesTest`).
- [x] Manually verified that empty optional fields with constraints are now saved successfully.
