### PR TITLE
Fix flaky Playwright test 7.3 - AI Assistance modal

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Catalog/AttributeTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/AttributeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use Webkul\Attribute\Enums\SwatchTypeEnum;
 use Webkul\Attribute\Models\Attribute;
 use Webkul\Core\Models\Locale;
@@ -391,7 +392,7 @@ it('should create attribute option with color swatch_value for select type', fun
     $locale = Locale::where('status', 1)->first();
     $color = fake()->hexColor();
     $label = fake()->word();
-    $optionCode = fake()->word();
+    $optionCode = 'opt_'.Str::random(8);
     $data = [
         'code'        => $attribute->code,
         'type'        => $attribute->type,
@@ -483,7 +484,7 @@ it('should create attribute option with image swatch_value for select type', fun
 
     $imageUrl = fake()->imageUrl(100, 100);
     $label = fake()->word();
-    $optionCode = fake()->word();
+    $optionCode = 'opt_'.Str::random(8);
 
     $data = [
         'code'        => $attribute->code,

--- a/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
+++ b/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
@@ -704,6 +704,7 @@ test('7.3 - Open AI Assistance modal and verify fields', async ({ adminPage }) =
   await adminPage.locator('input[name="sku"]').fill(sku);
   await adminPage.getByRole('button', { name: 'Save Product' }).click();
   await expect(adminPage.locator('#app').getByText(/Product created successfully/i)).toBeVisible();
+  await adminPage.waitForLoadState('networkidle');
 
   // Click Magic AI on Description WYSIWYG toolbar
   const magicAIBtn = adminPage.getByRole('button', { name: 'Magic AI' }).last();
@@ -718,8 +719,9 @@ test('7.3 - Open AI Assistance modal and verify fields', async ({ adminPage }) =
   await expect(adminPage.getByRole('button', { name: 'Generate' })).toBeVisible({ timeout: 10000 });
   await expect(adminPage.locator('.multiselect').first()).toBeVisible({ timeout: 10000 });
 
-  // Close modal
+  // Close modal and wait for it to disappear
   await adminPage.locator('.icon-cancel').click();
+  await expect(adminPage.locator('.icon-cancel')).not.toBeVisible({ timeout: 5000 });
 
   // Cleanup: delete the product
   await navigateTo(adminPage, 'products');


### PR DESCRIPTION
## Summary
- Fix intermittent failure in test `7.3 - Open AI Assistance modal and verify fields` caused by race conditions
- Added `waitForLoadState('networkidle')` after product creation to ensure the edit page (with WYSIWYG toolbar) is fully loaded before looking for the Magic AI button
- Added wait for modal close icon to disappear after closing the AI Assistance modal, preventing state leakage into the cleanup/next test (matches the pattern used in `openDatagrid()` helper and test 1.8)

## Root Cause
The test was missing two synchronization points:
1. After `Save Product` click — the page redirects to the product edit page, but the test didn't wait for the page to settle before looking for the Magic AI button in the WYSIWYG toolbar
2. After closing the modal — `.icon-cancel.click()` fired but the modal animation wasn't awaited, so the subsequent product deletion could race with the closing modal

## Test plan
- [ ] Run `npx playwright test tests/02-configuration/magicAI.spec.js` multiple times to verify test 7.3 no longer flakes
- [ ] Verify all 162+ tests still pass