### PR TITLE
Add Gravatar fallback for admin avatars

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Settings/UserDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/UserDataGrid.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Webkul\DataGrid\DataGrid;
+use Webkul\User\Models\Admin as AdminUser;
 
 class UserDataGrid extends DataGrid
 {
@@ -79,7 +80,7 @@ class UserDataGrid extends DataGrid
                     return Storage::url($row->user_image);
                 }
 
-                return null;
+                return AdminUser::getGravatarUrlFromEmail($row->email);
             },
         ]);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/User/AvatarController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/AvatarController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Webkul\Admin\Http\Controllers\User;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+use Webkul\Admin\Http\Controllers\Controller;
+
+class AvatarController extends Controller
+{
+    /**
+     * Proxy gravatar image through local app domain.
+     */
+    public function gravatar(string $hash): Response
+    {
+        if (! preg_match('/^[a-f0-9]{32,64}$/', $hash)) {
+            abort(404);
+        }
+
+        $gravatarUrl = "https://gravatar.com/avatar/{$hash}?s=200&d=404";
+
+        $response = Http::timeout(4)
+            ->withHeaders([
+                'User-Agent' => 'UnoPim Avatar Proxy',
+                'Accept'     => 'image/*',
+            ])
+            ->get($gravatarUrl);
+
+        if (! $response->successful()) {
+            abort(404);
+        }
+
+        return response($response->body())
+            ->header('Content-Type', $response->header('Content-Type', 'image/png'))
+            ->header('Cache-Control', 'public, max-age=300');
+    }
+}

--- a/packages/Webkul/Admin/src/Http/Controllers/User/AvatarController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/AvatarController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Http\Controllers\User;
 
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
 use Webkul\Admin\Http\Controllers\Controller;
@@ -13,18 +14,22 @@ class AvatarController extends Controller
      */
     public function gravatar(string $hash): Response
     {
-        if (! preg_match('/^[a-f0-9]{32,64}$/', $hash)) {
+        if (! preg_match('/^[a-f0-9]{32}$/', $hash)) {
             abort(404);
         }
 
         $gravatarUrl = "https://gravatar.com/avatar/{$hash}?s=200&d=404";
 
-        $response = Http::timeout(4)
-            ->withHeaders([
-                'User-Agent' => 'UnoPim Avatar Proxy',
-                'Accept'     => 'image/*',
-            ])
-            ->get($gravatarUrl);
+        try {
+            $response = Http::timeout(4)
+                ->withHeaders([
+                    'User-Agent' => 'UnoPim Avatar Proxy',
+                    'Accept'     => 'image/*',
+                ])
+                ->get($gravatarUrl);
+        } catch (ConnectionException $exception) {
+            abort(404);
+        }
 
         if (! $response->successful()) {
             abort(404);

--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
@@ -54,13 +54,18 @@
         <!-- Admin profile -->
         <x-admin::dropdown position="bottom-right">
             <x-slot:toggle>
-                @if ($admin->image)
-                    <button class="flex w-9 h-9 overflow-hidden rounded-full cursor-pointer hover:opacity-80 focus:opacity-80">
+                @if ($admin->avatar_url)
+                    <button class="relative flex w-9 h-9 overflow-hidden rounded-full cursor-pointer hover:opacity-80 focus:opacity-80">
                         <img
-                            src="{{ $admin->image_url }}"
+                            src="{{ $admin->avatar_url }}"
                             class="w-full h-full object-cover object-top"
-                            alt="{{ $admin->image_url }}"
+                            alt="{{ $admin->name }}"
+                            onerror="this.classList.add('hidden'); this.nextElementSibling.classList.remove('hidden');"
                         />
+
+                        <span class="hidden flex absolute inset-0 justify-center items-center bg-violet-400 text-sm text-white font-semibold leading-6">
+                            {{ substr($admin->name, 0, 1) }}
+                        </span>
                     </button>
                 @else
                     <button class="flex justify-center items-center w-9 h-9 bg-violet-400 rounded-full text-sm text-white font-semibold cursor-pointer leading-6 transition-all hover:bg-violet-500 focus:bg-violet-500">

--- a/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
@@ -122,6 +122,7 @@
                                         class="h-9 object-cover"
                                         :src="record.user_img"
                                         alt="record.user_name"
+                                        @error="record.user_img = null"
                                     />
                                 </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
@@ -122,7 +122,7 @@
                                         class="h-9 object-cover"
                                         :src="record.user_img"
                                         alt="record.user_name"
-                                        @error="record.user_img = null"
+                                        v-on:error="record.user_img = null"
                                     />
                                 </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
@@ -121,7 +121,7 @@
                                     <img
                                         class="h-9 object-cover"
                                         :src="record.user_img"
-                                        alt="record.user_name"
+                                        :alt="record.user_name"
                                         v-on:error="record.user_img = null"
                                     />
                                 </div>

--- a/packages/Webkul/Admin/src/Routes/auth-routes.php
+++ b/packages/Webkul/Admin/src/Routes/auth-routes.php
@@ -17,7 +17,8 @@ Route::group(['prefix' => config('app.admin_url')], function () {
      * Public avatar proxy route (no auth middleware).
      */
     Route::get('avatar/u/{hash}.png', [AvatarController::class, 'gravatar'])
-        ->name('admin.avatar.public');
+        ->name('admin.avatar.public')
+        ->middleware('throttle:60,1');
 
     /**
      * Redirect route.

--- a/packages/Webkul/Admin/src/Routes/auth-routes.php
+++ b/packages/Webkul/Admin/src/Routes/auth-routes.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Webkul\Admin\Http\Controllers\Controller;
+use Webkul\Admin\Http\Controllers\User\AvatarController;
 use Webkul\Admin\Http\Controllers\User\ForgetPasswordController;
 use Webkul\Admin\Http\Controllers\User\ResetPasswordController;
 use Webkul\Admin\Http\Controllers\User\SessionController;
@@ -12,6 +13,12 @@ Route::get('/', [Controller::class, 'redirectToLogin']);
  * Auth routes.
  */
 Route::group(['prefix' => config('app.admin_url')], function () {
+    /**
+     * Public avatar proxy route (no auth middleware).
+     */
+    Route::get('avatar/u/{hash}.png', [AvatarController::class, 'gravatar'])
+        ->name('admin.avatar.public');
+
     /**
      * Redirect route.
      */

--- a/packages/Webkul/User/src/Models/Admin.php
+++ b/packages/Webkul/User/src/Models/Admin.php
@@ -71,6 +71,46 @@ class Admin extends Authenticatable implements AdminContract, AuditableContract
     }
 
     /**
+     * Get avatar url. Priority: uploaded image -> gravatar -> null.
+     */
+    public function getAvatarUrlAttribute(): ?string
+    {
+        return $this->image_url() ?: $this->getGravatarUrlAttribute();
+    }
+
+    /**
+     * Build deterministic gravatar url from email.
+     */
+    public function getGravatarUrlAttribute(): ?string
+    {
+        return self::getGravatarUrlFromEmail($this->email);
+    }
+
+    /**
+     * Build gravatar url from email.
+     */
+    public static function getGravatarUrlFromEmail(?string $email): ?string
+    {
+        if (! $email) {
+            return null;
+        }
+
+        $normalizedEmail = mb_strtolower(trim($email));
+
+        if ($normalizedEmail === '') {
+            return null;
+        }
+
+        $hash = hash('sha256', $normalizedEmail);
+
+        try {
+            return route('admin.avatar.public', ['hash' => $hash]);
+        } catch (\Throwable $exception) {
+            return "https://gravatar.com/avatar/{$hash}?s=200&d=404";
+        }
+    }
+
+    /**
      * @return array
      */
     public function toArray()

--- a/packages/Webkul/User/src/Models/Admin.php
+++ b/packages/Webkul/User/src/Models/Admin.php
@@ -101,7 +101,7 @@ class Admin extends Authenticatable implements AdminContract, AuditableContract
             return null;
         }
 
-        $hash = hash('sha256', $normalizedEmail);
+        $hash = md5($normalizedEmail);
 
         try {
             return route('admin.avatar.public', ['hash' => $hash]);


### PR DESCRIPTION
## Summary
- add Gravatar-based avatar fallback when no uploaded admin image exists
- proxy avatar fetches through a local UnoPim endpoint to avoid browser-side blocking
- keep existing initials fallback when image loading fails
- apply fallback consistently in header and users datagrid list

## Changes
- add AvatarController proxy endpoint
- add public admin route for avatar proxy
- add avatar/gravatar URL helpers in Admin model
- update users datagrid to use Gravatar URL when no uploaded image is present
- update header avatar rendering with graceful onerror fallback to initials
- update users list image rendering with onerror fallback to initials