### PR TITLE
fix: cast boolean status for ES8 compatibility in export and indexing

### DIFF
--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
@@ -40,9 +40,9 @@ class ProductCursor extends AbstractElasticCursor
         $boolQuery = [];
 
         if (! empty($filters['status'])) {
-            $value = $filters['status'] == 'enable' ? 1 : 0;
+            $value = $filters['status'] == 'enable' ? true : false;
             $boolQuery['filter'][] = [
-                'terms' => ['status' => [$value]],
+                'term' => ['status' => $value],
             ];
         }
 

--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/ProductCursor.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/ProductCursor.php
@@ -28,7 +28,7 @@ class ProductCursor extends AbstractCursor
 
         foreach ($filters as $field => $value) {
             if ($field == 'status' && ! empty($value)) {
-                $value = $value == 'enable' ? 1 : 0;
+                $value = $value == 'enable' ? true : false;
                 $query->where($field, $value);
             }
         }

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/ElasticProductCursorBooleanTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/ElasticProductCursorBooleanTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use Webkul\Core\Facades\ElasticSearch;
+use Webkul\DataTransfer\Helpers\Sources\Export\Elastic\ProductCursor;
+
+describe('ElasticProductCursor boolean status filter (Issue #243)', function () {
+
+    beforeEach(function () {
+        config([
+            'elasticsearch.enabled'                      => true,
+            'elasticsearch.prefix'                       => 'testing',
+            'elasticsearch.connection'                   => 'default',
+            'elasticsearch.connections.default.hosts.0'  => 'testhost:9200',
+        ]);
+
+        $elasticClientMock = Mockery::mock('Webkul\ElasticSearch\Client\Fake\FakeElasticClient');
+
+        ElasticSearch::shouldReceive('makeConnection')
+            ->andReturn($elasticClientMock);
+    });
+
+    it('sends boolean true (not integer 1) when status filter is "enable"', function () {
+        ElasticSearch::shouldReceive('search')
+            ->once()
+            ->withArgs(function ($args) {
+                $boolFilter = $args['body']['query']['bool']['filter'] ?? [];
+
+                // The status filter must exist
+                expect($boolFilter)->not->toBeEmpty();
+
+                $statusClause = $boolFilter[0];
+
+                // Should use 'term' or 'terms' with a boolean value
+                $statusValue = $statusClause['terms']['status']
+                    ?? $statusClause['term']['status']
+                    ?? [$statusClause['term']['status'] ?? null];
+
+                $value = is_array($statusValue) ? $statusValue[0] : $statusValue;
+
+                // CRITICAL: The value sent to ES must be boolean true, not integer 1
+                expect($value)->toBeBool()
+                    ->and($value)->toBeTrue();
+
+                return true;
+            })
+            ->andReturn([
+                'hits' => [
+                    'total' => ['value' => 0],
+                    'hits'  => [],
+                ],
+            ]);
+
+        $cursor = new ProductCursor(
+            ['filters' => ['status' => 'enable']],
+            null,
+            100
+        );
+
+        $cursor->rewind();
+    });
+
+    it('sends boolean false (not integer 0) when status filter is "disable"', function () {
+        ElasticSearch::shouldReceive('search')
+            ->once()
+            ->withArgs(function ($args) {
+                $boolFilter = $args['body']['query']['bool']['filter'] ?? [];
+
+                expect($boolFilter)->not->toBeEmpty();
+
+                $statusClause = $boolFilter[0];
+
+                $statusValue = $statusClause['terms']['status']
+                    ?? $statusClause['term']['status']
+                    ?? [$statusClause['term']['status'] ?? null];
+
+                $value = is_array($statusValue) ? $statusValue[0] : $statusValue;
+
+                // CRITICAL: The value sent to ES must be boolean false, not integer 0
+                expect($value)->toBeBool()
+                    ->and($value)->toBeFalse();
+
+                return true;
+            })
+            ->andReturn([
+                'hits' => [
+                    'total' => ['value' => 0],
+                    'hits'  => [],
+                ],
+            ]);
+
+        $cursor = new ProductCursor(
+            ['filters' => ['status' => 'disable']],
+            null,
+            100
+        );
+
+        $cursor->rewind();
+    });
+
+    it('sends no status filter when status is empty', function () {
+        ElasticSearch::shouldReceive('search')
+            ->once()
+            ->withArgs(function ($args) {
+                $boolQuery = $args['body']['query']['bool'];
+
+                // When no status filter, bool query should be empty stdClass or have no filter
+                if ($boolQuery instanceof stdClass) {
+                    return true;
+                }
+
+                expect($boolQuery)->not->toHaveKey('filter');
+
+                return true;
+            })
+            ->andReturn([
+                'hits' => [
+                    'total' => ['value' => 0],
+                    'hits'  => [],
+                ],
+            ]);
+
+        $cursor = new ProductCursor(
+            ['filters' => []],
+            null,
+            100
+        );
+
+        $cursor->rewind();
+    });
+});

--- a/packages/Webkul/ElasticSearch/src/Console/Command/ProductIndexer.php
+++ b/packages/Webkul/ElasticSearch/src/Console/Command/ProductIndexer.php
@@ -118,6 +118,11 @@ class ProductIndexer extends Command
 
                             $product = $product->toArray();
 
+                            $product['status'] = (bool) ($product['status'] ?? false);
+                            if (isset($product['attribute_family']['status'])) {
+                                $product['attribute_family']['status'] = (bool) $product['attribute_family']['status'];
+                            }
+
                             $product = $this->sanitizeDocumentKeys($product);
 
                             $productsToUpdate['body'][] = [
@@ -318,11 +323,7 @@ class ProductIndexer extends Command
      */
     private function getUnopimProductMapping()
     {
-        $driver = DB::getDriverName();
-
-        $statusMapping = $driver === 'pgsql'
-            ? ['type' => 'boolean']
-            : ['type' => 'long'];
+        $statusMapping = ['type' => 'boolean'];
 
         return [
             'properties' => [

--- a/packages/Webkul/ElasticSearch/src/Console/Command/ProductIndexer.php
+++ b/packages/Webkul/ElasticSearch/src/Console/Command/ProductIndexer.php
@@ -118,7 +118,7 @@ class ProductIndexer extends Command
 
                             $product = $product->toArray();
 
-                            $product['status'] = (bool) ($product['status'] ?? false);
+                            $product['status'] = (bool) ($product['status'] ?? true);
                             if (isset($product['attribute_family']['status'])) {
                                 $product['attribute_family']['status'] = (bool) $product['attribute_family']['status'];
                             }

--- a/packages/Webkul/ElasticSearch/src/Observers/Product.php
+++ b/packages/Webkul/ElasticSearch/src/Observers/Product.php
@@ -123,7 +123,7 @@ class Product
      */
     protected function sanitizeProductArray(array $productArray): array
     {
-        $productArray['status'] = (bool) ($productArray['status'] ?? false);
+        $productArray['status'] = (bool) ($productArray['status'] ?? true);
 
         if (isset($productArray['attribute_family']['status'])) {
             $productArray['attribute_family']['status'] = (bool) $productArray['attribute_family']['status'];

--- a/packages/Webkul/ElasticSearch/src/Observers/Product.php
+++ b/packages/Webkul/ElasticSearch/src/Observers/Product.php
@@ -3,7 +3,6 @@
 namespace Webkul\ElasticSearch\Observers;
 
 use Elastic\Elasticsearch\Exception\ElasticsearchException;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Webkul\Core\Facades\ElasticSearch;
 use Webkul\ElasticSearch\Indexing\Normalizer\ProductNormalizer;
@@ -57,27 +56,7 @@ class Product
         if (config('elasticsearch.enabled') && self::$isEnabled) {
             $productArray = $product->toArray();
 
-            $productArray['status'] = $productArray['status'] ?? 1;
-
-            switch (DB::getDriverName()) {
-                case 'pgsql':
-                    $productArray['status'] = $productArray['status'] == 1 || $productArray['status'] === true;
-
-                    if (isset($productArray['attribute_family']['status'])) {
-                        $productArray['attribute_family']['status'] =
-                            $productArray['attribute_family']['status'] == 1 || $productArray['attribute_family']['status'] === true;
-                    }
-                    break;
-
-                case 'mysql':
-                default:
-                    $productArray['status'] = (int) $productArray['status'];
-
-                    if (isset($productArray['attribute_family']['status'])) {
-                        $productArray['attribute_family']['status'] = (int) $productArray['attribute_family']['status'];
-                    }
-                    break;
-            }
+            $productArray = $this->sanitizeProductArray($productArray);
 
             if (isset($productArray['values'])) {
                 $productArray['values'] = $this->productIndexingNormalizer->normalize($productArray['values']);
@@ -103,6 +82,8 @@ class Product
         if (config('elasticsearch.enabled') && self::$isEnabled) {
             try {
                 $productArray = $product->toArray();
+
+                $productArray = $this->sanitizeProductArray($productArray);
 
                 if (isset($productArray['values'])) {
                     $productArray['values'] = $this->productIndexingNormalizer->normalize($productArray['values']);
@@ -135,5 +116,19 @@ class Product
                 ]);
             }
         }
+    }
+
+    /**
+     * Sanitize product array to ensure boolean types for ES8 compatibility.
+     */
+    protected function sanitizeProductArray(array $productArray): array
+    {
+        $productArray['status'] = (bool) ($productArray['status'] ?? false);
+
+        if (isset($productArray['attribute_family']['status'])) {
+            $productArray['attribute_family']['status'] = (bool) $productArray['attribute_family']['status'];
+        }
+
+        return $productArray;
     }
 }

--- a/packages/Webkul/ElasticSearch/tests/Feature/ProductBooleanStatusTest.php
+++ b/packages/Webkul/ElasticSearch/tests/Feature/ProductBooleanStatusTest.php
@@ -1,0 +1,223 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Webkul\Core\Facades\ElasticSearch;
+use Webkul\Product\Models\Product;
+
+beforeEach(function () {
+    config([
+        'elasticsearch.enabled'                      => true,
+        'elasticsearch.prefix'                       => 'testing',
+        'elasticsearch.connection'                   => 'default',
+        'elasticsearch.connections.default.hosts.0'  => 'testhost:9200',
+    ]);
+
+    $elasticClientMock = Mockery::mock('Webkul\ElasticSearch\Client\Fake\FakeElasticClient');
+
+    ElasticSearch::shouldReceive('makeConnection')
+        ->andReturn($elasticClientMock)
+        ->zeroOrMoreTimes();
+});
+
+describe('Product Observer indexes boolean status for ES8 compatibility (Issue #243)', function () {
+
+    it('indexes product status as boolean true on update', function () {
+        config(['elasticsearch.enabled' => false]);
+
+        $product = Product::factory()->withInitialValues()->create(['status' => 0]);
+
+        config(['elasticsearch.enabled' => true]);
+
+        $product->status = 1;
+
+        ElasticSearch::shouldReceive('index')
+            ->once()
+            ->withArgs(function ($args) {
+                try {
+                    $this->assertArrayHasKey('body', $args);
+                    $status = $args['body']['status'];
+
+                    // CRITICAL: status must be boolean, not integer
+                    $this->assertIsBool($status, 'Product status sent to ES must be boolean, got: '.gettype($status).' value: '.var_export($status, true));
+                    $this->assertTrue($status);
+                } catch (ExpectationFailedException $e) {
+                    throw $e;
+                }
+
+                return true;
+            });
+
+        $product->save();
+    });
+
+    it('indexes product status as boolean false on update', function () {
+        config(['elasticsearch.enabled' => false]);
+
+        $product = Product::factory()->withInitialValues()->create(['status' => 1]);
+
+        config(['elasticsearch.enabled' => true]);
+
+        $product->status = 0;
+
+        ElasticSearch::shouldReceive('index')
+            ->once()
+            ->withArgs(function ($args) {
+                try {
+                    $this->assertArrayHasKey('body', $args);
+                    $status = $args['body']['status'];
+
+                    $this->assertIsBool($status, 'Product status sent to ES must be boolean, got: '.gettype($status).' value: '.var_export($status, true));
+                    $this->assertFalse($status);
+                } catch (ExpectationFailedException $e) {
+                    throw $e;
+                }
+
+                return true;
+            });
+
+        $product->save();
+    });
+
+    it('indexes attribute_family status as boolean on update', function () {
+        config(['elasticsearch.enabled' => false]);
+
+        $product = Product::factory()->withInitialValues()->create();
+
+        config(['elasticsearch.enabled' => true]);
+
+        $product->status = 0;
+
+        ElasticSearch::shouldReceive('index')
+            ->once()
+            ->withArgs(function ($args) {
+                try {
+                    $this->assertArrayHasKey('body', $args);
+
+                    if (isset($args['body']['attribute_family']['status'])) {
+                        $familyStatus = $args['body']['attribute_family']['status'];
+                        $this->assertIsBool($familyStatus, 'attribute_family.status sent to ES must be boolean, got: '.gettype($familyStatus));
+                    }
+                } catch (ExpectationFailedException $e) {
+                    throw $e;
+                }
+
+                return true;
+            });
+
+        $product->save();
+    });
+});
+
+describe('ProductIndexer maps status as boolean type for ES8 (Issue #243)', function () {
+
+    it('uses boolean type for status field mapping regardless of database driver', function () {
+        config(['elasticsearch.enabled' => false]);
+
+        Product::factory()->create();
+
+        config(['elasticsearch.enabled' => true]);
+
+        $indicesMock = Mockery::mock('Elastic\Elasticsearch\Endpoints\Indices');
+
+        ElasticSearch::shouldReceive('indices')->andReturn($indicesMock)->between(1, 5);
+
+        $indicesMockResponse = Mockery::mock('Elastic\Elasticsearch\Response\Elasticsearch');
+
+        $indicesMock->shouldReceive('exists')->andReturn($indicesMockResponse);
+        $indicesMockResponse->shouldReceive('asBool')->andReturn(false);
+
+        $indicesMock->shouldReceive('create')
+            ->once()
+            ->withArgs(function ($args) {
+                try {
+                    $this->assertArrayHasKey('body', $args);
+                    $this->assertArrayHasKey('mappings', $args['body']);
+
+                    $properties = $args['body']['mappings']['properties'];
+
+                    // Top-level status must be boolean
+                    $this->assertEquals(['type' => 'boolean'], $properties['status']);
+
+                    // attribute_family.status must also be boolean
+                    $this->assertEquals(
+                        ['type' => 'boolean'],
+                        $properties['attribute_family']['properties']['status']
+                    );
+                } catch (ExpectationFailedException $e) {
+                    $this->fail($e->getMessage());
+                }
+
+                return true;
+            });
+
+        ElasticSearch::shouldReceive('search')->andReturn([
+            'hits' => [
+                'total' => 0,
+                'hits'  => [],
+            ],
+            '_scroll_id' => '83h84747',
+        ])->zeroOrMoreTimes();
+
+        ElasticSearch::shouldReceive('scroll')->andReturn([
+            'hits' => [
+                'hits' => [],
+            ],
+        ])->zeroOrMoreTimes();
+
+        ElasticSearch::shouldReceive('bulk')->zeroOrMoreTimes();
+
+        Artisan::call('unopim:product:index');
+    });
+
+    it('casts status to boolean during bulk indexing', function () {
+        config(['elasticsearch.enabled' => false]);
+
+        Product::factory()->create(['status' => 1]);
+
+        config(['elasticsearch.enabled' => true]);
+
+        $indicesMock = Mockery::mock('Elastic\Elasticsearch\Endpoints\Indices');
+        ElasticSearch::shouldReceive('indices')->andReturn($indicesMock)->between(1, 5);
+
+        $indicesMockResponse = Mockery::mock('Elastic\Elasticsearch\Response\Elasticsearch');
+        $indicesMock->shouldReceive('exists')->andReturn($indicesMockResponse);
+        $indicesMockResponse->shouldReceive('asBool')->andReturn(true);
+
+        ElasticSearch::shouldReceive('search')->andReturn([
+            'hits' => [
+                'total' => 0,
+                'hits'  => [],
+            ],
+            '_scroll_id' => 'test_scroll',
+        ])->zeroOrMoreTimes();
+
+        ElasticSearch::shouldReceive('scroll')->andReturn([
+            'hits' => [
+                'hits' => [],
+            ],
+        ])->zeroOrMoreTimes();
+
+        ElasticSearch::shouldReceive('bulk')
+            ->between(1, 10000)
+            ->withArgs(function ($args) {
+                $this->assertIsArray($args);
+                $this->assertArrayHasKey('body', $args);
+
+                // The product body is at index 1 (index 0 is the index action)
+                if (isset($args['body'][1])) {
+                    $productBody = $args['body'][1];
+
+                    if (isset($productBody['status'])) {
+                        $this->assertIsBool(
+                            $productBody['status'],
+                            'Bulk indexed product status must be boolean, got: '.gettype($productBody['status'])
+                        );
+                    }
+                }
+
+                return true;
+            });
+
+        Artisan::call('unopim:product:index');
+    });
+});

--- a/packages/Webkul/ElasticSearch/tests/Feature/ProductIndexTest.php
+++ b/packages/Webkul/ElasticSearch/tests/Feature/ProductIndexTest.php
@@ -91,7 +91,15 @@ it('should index the product to elastic when product is created', function () {
 
                 $this->assertEquals('testing_products', $args['index']);
                 $this->assertEquals($product->id, $args['id']);
-                $this->assertEquals($product->toArray(), $args['body']);
+
+                $expectedBody = $product->toArray();
+                // Observer sanitizes status to boolean for ES8 compatibility
+                $expectedBody['status'] = (bool) $expectedBody['status'];
+                if (isset($expectedBody['attribute_family']['status'])) {
+                    $expectedBody['attribute_family']['status'] = (bool) $expectedBody['attribute_family']['status'];
+                }
+
+                $this->assertEquals($expectedBody, $args['body']);
             } catch (ExpectationFailedException $e) {
                 throw $e;
             }
@@ -124,6 +132,12 @@ it('should index the product to elastic when product is updated', function () {
                 $this->assertEquals($product->id, $args['id']);
 
                 $productArray = $product->toArray();
+
+                // Observer sanitizes status to boolean for ES8 compatibility
+                $productArray['status'] = (bool) $productArray['status'];
+                if (isset($productArray['attribute_family']['status'])) {
+                    $productArray['attribute_family']['status'] = (bool) $productArray['attribute_family']['status'];
+                }
 
                 // According to indexing format we need to change the sku key to sku-text according to normalizer
                 $productArray['values']['common']['sku-text'] = $product->sku;

--- a/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
+++ b/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
@@ -713,8 +713,10 @@ test('7.3 - Open AI Assistance modal and verify fields', async ({ adminPage }) =
   // Verify AI Assistance modal fields — wait for modal to fully render
   await expect(adminPage.locator('#app').getByText('AI Assistance')).toBeVisible({ timeout: 10000 });
   await expect(adminPage.locator('#app').getByText('Default Prompt')).toBeVisible({ timeout: 10000 });
-  // "System Prompt" collapsible header is always visible once the modal renders
-  await expect(adminPage.locator('#app').getByText('System Prompt', { exact: true })).toBeVisible({ timeout: 10000 });
+  // "System Prompt" collapsible header — DOM structure is:
+  // <span> System Prompt <span>(Selected Prompt Name)</span></span>
+  // Use filter+hasText to match the outer span by its partial text content
+  await expect(adminPage.locator('#app span').filter({ hasText: /^\s*System Prompt\s*\(/ }).first()).toBeVisible({ timeout: 10000 });
   await expect(adminPage.getByRole('button', { name: 'Generate' })).toBeVisible({ timeout: 10000 });
   await expect(adminPage.locator('.multiselect').first()).toBeVisible({ timeout: 10000 });
 

--- a/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
+++ b/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
@@ -6,128 +6,90 @@ const { navigateTo, generateUid, clickSaveAndExpect } = require('../../utils/hel
  * ES8 rejects integer 1/0 for boolean fields — requires true/false.
  *
  * This test verifies that creating and running a product export with a status
- * filter ("Enable") does not fail.
+ * filter ("Enable"/"Disable") does not fail.
  */
+
+/**
+ * Helper: Create a product export, apply a status filter, run export, and clean up.
+ */
+async function createExportWithStatusFilter(adminPage, code, statusLabel) {
+  // Navigate to exports and create a new product export
+  await navigateTo(adminPage, 'exports');
+  await adminPage.getByRole('link', { name: 'Create Export' }).click();
+
+  // Fill in export code
+  await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
+
+  // Select file format — CSV
+  await adminPage.locator('input[name="filters[file_format]"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
+  await adminPage.getByRole('option', { name: 'CSV' }).locator('span').first().click();
+
+  // Enable "With Media"
+  await adminPage.locator('div').filter({ hasText: /^With Media$/ }).locator('div').click();
+
+  // Save the export
+  await clickSaveAndExpect(adminPage, 'Save Export', /Export created successfully/i);
+
+  // Now on the edit page — set the Status filter
+  const statusSelect = adminPage.locator('input[name="filters[status]"], select[name="filters[status]"]')
+    .locator('..')
+    .locator('.multiselect__placeholder, .multiselect__single, .multiselect__tags')
+    .first();
+
+  // Status filter must be present — assert, don't skip
+  await expect(statusSelect, 'Status filter control should be visible so Issue #243 is actually exercised').toBeVisible({ timeout: 5000 });
+
+  await statusSelect.click();
+  await adminPage.getByRole('option', { name: new RegExp(statusLabel, 'i') }).locator('span').first().click();
+
+  // Save again with the status filter applied
+  await adminPage.getByRole('button', { name: /Save Export/i }).click();
+  await adminPage.waitForLoadState('networkidle');
+
+  // Run the export — this is where the ES8 bug would manifest
+  const exportNowBtn = adminPage.getByRole('button', { name: 'Export Now' });
+  await expect(exportNowBtn).toBeVisible({ timeout: 5000 });
+  await exportNowBtn.click();
+
+  // The export should be queued successfully, not fail with ES boolean error
+  await expect(adminPage.locator('#app').getByText(/Job queued/i)).toBeVisible({ timeout: 20000 });
+}
+
+/**
+ * Helper: Delete an export job by code via search + delete action.
+ */
+async function deleteExport(adminPage, code) {
+  await navigateTo(adminPage, 'exports');
+  await adminPage.getByRole('textbox', { name: 'Search' }).fill(code);
+  await adminPage.keyboard.press('Enter');
+  await adminPage.waitForLoadState('networkidle');
+  const deleteBtn = adminPage.locator('span[title="Delete"]').first();
+  if (await deleteBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await deleteBtn.click();
+    await adminPage.getByRole('button', { name: 'Delete' }).click();
+    await expect(adminPage.locator('#app').getByText(/Export deleted successfully/i)).toBeVisible({ timeout: 20000 });
+  }
+}
+
 test.describe('Export with Status Filter (Issue #243)', () => {
 
   test('Create Product Export with Status filter set to Enable and run export', async ({ adminPage }) => {
     const uid = generateUid();
     const code = `exp-status-${uid}`;
 
-    // Navigate to exports and create a new product export
-    await navigateTo(adminPage, 'exports');
-    await adminPage.getByRole('link', { name: 'Create Export' }).click();
+    await createExportWithStatusFilter(adminPage, code, 'Enable');
 
-    // Fill in export code
-    await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
-
-    // Select file format — CSV
-    await adminPage.locator('input[name="filters[file_format]"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
-    await adminPage.getByRole('option', { name: 'CSV' }).locator('span').first().click();
-
-    // Enable "With Media"
-    await adminPage.locator('div').filter({ hasText: /^With Media$/ }).locator('div').click();
-
-    // Save the export
-    await clickSaveAndExpect(adminPage, 'Save Export', /Export created successfully/i);
-
-    // Now on the edit page — set the Status filter to "Enable"
-    const statusSelect = adminPage.locator('input[name="filters[status]"], select[name="filters[status]"]')
-      .locator('..')
-      .locator('.multiselect__placeholder, .multiselect__single, .multiselect__tags')
-      .first();
-
-    // Try to find and set the status filter
-    const statusFilterExists = await statusSelect.isVisible({ timeout: 5000 }).catch(() => false);
-
-    if (statusFilterExists) {
-      await statusSelect.click();
-      await adminPage.getByRole('option', { name: /Enable/i }).locator('span').first().click();
-
-      // Save again with the status filter applied
-      await adminPage.getByRole('button', { name: /Save Export/i }).click();
-      await adminPage.waitForLoadState('networkidle');
-    }
-
-    // Run the export — this is where the ES8 bug would manifest
-    const exportNowBtn = adminPage.getByRole('button', { name: 'Export Now' });
-    if (await exportNowBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await exportNowBtn.click();
-
-      // The export should be queued successfully, not fail with ES boolean error
-      await expect(adminPage.locator('#app').getByText(/Job queued/i)).toBeVisible({ timeout: 20000 });
-    }
-
-    // Cleanup — delete the export
-    await navigateTo(adminPage, 'exports');
-    await adminPage.getByRole('textbox', { name: 'Search' }).fill(code);
-    await adminPage.keyboard.press('Enter');
-    await adminPage.waitForLoadState('networkidle');
-
-    const deleteBtn = adminPage.locator('span[title="Delete"]').first();
-    if (await deleteBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await deleteBtn.click();
-      await adminPage.getByRole('button', { name: 'Delete' }).click();
-      await expect(adminPage.locator('#app').getByText(/Export deleted successfully/i)).toBeVisible({ timeout: 20000 });
-    }
+    // Cleanup
+    await deleteExport(adminPage, code);
   });
 
   test('Create Product Export with Status filter set to Disable and run export', async ({ adminPage }) => {
     const uid = generateUid();
     const code = `exp-dis-${uid}`;
 
-    // Navigate to exports and create a new product export
-    await navigateTo(adminPage, 'exports');
-    await adminPage.getByRole('link', { name: 'Create Export' }).click();
-
-    // Fill in export code
-    await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
-
-    // Select file format — CSV
-    await adminPage.locator('input[name="filters[file_format]"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
-    await adminPage.getByRole('option', { name: 'CSV' }).locator('span').first().click();
-
-    // Enable "With Media"
-    await adminPage.locator('div').filter({ hasText: /^With Media$/ }).locator('div').click();
-
-    // Save the export
-    await clickSaveAndExpect(adminPage, 'Save Export', /Export created successfully/i);
-
-    // Now on the edit page — set the Status filter to "Disable"
-    const statusSelect = adminPage.locator('input[name="filters[status]"], select[name="filters[status]"]')
-      .locator('..')
-      .locator('.multiselect__placeholder, .multiselect__single, .multiselect__tags')
-      .first();
-
-    const statusFilterExists = await statusSelect.isVisible({ timeout: 5000 }).catch(() => false);
-
-    if (statusFilterExists) {
-      await statusSelect.click();
-      await adminPage.getByRole('option', { name: /Disable/i }).locator('span').first().click();
-
-      // Save again with the status filter applied
-      await adminPage.getByRole('button', { name: /Save Export/i }).click();
-      await adminPage.waitForLoadState('networkidle');
-    }
-
-    // Run the export
-    const exportNowBtn = adminPage.getByRole('button', { name: 'Export Now' });
-    if (await exportNowBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await exportNowBtn.click();
-      await expect(adminPage.locator('#app').getByText(/Job queued/i)).toBeVisible({ timeout: 20000 });
-    }
+    await createExportWithStatusFilter(adminPage, code, 'Disable');
 
     // Cleanup
-    await navigateTo(adminPage, 'exports');
-    await adminPage.getByRole('textbox', { name: 'Search' }).fill(code);
-    await adminPage.keyboard.press('Enter');
-    await adminPage.waitForLoadState('networkidle');
-
-    const deleteBtn = adminPage.locator('span[title="Delete"]').first();
-    if (await deleteBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await deleteBtn.click();
-      await adminPage.getByRole('button', { name: 'Delete' }).click();
-      await expect(adminPage.locator('#app').getByText(/Export deleted successfully/i)).toBeVisible({ timeout: 20000 });
-    }
+    await deleteExport(adminPage, code);
   });
 });

--- a/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
+++ b/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
@@ -20,6 +20,10 @@ async function createExportWithStatusFilter(adminPage, code, statusLabel) {
   // Fill in export code
   await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
 
+  // Select entity type — Products (only products have the status filter)
+  await adminPage.locator('#export-type').locator('.multiselect__single, .multiselect__placeholder').first().click();
+  await adminPage.getByRole('option', { name: 'Products' }).locator('span').first().click();
+
   // Select file format — CSV
   await adminPage.locator('input[name="filters[file_format]"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
   await adminPage.getByRole('option', { name: 'CSV' }).locator('span').first().click();

--- a/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
+++ b/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
@@ -31,8 +31,12 @@ async function createExportWithStatusFilter(adminPage, code, statusLabel) {
   // Enable "With Media"
   await adminPage.locator('div').filter({ hasText: /^With Media$/ }).locator('div').click();
 
-  // Save the export
+  // Save the export — redirects to the show/detail page
   await clickSaveAndExpect(adminPage, 'Save Export', /Export created successfully/i);
+
+  // Navigate to the edit page to set the Status filter
+  await adminPage.getByRole('link', { name: 'Edit' }).click();
+  await adminPage.waitForLoadState('networkidle');
 
   // Now on the edit page — set the Status filter
   const statusSelect = adminPage.locator('input[name="filters[status]"], select[name="filters[status]"]')
@@ -46,7 +50,7 @@ async function createExportWithStatusFilter(adminPage, code, statusLabel) {
   await statusSelect.click();
   await adminPage.getByRole('option', { name: new RegExp(statusLabel, 'i') }).locator('span').first().click();
 
-  // Save again with the status filter applied
+  // Save with the status filter applied — redirects back to show page
   await adminPage.getByRole('button', { name: /Save Export/i }).click();
   await adminPage.waitForLoadState('networkidle');
 

--- a/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
+++ b/tests/e2e-pw/tests/04-datatransfer/export-status-filter.spec.js
@@ -1,0 +1,133 @@
+const { test, expect } = require('../../utils/fixtures');
+const { navigateTo, generateUid, clickSaveAndExpect } = require('../../utils/helpers');
+
+/**
+ * Issue #243: Export Job fails with Elasticsearch 8 when filtering by boolean status.
+ * ES8 rejects integer 1/0 for boolean fields — requires true/false.
+ *
+ * This test verifies that creating and running a product export with a status
+ * filter ("Enable") does not fail.
+ */
+test.describe('Export with Status Filter (Issue #243)', () => {
+
+  test('Create Product Export with Status filter set to Enable and run export', async ({ adminPage }) => {
+    const uid = generateUid();
+    const code = `exp-status-${uid}`;
+
+    // Navigate to exports and create a new product export
+    await navigateTo(adminPage, 'exports');
+    await adminPage.getByRole('link', { name: 'Create Export' }).click();
+
+    // Fill in export code
+    await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
+
+    // Select file format — CSV
+    await adminPage.locator('input[name="filters[file_format]"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
+    await adminPage.getByRole('option', { name: 'CSV' }).locator('span').first().click();
+
+    // Enable "With Media"
+    await adminPage.locator('div').filter({ hasText: /^With Media$/ }).locator('div').click();
+
+    // Save the export
+    await clickSaveAndExpect(adminPage, 'Save Export', /Export created successfully/i);
+
+    // Now on the edit page — set the Status filter to "Enable"
+    const statusSelect = adminPage.locator('input[name="filters[status]"], select[name="filters[status]"]')
+      .locator('..')
+      .locator('.multiselect__placeholder, .multiselect__single, .multiselect__tags')
+      .first();
+
+    // Try to find and set the status filter
+    const statusFilterExists = await statusSelect.isVisible({ timeout: 5000 }).catch(() => false);
+
+    if (statusFilterExists) {
+      await statusSelect.click();
+      await adminPage.getByRole('option', { name: /Enable/i }).locator('span').first().click();
+
+      // Save again with the status filter applied
+      await adminPage.getByRole('button', { name: /Save Export/i }).click();
+      await adminPage.waitForLoadState('networkidle');
+    }
+
+    // Run the export — this is where the ES8 bug would manifest
+    const exportNowBtn = adminPage.getByRole('button', { name: 'Export Now' });
+    if (await exportNowBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await exportNowBtn.click();
+
+      // The export should be queued successfully, not fail with ES boolean error
+      await expect(adminPage.locator('#app').getByText(/Job queued/i)).toBeVisible({ timeout: 20000 });
+    }
+
+    // Cleanup — delete the export
+    await navigateTo(adminPage, 'exports');
+    await adminPage.getByRole('textbox', { name: 'Search' }).fill(code);
+    await adminPage.keyboard.press('Enter');
+    await adminPage.waitForLoadState('networkidle');
+
+    const deleteBtn = adminPage.locator('span[title="Delete"]').first();
+    if (await deleteBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await deleteBtn.click();
+      await adminPage.getByRole('button', { name: 'Delete' }).click();
+      await expect(adminPage.locator('#app').getByText(/Export deleted successfully/i)).toBeVisible({ timeout: 20000 });
+    }
+  });
+
+  test('Create Product Export with Status filter set to Disable and run export', async ({ adminPage }) => {
+    const uid = generateUid();
+    const code = `exp-dis-${uid}`;
+
+    // Navigate to exports and create a new product export
+    await navigateTo(adminPage, 'exports');
+    await adminPage.getByRole('link', { name: 'Create Export' }).click();
+
+    // Fill in export code
+    await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
+
+    // Select file format — CSV
+    await adminPage.locator('input[name="filters[file_format]"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
+    await adminPage.getByRole('option', { name: 'CSV' }).locator('span').first().click();
+
+    // Enable "With Media"
+    await adminPage.locator('div').filter({ hasText: /^With Media$/ }).locator('div').click();
+
+    // Save the export
+    await clickSaveAndExpect(adminPage, 'Save Export', /Export created successfully/i);
+
+    // Now on the edit page — set the Status filter to "Disable"
+    const statusSelect = adminPage.locator('input[name="filters[status]"], select[name="filters[status]"]')
+      .locator('..')
+      .locator('.multiselect__placeholder, .multiselect__single, .multiselect__tags')
+      .first();
+
+    const statusFilterExists = await statusSelect.isVisible({ timeout: 5000 }).catch(() => false);
+
+    if (statusFilterExists) {
+      await statusSelect.click();
+      await adminPage.getByRole('option', { name: /Disable/i }).locator('span').first().click();
+
+      // Save again with the status filter applied
+      await adminPage.getByRole('button', { name: /Save Export/i }).click();
+      await adminPage.waitForLoadState('networkidle');
+    }
+
+    // Run the export
+    const exportNowBtn = adminPage.getByRole('button', { name: 'Export Now' });
+    if (await exportNowBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await exportNowBtn.click();
+      await expect(adminPage.locator('#app').getByText(/Job queued/i)).toBeVisible({ timeout: 20000 });
+    }
+
+    // Cleanup
+    await navigateTo(adminPage, 'exports');
+    await adminPage.getByRole('textbox', { name: 'Search' }).fill(code);
+    await adminPage.keyboard.press('Enter');
+    await adminPage.waitForLoadState('networkidle');
+
+    const deleteBtn = adminPage.locator('span[title="Delete"]').first();
+    if (await deleteBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await deleteBtn.click();
+      await adminPage.getByRole('button', { name: 'Delete' }).click();
+      await expect(adminPage.locator('#app').getByText(/Export deleted successfully/i)).toBeVisible({ timeout: 20000 });
+    }
+  });
+});


### PR DESCRIPTION
## Issue Reference
Fixes #243

## Summary
- Elasticsearch 8 rejects integer `1`/`0` for boolean fields, requiring strict `true`/`false` values
- Export jobs with status filters and product indexing were failing with `Can't parse boolean value [1], expected [true] or [false]`
- Standardized all status values sent to Elasticsearch to use native PHP booleans

## Approach
- **ElasticProductCursor**: Changed status filter from integer `1`/`0` to boolean `true`/`false`, switched from `terms` to `term` query
- **ProductCursor** (non-ES): Changed to boolean for consistency across database drivers
- **Product Observer**: Replaced driver-specific `switch(DB::getDriverName())` with a unified `sanitizeProductArray()` method that casts status to `(bool)`. Applied to both `created()` and `updated()` events (the `updated()` path was previously missing any boolean conversion)
- **ProductIndexer**: Standardized status mapping to `boolean` type for all DB drivers (was `long` for MySQL, `boolean` only for PostgreSQL). Added `(bool)` cast during bulk indexing

## Code Changes
- `packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php`
- `packages/Webkul/DataTransfer/src/Helpers/Sources/Export/ProductCursor.php`
- `packages/Webkul/ElasticSearch/src/Console/Command/ProductIndexer.php`
- `packages/Webkul/ElasticSearch/src/Observers/Product.php`
- `packages/Webkul/ElasticSearch/tests/Feature/ProductIndexTest.php` (updated to expect boolean)

## Tests Added
- **Pest**: `ElasticProductCursorBooleanTest.php` — 3 tests verifying boolean values in ES queries
- **Pest**: `ProductBooleanStatusTest.php` — 5 tests verifying observer and indexer boolean behavior
- **Playwright**: `export-status-filter.spec.js` — 2 E2E tests for export with Enable/Disable status filter

## Test Plan
- [x] Pest tests pass (8 new tests, 11 total with existing)
- [x] Pint formatting passes with zero issues
- [x] Playwright E2E tests pass (2 new tests)
- [x] No regressions in existing DataTransfer and ElasticSearch test suites

## Note
Supersedes #254 with the addition of comprehensive test coverage.