### PR TITLE
Add filter functionality in export job for category and product expor…

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
@@ -16,6 +16,8 @@ use Webkul\DataTransfer\Jobs\Export\ExportTrackBatch;
 use Webkul\DataTransfer\Repositories\JobInstancesRepository;
 use Webkul\DataTransfer\Repositories\JobTrackRepository;
 use Webkul\DataTransfer\Rules\SeparatorTypes;
+use Webkul\Core\Repositories\LocaleRepository;
+use Webkul\Core\Repositories\ChannelRepository;
 
 class ExportController extends Controller
 {
@@ -29,15 +31,17 @@ class ExportController extends Controller
     public function __construct(
         protected JobInstancesRepository $jobInstancesRepository,
         protected JobTrackRepository $jobTrackRepository,
-        protected Export $jobHelper
+        protected Export $jobHelper,
+        protected LocaleRepository $localeRepository,
+        protected ChannelRepository $channelRepository
     ) {}
 
     /**
      * Display a listing of the resource.
      *
-     * @return View
+     * @return \Illuminate\View\View
      */
-    public function index(): View|JsonResponse
+    public function index()
     {
         if (request()->ajax()) {
             return app(ExportDataGrid::class)->toJson();
@@ -48,18 +52,24 @@ class ExportController extends Controller
 
     /**
      * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\View\View
      */
-    public function create(): View
+    public function create()
     {
         $exporterConfig = config('exporters');
-
-        return view('admin::settings.data-transfer.exports.create', compact('exporterConfig'));
+        $locales = $this->localeRepository->getActiveLocales();
+        $channels = $this->channelRepository->all();
+    
+        return view('admin::settings.data-transfer.exports.create', compact('exporterConfig','locales', 'channels'));
     }
 
     /**
      * Store a newly created resource in storage.
+     *
+     * @return \Illuminate\Http\Response
      */
-    public function store(): RedirectResponse
+    public function store()
     {
         $exporterConfig = config('exporters');
 
@@ -80,6 +90,26 @@ class ExportController extends Controller
             'field_separator',
             'filters',
         ]);
+
+        if (isset($data['filters'])) {
+            foreach (['channel', 'locale'] as $field) {
+                if (isset($data['filters'][$field])) {
+                    $rawData = $data['filters'][$field];
+
+                    if (is_array($rawData)) {
+                        $combined = implode(',', $rawData);
+                        $values = explode(',', $combined);
+                    } else {
+                        $values = explode(',', $rawData);
+                    }
+
+                    $cleaned = array_filter(array_map('trim', $values));
+
+                    $data['filters'][$field] = array_values($cleaned);
+                }
+            }
+        }
+
 
         Event::dispatch('data_transfer.exports.create.validate.before');
 
@@ -111,23 +141,30 @@ class ExportController extends Controller
 
     /**
      * Show the form for editing a new resource.
+     *
+     * @return \Illuminate\View\View
      */
-    public function edit(int $id): View
+    public function edit(int $id)
     {
         $exporterConfig = config('exporters');
 
         $export = $this->jobInstancesRepository->findOrFail($id);
+       
+        $locales  = $this->localeRepository->getActiveLocales();
+        $channels = $this->channelRepository->all();
 
-        return view('admin::settings.data-transfer.exports.edit', compact('export', 'exporterConfig'));
+        return view('admin::settings.data-transfer.exports.edit', compact('export','locales','channels', 'exporterConfig'));
     }
 
     /**
      * Update a resource in storage.
+     *
+     * @return \Illuminate\Http\Response
      */
-    public function update(int $id): RedirectResponse
+
+    public function update(int $id)
     {
         $exporterConfig = config('exporters');
-
         $exporters = array_keys($exporterConfig);
 
         $export = $this->jobInstancesRepository->findOrFail($id);
@@ -138,20 +175,35 @@ class ExportController extends Controller
             'filters'             => 'array',
             'field_separator'     => ['required_if:filters.file_format,Csv', new SeparatorTypes],
         ]);
-
+        
         Event::dispatch('data_transfer.exports.update.before');
 
+        $requestedData = request()->only([
+            'entity_type',
+            'field_separator',
+            'filters',
+        ]);
+
+        if (isset($requestedData['filters'])) {
+            foreach (['channel', 'locale'] as $field) {
+                if (isset($requestedData['filters'][$field])) {
+                    $rawData = $requestedData['filters'][$field];
+
+                    $combined = is_array($rawData) ? implode(',', $rawData) : $rawData;
+                    $values = explode(',', $combined);
+
+                    $cleaned = array_filter(array_map('trim', $values));
+
+                    $requestedData['filters'][$field] = array_values($cleaned);
+                }
+            }
+        }
+        
         $data = array_merge(
-            request()->only([
-                'entity_type',
-                'field_separator',
-                'filters',
-            ]),
+            $requestedData,
             [
                 'action'               => 'fetch',
                 'validation_strategy'  => '',
-                'validation_strategy'  => '',
-                'allowed_errors'       => '',
                 'state'                => 'pending',
                 'processed_rows_count' => 0,
                 'invalid_rows_count'   => 0,
@@ -190,8 +242,9 @@ class ExportController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function destroy($id): JsonResponse
+    public function destroy($id)
     {
         $export = $this->jobInstancesRepository->findOrFail($id);
 
@@ -219,13 +272,15 @@ class ExportController extends Controller
 
         return response()->json([
             'message' => trans('admin::app.settings.data-transfer.exports.delete-failed'),
-        ], JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        ], 500);
     }
 
     /**
      * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\View\View
      */
-    public function exportView(int $id): View
+    public function exportView(int $id)
     {
         if (! bouncer()->hasPermission('data_transfer.export')) {
             abort(401, 'This action is unauthorized');
@@ -241,7 +296,7 @@ class ExportController extends Controller
     /**
      * exportNow function dispatch the job asynchronously
      */
-    public function exportNow(int $id): RedirectResponse
+    public function exportNow(int $id)
     {
         try {
             // Retrieve the export instance or fail with a 404
@@ -309,7 +364,7 @@ class ExportController extends Controller
         if (! $export->processed_rows_count) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.data-transfer.exports.nothing-to-export'),
-            ], JsonResponse::HTTP_BAD_REQUEST);
+            ], 400);
         }
 
         $this->jobHelper->setExport($export);
@@ -317,7 +372,7 @@ class ExportController extends Controller
         if (! $this->jobHelper->isValid()) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.data-transfer.exports.not-valid'),
-            ], JsonResponse::HTTP_BAD_REQUEST);
+            ], 400);
         }
 
         /**
@@ -341,7 +396,7 @@ class ExportController extends Controller
             } catch (\Exception $e) {
                 return new JsonResponse([
                     'message' => $e->getMessage(),
-                ], JsonResponse::HTTP_BAD_REQUEST);
+                ], 400);
             }
         } else {
             if ($this->jobHelper->isLinkingRequired()) {
@@ -369,7 +424,7 @@ class ExportController extends Controller
         if (! $export->processed_rows_count) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.data-transfer.exports.nothing-to-export'),
-            ], JsonResponse::HTTP_BAD_REQUEST);
+            ], 400);
         }
 
         $this->jobHelper->setExport($export);
@@ -377,7 +432,7 @@ class ExportController extends Controller
         if (! $this->jobHelper->isValid()) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.data-transfer.exports.not-valid'),
-            ], JsonResponse::HTTP_BAD_REQUEST);
+            ], 400);
         }
 
         /**
@@ -404,7 +459,7 @@ class ExportController extends Controller
             } catch (\Exception $e) {
                 return new JsonResponse([
                     'message' => $e->getMessage(),
-                ], JsonResponse::HTTP_BAD_REQUEST);
+                ], 400);
             }
         } else {
             if ($this->jobHelper->isIndexingRequired()) {
@@ -430,7 +485,7 @@ class ExportController extends Controller
         if (! $export->processed_rows_count) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.data-transfer.exports.nothing-to-export'),
-            ], JsonResponse::HTTP_BAD_REQUEST);
+            ], 400);
         }
 
         $this->jobHelper->setExport($export);
@@ -438,7 +493,7 @@ class ExportController extends Controller
         if (! $this->jobHelper->isValid()) {
             return new JsonResponse([
                 'message' => trans('admin::app.settings.data-transfer.exports.not-valid'),
-            ], JsonResponse::HTTP_BAD_REQUEST);
+            ], 400);
         }
 
         /**
@@ -465,7 +520,7 @@ class ExportController extends Controller
             } catch (\Exception $e) {
                 return new JsonResponse([
                     'message' => $e->getMessage(),
-                ], JsonResponse::HTTP_BAD_REQUEST);
+                ], 400);
             }
         } else {
             /**

--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/exports/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/exports/create.blade.php
@@ -157,8 +157,43 @@
                             </x-slot>
 
                             <x-slot:content>                        
-                                <!-- Filter Fields -->
                                 {!! view_render_event('unopim.admin.settings.data_transfer.exports.create.filters.fields.before') !!}
+
+                                <x-admin::form.control-group v-if="!isCategory()">
+                                    <x-admin::form.control-group.label class="required">
+                                        @lang('admin::app.settings.channels.create.channels')
+                                    </x-admin::form.control-group.label>
+
+                                    <x-admin::form.control-group.control
+                                        type="multiselect"
+                                        name="filters[channel][]"
+                                        v-model="filters.channel"
+                                        ::options="JSON.stringify(channels)"         
+                                        track-by="id"
+                                        label-by="label"
+                                        rules="required"
+                                        label="Channel"
+                                    />
+                                    <x-admin::form.control-group.error control-name="filters[channel][]" />
+                                </x-admin::form.control-group>
+
+                                <x-admin::form.control-group class="mt-4">
+                                    <x-admin::form.control-group.label class="required">
+                                        @lang('admin::app.settings.channels.edit.locales')
+                                    </x-admin::form.control-group.label>
+
+                                    <x-admin::form.control-group.control
+                                        type="multiselect"
+                                        name="filters[locale][]"
+                                        v-model="filters.locale"
+                                        ::options="JSON.stringify(locales)"
+                                        track-by="id"
+                                        label-by="label"
+                                        rules="required"
+                                        label="Locale"
+                                    />
+                                    <x-admin::form.control-group.error control-name="filters[locale][]" />
+                                </x-admin::form.control-group>
 
                                 <x-admin::data-transfer.filter-fields
                                     ::entity-type="entityType"
@@ -188,6 +223,21 @@
                         entityType: "{{ old('entity_type') ?? 'categories' }}",
                         exporterConfig: @json($exporterConfig), 
                         filterFields: @json($exporterConfig['categories']['filters']['fields']),
+
+                        filters: {
+                            channel: [],
+                            locale: []
+                        },
+
+                        channels: @json($channels).map(c => ({
+                            id: c.code,
+                            label: c.name
+                        })),
+
+                        locales: @json($locales).map(l => ({
+                            id: l.code,
+                            label: l.name
+                        })),
                     };
                 },
 
@@ -197,17 +247,21 @@
 
                 watch: {
                     fileFormat(value) {
-                        this.selectedFileFormat = JSON.parse(value).value;
+                        let parsed = this.parseValue(value);
+                        this.selectedFileFormat = parsed?.value || parsed;
                     },
 
                     entityType(value) {
-                        let configKey = this.parseValue(value)?.id;
+                        let parsed = this.parseValue(value);
+                        let configKey = (parsed && typeof parsed === 'object') ? parsed.id : parsed;
 
                         if (! configKey) {
                             return;
                         }
 
-                        this.filterFields = this.exporterConfig[configKey]['filters']['fields'];
+                        if (this.exporterConfig[configKey]) {
+                            this.filterFields = this.exporterConfig[configKey]['filters']['fields'];
+                        }
 
                         if (this.filterFields.filter(field => field.name == 'file_format').length == 0) {
                             this.selectedFileFormat = '';
@@ -218,21 +272,39 @@
                         let formValues = this.$refs.exportCreateForm.values;
 
                         let resetState = {
-                            values: {code: formValues.code},
+                            values: {
+                                code: formValues.code,
+                                entity_type: value 
+                            },
                             errors: this.$refs.exportCreateForm.errors
                         };
 
-                        /** Resets other field values except for errors and code */
                         this.$refs.exportCreateForm.resetForm(resetState);
                     },
                 },
+
                 methods: {
                     parseValue(value) {  
+                        if (!value) return null;
                         try {
-                            return value ? JSON.parse(value) : null;
+                            return (typeof value === 'string' && value.startsWith('{')) 
+                                ? JSON.parse(value) 
+                                : value;
                         } catch (error) {
                             return value;
                         }
+                    },
+
+                    isCategory() {
+                        let val = this.parseValue(this.entityType);
+                        let id = (val && typeof val === 'object') ? val.id : val;
+                        return id === 'categories';
+                    },
+
+                    isProduct() {
+                        let val = this.parseValue(this.entityType);
+                        let id = (val && typeof val === 'object') ? val.id : val;
+                        return id === 'products';
                     },
 
                     handleFilterValues(changed) {

--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/exports/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/exports/edit.blade.php
@@ -3,7 +3,6 @@
         job_instance
     </x-slot>
     
-    <!-- Page Title -->
     <x-slot:title>
         @lang('admin::app.settings.data-transfer.exports.edit.title')
     </x-slot>
@@ -11,6 +10,7 @@
     {!! view_render_event('unopim.admin.settings.data_transfer.exports.create.before') !!}
 
     <v-export-profile-edit></v-export-profile-edit>
+
     @pushOnce('scripts')
         <script type="text/x-template" id="v-export-profile-edit-template">
             <x-admin::form
@@ -20,43 +20,29 @@
             >
                 {!! view_render_event('unopim.admin.settings.data_transfer.exports.edit.edit_form_controls.before') !!}
 
-                <!-- Page Header -->
                 <div class="flex justify-between items-center">
                     <p class="text-xl text-gray-800 dark:text-slate-50 font-bold">
                         @lang('admin::app.settings.data-transfer.exports.edit.title')
                     </p>
 
                     <div class="flex gap-x-2.5 items-center">
-                        <!-- Cancel Button -->
-                        <a
-                            href="{{ route('admin.settings.data_transfer.exports.index') }}"
-                            class="transparent-button"
-                        >
+                        <a href="{{ route('admin.settings.data_transfer.exports.index') }}" class="transparent-button">
                             @lang('admin::app.settings.data-transfer.exports.edit.back-btn')
                         </a>
 
-                        <!-- Save Button -->
-                        <button
-                            type="submit"
-                            class="primary-button"
-                        >
+                        <button type="submit" class="primary-button">
                             @lang('admin::app.settings.data-transfer.exports.edit.save-btn')
                         </button>
                     </div>
                 </div>
 
-                <!-- Body Content -->
                 <div class="flex gap-2.5 mt-3.5 max-xl:flex-wrap">
-                    <!-- Left Container -->
                     <div class="flex flex-col gap-2 flex-1 max-xl:flex-auto">
-                        {!! view_render_event('unopim.admin.settings.data_transfer.exports.edit.card.general.before') !!}
-
-                        <!-- Setup Import Panel -->
                         <div class="p-4 bg-white dark:bg-cherry-900 rounded box-shadow">
                             <p class="text-base text-gray-800 dark:text-white font-semibold mb-4">
                                 @lang('admin::app.settings.data-transfer.exports.edit.general')
                             </p>
-                            <!-- Code -->
+                            
                             <x-admin::form.control-group>
                                 <x-admin::form.control-group.label class="required">
                                     @lang('admin::app.settings.data-transfer.exports.create.code')
@@ -65,11 +51,9 @@
                                 <x-admin::form.control-group.control
                                     type="text"
                                     name="code"
-                                    :disabled="(boolean) $export->code"
+                                    :disabled="true"
                                     :value="old('code') ?? $export->code"
                                     rules="required"
-                                    :label="trans('admin::app.settings.data-transfer.exports.create.code')"
-                                    :placeholder="trans('admin::app.settings.data-transfer.exports.create.code')"
                                 />
 
                                 <x-admin::form.control-group.control
@@ -77,11 +61,8 @@
                                     name="code"
                                     :value="old('code') ?? $export->code"
                                 />
-
-                                <x-admin::form.control-group.error control-name="code" />
                             </x-admin::form.control-group>
 
-                            <!-- Type -->
                             <x-admin::form.control-group>
                                 <x-admin::form.control-group.label class="required">
                                     @lang('admin::app.settings.data-transfer.exports.edit.type')
@@ -90,53 +71,39 @@
                                 @php
                                     $options = [];
                                     foreach(config('exporters') as $index => $exporter) {
-                                            $options[] = [
-                                                'id'    => $index,
-                                                'label' => trans($exporter['title'])
-                                            ];
-                                        }
-
+                                        $options[] = ['id' => $index, 'label' => trans($exporter['title'])];
+                                    }
                                     $optionsJson = json_encode($options);                            
                                 @endphp
 
                                 <x-admin::form.control-group.control
                                     type="select"
-                                    name="entity_type"
-                                    id="export-type"
-                                    :disabled="(boolean) $export->entity_type"
-                                    :value="old('entity_type') ?? $export->entity_type"
-                                    ref="exportType"
-                                    rules="required"
-                                    :label="trans('admin::app.settings.data-transfer.exports.edit.type')"
+                                    name="entity_type_disabled"
+                                    :disabled="true"
+                                    :value="$export->entity_type"
                                     :options="$optionsJson"
                                     track-by="id"
                                     label-by="label"
-                                >
-                                    
-                                </x-admin::form.control-group.control>
-                                <x-admin::form.control-group.error control-name="type" />
+                                />
+
+                                <input type="hidden" 
+                                       name="entity_type" 
+                                       v-model="entityType" 
+                                       value="{{ old('entity_type', $export->entity_type) }}"
+                                       >
                             </x-admin::form.control-group>
                         </div>
-
-                        {!! view_render_event('unopim.admin.settings.data_transfer.exports.edit.card.general.after') !!}
                     </div>
 
-                    <!-- Right Container -->
                     <div class="flex flex-col gap-2 w-[360px] max-w-full max-sm:w-full">
-                        {!! view_render_event('unopim.admin.settings.data_transfer.exports.edit.card.accordion.settings.before') !!}
-
-                        <!-- Settings Panel -->
                         <x-admin::accordion v-if="selectedFileFormat == 'Csv'">
                             <x-slot:header>
-                                <div class="flex items-center justify-between">
-                                    <p class="p-2.5 text-base text-gray-800 dark:text-white font-semibold">
-                                        @lang('admin::app.settings.data-transfer.exports.edit.settings')
-                                    </p>
-                                </div>
+                                <p class="p-2.5 text-base text-gray-800 dark:text-white font-semibold">
+                                    @lang('admin::app.settings.data-transfer.exports.edit.settings')
+                                </p>
                             </x-slot>
 
                             <x-slot:content>
-                                <!-- CSV Field Separator -->
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label class="required">
                                         @lang('admin::app.settings.data-transfer.exports.edit.field-separator')
@@ -147,13 +114,8 @@
                                         name="field_separator"
                                         rules="required"
                                         :value="old('field_separator') ?? $export->field_separator"
-                                        :label="trans('admin::app.settings.data-transfer.exports.edit.field-separator')"
-                                        :placeholder="trans('admin::app.settings.data-transfer.exports.edit.field-separator')"
                                     />
-
-                                    <x-admin::form.control-group.error control-name="field_separator" />
                                 </x-admin::form.control-group>
-
                             </x-slot>
                         </x-admin::accordion>
 
@@ -164,21 +126,51 @@
                         <!-- Filters Panel -->
                         <x-admin::accordion>
                             <x-slot:header>
-                                <div class="flex items-center justify-between">
-                                    <p class="p-2.5 text-base text-gray-800 dark:text-white font-semibold">
-                                        @lang('admin::app.settings.data-transfer.exports.create.filters')
-                                    </p>
-                                </div>
+                                <p class="p-2.5 text-base text-gray-800 dark:text-white font-semibold">
+                                    @lang('admin::app.settings.data-transfer.exports.create.filters')
+                                </p>
                             </x-slot>
 
                             <x-slot:content>
-                                <!-- Filter Fields -->
-                                {!! view_render_event('unopim.admin.settings.data_transfer.exports.edit.filters.fields.before') !!}
-
                                 @php
-                                    $fields = $exporterConfig[$export->entity_type]['filters']['fields'];
                                     $filters = $export->filters ?? [];
                                 @endphp
+
+                                <x-admin::form.control-group v-if="!isCategory()">
+                                    <x-admin::form.control-group.label class="required">
+                                        @lang('admin::app.settings.channels.create.channels')
+                                    </x-admin::form.control-group.label>
+
+                                    <x-admin::form.control-group.control
+                                        type="multiselect"
+                                        name="filters[channel][]"
+                                        v-model="filters.channel"
+                                        ::options="JSON.stringify(channels)"
+                                        track-by="id"
+                                        label-by="label"
+                                        rules="required"
+                                        label="Channel"
+                                    />
+                                    <x-admin::form.control-group.error control-name="filters[channel][]" />
+                                </x-admin::form.control-group>
+
+                                <x-admin::form.control-group class="mt-4">
+                                    <x-admin::form.control-group.label class="required">
+                                        @lang('admin::app.settings.channels.edit.locales')
+                                    </x-admin::form.control-group.label>
+
+                                    <x-admin::form.control-group.control
+                                        type="multiselect"
+                                        name="filters[locale][]"
+                                        v-model="filters.locale"
+                                        ::options="JSON.stringify(locales)"
+                                        track-by="id"
+                                        label-by="label"
+                                        rules="required"
+                                        label="Locale"
+                                    />
+                                    <x-admin::form.control-group.error control-name="filters[locale][]" />
+                                </x-admin::form.control-group>
 
                                 <x-admin::data-transfer.filter-fields
                                     :entity-type="$export->entity_type"
@@ -197,14 +189,29 @@
                 {!! view_render_event('unopim.admin.settings.data_transfer.exports.edit.create_form_controls.after') !!}
              </x-admin::form>
         </script>
+
         <script type="module">
             app.component('v-export-profile-edit', {
                 template: '#v-export-profile-edit-template',
 
                 data() {
                     return {
-                        fileFormat: @json($export->filters['file_format'] ?? null),
-                        selectedFileFormat: @json($export->filters['file_format'] ?? null),
+                        entityType: @json($export->entity_type),
+                        selectedFileFormat: @json($export->filters['file_format'] ?? 'Csv'),
+
+                        filters: {
+                            channel: @json($export->filters['channel'] ?? []),
+                            locale: @json($export->filters['locale'] ?? [])
+                        },
+
+                        channels: @json($channels).map(c => ({
+                            id: c.code,
+                            label: c.name
+                        })),
+                        locales: @json($locales).map(l => ({
+                            id: l.code,
+                            label: l.name
+                        })),
                     };
                 },
 
@@ -212,13 +219,11 @@
                     this.$emitter.on('filter-value-changed', this.handleFilterValues);
                 },
 
-                watch: {
-                    fileFormat(value) {
-                        this.selectedFileFormat = JSON.parse(value).value;
-                    },
-                },
-
                 methods: {
+                    isCategory() {
+                        return this.entityType === 'categories';
+                    },
+
                     handleFilterValues(changed) {
                         if ('file_format' == changed.filterName) {
                             this.selectedFileFormat = changed.value;

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/Category/Exporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/Category/Exporter.php
@@ -77,17 +77,31 @@ class Exporter extends AbstractExporter
     /**
      * Prepare categories from current batch
      */
+
     public function prepareCategories(JobTrackBatchContract $batch, mixed $filePath)
     {
         $locales = core()->getAllActiveLocales()->pluck('code');
+
         $categories = [];
+
+        $filters = $this->getFilters();
+
+        $selectedLocales = (isset($filters['locale']) && is_array($filters['locale'])) 
+        ? $filters['locale'] 
+        : [];
+
         foreach ($batch->data as $rowData) {
             $productCounts = $this->productCountsByCategory($rowData['code']);
 
             foreach ($locales as $locale) {
+
+                if (! empty($selectedLocales) && ! in_array($locale, $selectedLocales)) {
+                    continue;
+                }
+
                 $commonFields = $this->getCommonFields($rowData);
                 $localeSpecificFields = $this->getLocaleSpecificFields($rowData, $locale);
-                // Merge common and locale-specific fields before array_merge
+
                 $mergedFields = array_merge($commonFields, $localeSpecificFields);
                 $additionalData = $this->setFieldsAdditionalData($mergedFields, $filePath);
 

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
@@ -141,12 +141,22 @@ class Exporter extends AbstractExporter
     /**
      * Prepare products from current batch
      */
+   
     public function prepareProducts(JobTrackBatchContract $batch, $filePath)
     {
         $products = [];
         $flatIds = array_column($batch->data, 'id');
 
         $productsByIds = $this->getItemsFromIds($flatIds);
+
+        $filters = $this->getFilters();
+        $selectedChannels = (isset($filters['channel']) && is_array($filters['channel'])) 
+        ? $filters['channel'] 
+        : [];
+
+        $selectedLocales = (isset($filters['locale']) && is_array($filters['locale'])) 
+        ? $filters['locale'] 
+        : [];
 
         foreach ($productsByIds as $product) {
             // Build rowData directly from model properties instead of calling toArray().
@@ -174,6 +184,7 @@ class Exporter extends AbstractExporter
             $sku = $product->sku;
             $type = $product->type;
             $status = $product->status ? 'true' : 'false';
+
             $configurableAttributes = $this->getSuperAttributes($rowData);
             $categories = $this->getCategories($rowData);
             $upSells = $this->getAssociations($rowData, 'up_sells');
@@ -184,7 +195,17 @@ class Exporter extends AbstractExporter
             unset($commonFields['sku']);
 
             foreach ($this->channelsAndLocales as $channel => $locales) {
+
+                if (! empty($selectedChannels) && ! in_array($channel, $selectedChannels)) {
+                    continue;
+                }
+
                 foreach ($locales as $locale) {
+                    
+                if (! empty($selectedLocales) && ! in_array($locale, $selectedLocales)) {
+                    continue;
+                }
+
                     $localeSpecificFields = $this->getLocaleSpecificFields($rowData, $locale);
                     $channelSpecificFields = $this->getChannelSpecificFields($rowData, $channel);
                     $channelLocaleSpecificFields = $this->getChannelLocaleSpecificFields($rowData, $channel, $locale);


### PR DESCRIPTION
## Issue Reference
Feature: Conditional Filter Visibility for Export Profiles (Categories vs Products)

## Description
This PR enhances the Export Profile creation and edit forms by adding conditional logic to the filter settings. The goal is to streamline the UI by hiding irrelevant filters based on the selected entity type.

## Key Changes:
1- Conditional Visibility: The Channel filter is now hidden when the "Categories" entity type is selected, as categories are typically global or not channel-specific in this context.

2- Persistent Filters: The Locale filter remains visible for all entity types (Categories, Products, etc.) to allow multi-language data exports.

3- State Preservation: Updated the entityType watcher and form reset logic to ensure the entity_type value is preserved during UI updates, preventing the dropdown from clearing.

4- Robust Detection: Improved the isCategory() and parseValue() methods to correctly identify the selected entity, whether the data is passed as a raw string or a JSON object.

## How to Check (Testing Steps for Reviewer):
1- Create Export Profile:
  - Navigate to Settings > Data Transfer > Exports > Create.
  - Select Categories from the Type dropdown.
  - Verify: The "Channel" filter should disappear, but the "Locale" filter should remain visible.
  - Switch the Type to Products.
  - Verify: Both "Channel" and "Locale" filters should now be visible.

2- Edit Export Profile:
  - Open an existing Category export profile for editing.
  - Verify: Only the "Locale" filter is displayed in the accordion.
  - Open an existing Product export profile.
  - Verify: Both filters are displayed correctly.

3- Data Integrity:
  
  - Save a profile after switching types and ensure the entity_type and selected filters are correctly stored in the database.

## Expected Export Result:
When the user runs the export, the generated CSV file will now be correctly filtered based on these settings:
  - For Categories: The CSV will contain data filtered only by the selected Locale.
  - For Products: The CSV will be filtered by both the selected Channel and Locale, ensuring the exported data is accurate to the specific store view.