### PR TITLE
fix: use dynamic FK lookups in AdminFactory

### DIFF
--- a/packages/Webkul/User/src/Database/Factories/AdminFactory.php
+++ b/packages/Webkul/User/src/Database/Factories/AdminFactory.php
@@ -3,9 +3,8 @@
 namespace Webkul\User\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Webkul\Core\Models\Locale;
+use Illuminate\Support\Facades\DB;
 use Webkul\User\Models\Admin;
-use Webkul\User\Models\Role;
 
 class AdminFactory extends Factory
 {
@@ -27,9 +26,9 @@ class AdminFactory extends Factory
             'name'         => $this->faker->name(),
             'email'        => $this->faker->unique()->email,
             'password'     => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
-            'role_id'      => 1,
+            'role_id'      => DB::table('roles')->first()?->id ?? 1,
             'status'       => 1,
-            'ui_locale_id' => 58,
+            'ui_locale_id' => DB::table('locales')->where('code', 'en_US')->first()?->id ?? 1,
             'image'        => null,
         ];
     }


### PR DESCRIPTION
## Summary
- Replaces hardcoded `role_id => 1` and `ui_locale_id => 58` in `AdminFactory` with dynamic DB lookups
- Removes unused imports (`Locale`, `Role`) that caused the Pint linting failure
- Fixes all 3 failing CI workflows: **Pest Tests** (859 failures), **Linting Tests**, and **Playwright Tests**

## Root Cause
Commit `312d2266` reverted the factory to static values, but `ui_locale_id => 58` doesn't exist in the CI test database, causing FK constraint violations on every admin creation.

## Test plan
- [x] All 1169 Pest tests pass locally (3917 assertions)
- [x] Pint linting passes with zero issues
- [ ] CI workflows should pass on this PR