### PR TITLE
Add admin dark mode with manual toggle and browser auto mode

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar_AE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar_AE/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'حسابي',
                 'notifications' => 'إشعارات',
                 'visit-shop'    => 'زيارة متجر',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'عائلات السمات',

--- a/packages/Webkul/Admin/src/Resources/lang/ca_ES/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca_ES/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mi cuenta',
                 'notifications' => 'Notificaciones',
                 'visit-shop'    => 'Visitar tienda',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Familias de atributos',

--- a/packages/Webkul/Admin/src/Resources/lang/da_DK/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/da_DK/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Min konto',
                 'notifications' => 'Notifikationer',
                 'visit-shop'    => 'Besøg butik',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attributfamilier',

--- a/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mein Konto',
                 'notifications' => 'Benachrichtigungen',
                 'visit-shop'    => 'Shop besuchen',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attributfamilien',

--- a/packages/Webkul/Admin/src/Resources/lang/en_AU/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_AU/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'My Account',
                 'notifications' => 'Notifications',
                 'visit-shop'    => 'Visit Shop',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attribute Families',

--- a/packages/Webkul/Admin/src/Resources/lang/en_GB/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_GB/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'My Account',
                 'notifications' => 'Notifications',
                 'visit-shop'    => 'Visit Shop',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attribute Families',

--- a/packages/Webkul/Admin/src/Resources/lang/en_NZ/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_NZ/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'My Account',
                 'notifications' => 'Notifications',
                 'visit-shop'    => 'Visit Shop',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attribute Families',

--- a/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
@@ -2087,6 +2087,9 @@ return [
                 'my-account'    => 'My Account',
                 'notifications' => 'Notifications',
                 'visit-shop'    => 'Visit Shop',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
 
             'sidebar' => [

--- a/packages/Webkul/Admin/src/Resources/lang/es_ES/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es_ES/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mi cuenta',
                 'notifications' => 'Notificaciones',
                 'visit-shop'    => 'Visitar tienda',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Familias de atributos',

--- a/packages/Webkul/Admin/src/Resources/lang/es_VE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es_VE/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mi cuenta',
                 'notifications' => 'Notificaciones',
                 'visit-shop'    => 'Visitar tienda',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Familias de atributos',

--- a/packages/Webkul/Admin/src/Resources/lang/fi_FI/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fi_FI/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Oma Tili',
                 'notifications' => 'Ilmoitukset',
                 'visit-shop'    => 'Vierailu Kaupassa',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attribuuttiperheet',

--- a/packages/Webkul/Admin/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr_FR/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mon compte',
                 'notifications' => 'Notifications',
                 'visit-shop'    => 'Visiter la boutique',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Familles d\'attributs',

--- a/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'मेरा खाता',
                 'notifications' => 'अधिसूचना',
                 'visit-shop'    => 'यात्रा दुकान',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'विशेषण परिवार',

--- a/packages/Webkul/Admin/src/Resources/lang/hr_HR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hr_HR/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Moj račun',
                 'notifications' => 'Obavijesti',
                 'visit-shop'    => 'Posjetite trgovinu',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Grupe atributa',

--- a/packages/Webkul/Admin/src/Resources/lang/id_ID/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/id_ID/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Akun saya',
                 'notifications' => 'Pemberitahuan',
                 'visit-shop'    => 'Kunjungi toko',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Keluarga atribut',

--- a/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Il mio account',
                 'notifications' => 'Notifiche',
                 'visit-shop'    => 'Visita il negozio',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Famiglie di attributi',

--- a/packages/Webkul/Admin/src/Resources/lang/ja_JP/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja_JP/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'マイアカウント',
                 'notifications' => '通知',
                 'visit-shop'    => 'ショップを訪問',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => '属性ファミリー',

--- a/packages/Webkul/Admin/src/Resources/lang/ko_KR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ko_KR/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => '내 계정',
                 'notifications' => '알림',
                 'visit-shop'    => '매장 방문',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => '속성 그룹',

--- a/packages/Webkul/Admin/src/Resources/lang/mn_MN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/mn_MN/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Миний данс',
                 'notifications' => 'Мэдэгдэл',
                 'visit-shop'    => 'Дэлгүүр',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Аттригийн гэр бүлүүд',

--- a/packages/Webkul/Admin/src/Resources/lang/nl_NL/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl_NL/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mijn rekening',
                 'notifications' => 'Meldingen',
                 'visit-shop'    => 'Bezoek de winkel',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Teken families toe',

--- a/packages/Webkul/Admin/src/Resources/lang/no_NO/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/no_NO/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Min konto',
                 'notifications' => 'Varsler',
                 'visit-shop'    => 'Besøk butikk',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Egenskapsfamilier',

--- a/packages/Webkul/Admin/src/Resources/lang/pl_PL/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pl_PL/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Moje Konto',
                 'notifications' => 'Powiadomienia',
                 'visit-shop'    => 'Odwiedź Sklep',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Rodziny Atrybutów',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Minha Conta',
                 'notifications' => 'Notificações',
                 'visit-shop'    => 'Visitar Loja',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Famílias de Atributos',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_PT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_PT/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Minha Conta',
                 'notifications' => 'Notificações',
                 'visit-shop'    => 'Visitar Loja',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Famílias de Atributos',

--- a/packages/Webkul/Admin/src/Resources/lang/ro_RO/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ro_RO/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Contul Meu',
                 'notifications' => 'Notificări',
                 'visit-shop'    => 'Vizitează Magazinul',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Familii de Atribute',

--- a/packages/Webkul/Admin/src/Resources/lang/ru_RU/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ru_RU/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Мой счет',
                 'notifications' => 'Уведомления',
                 'visit-shop'    => 'Посетите магазин',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Атрибут семьи',

--- a/packages/Webkul/Admin/src/Resources/lang/sv_SE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/sv_SE/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Mitt Konto',
                 'notifications' => 'Meddelanden',
                 'visit-shop'    => 'Besök Butik',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Attributfamiljer',

--- a/packages/Webkul/Admin/src/Resources/lang/tl_PH/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tl_PH/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Aking Account',
                 'notifications' => 'Mga Abiso',
                 'visit-shop'    => 'Bumisita sa Tindahan',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Pamilya ng Katangian',

--- a/packages/Webkul/Admin/src/Resources/lang/tr_TR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr_TR/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Hesabım',
                 'notifications' => 'Bildirimler',
                 'visit-shop'    => 'Mağazayı Ziyaret Et',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Öznitelik Aileleri',

--- a/packages/Webkul/Admin/src/Resources/lang/uk_UA/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/uk_UA/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Мій обліковий запис',
                 'notifications' => 'Сповіщення',
                 'visit-shop'    => 'Відвідувати магазин',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Сім\'ї атрибутів',

--- a/packages/Webkul/Admin/src/Resources/lang/vi_VN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi_VN/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => 'Tài khoản của tôi',
                 'notifications' => 'Thông báo',
                 'visit-shop'    => 'Thăm cửa hàng',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => 'Nhóm thuộc tính',

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => '我的账户',
                 'notifications' => '通知',
                 'visit-shop'    => '访问商店',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => '属性家庭',

--- a/packages/Webkul/Admin/src/Resources/lang/zh_TW/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_TW/app.php
@@ -1956,6 +1956,9 @@ return [
                 'my-account'    => '我的帳戶',
                 'notifications' => '通知',
                 'visit-shop'    => '訪問商店',
+                'theme-auto'    => 'Theme: Auto',
+                'theme-dark'    => 'Theme: Dark',
+                'theme-light'   => 'Theme: Light',
             ],
             'sidebar' => [
                 'attribute-families' => '屬性族群',

--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
@@ -21,7 +21,7 @@
                 />
             @else
                 <img
-                    src="{{ request()->cookie('dark_mode') ? unopim_asset('images/dark_logo.svg') : unopim_asset('images/logo.svg') }}"
+                    src="{{ in_array(request()->cookie('dark_mode'), ['1', 'dark'], true) ? unopim_asset('images/dark_logo.svg') : unopim_asset('images/logo.svg') }}"
                     id="logo-image"
                     alt="{{ config('app.name') }}"
                 />
@@ -35,7 +35,7 @@
         <v-dark>
             <div class="flex">
                 <span
-                    class="{{ request()->cookie('dark_mode') ? 'icon-light' : 'icon-dark' }} p-1.5 rounded-md text-2xl cursor-pointer transition-all hover:bg-violet-50 dark:hover:bg-cherry-800"
+                    class="{{ in_array(request()->cookie('dark_mode'), ['1', 'dark'], true) ? 'icon-light' : 'icon-dark' }} p-1.5 rounded-md text-2xl cursor-pointer transition-all hover:bg-violet-50 dark:hover:bg-cherry-800"
                 ></span>
             </div>
         </v-dark>
@@ -132,7 +132,7 @@
                 />
             @else
                 <img
-                    src="{{ request()->cookie('dark_mode') ? unopim_asset('images/dark_logo.svg') : unopim_asset('images/logo.svg') }}"
+                    src="{{ in_array(request()->cookie('dark_mode'), ['1', 'dark'], true) ? unopim_asset('images/dark_logo.svg') : unopim_asset('images/logo.svg') }}"
                     id="logo-image"
                     alt="{{ config('app.name') }}"
                 />
@@ -315,7 +315,8 @@
         <div class="flex">
             <span
                 class="p-1.5 rounded-md text-2xl cursor-pointer transition-all hover:bg-violet-50 dark:hover:bg-cherry-800"
-                :class="[isDarkMode ? 'icon-light' : 'icon-dark']"
+                :class="[toggleIconClass]"
+                :title="toggleTitle"
                 @click="toggle"
             ></span>
         </div>
@@ -327,50 +328,98 @@
 
             data() {
                 return {
-                    isDarkMode: {{ request()->cookie('dark_mode') ?? 0 }},
+                    darkMode: "{{ request()->cookie('dark_mode', 'auto') }}",
 
                     logo: "{{ unopim_asset('images/logo.svg') }}",
 
                     dark_logo: "{{ unopim_asset('images/dark_logo.svg') }}",
+
+                    mediaQuery: null,
                 };
+            },
+
+            computed: {
+                toggleIconClass() {
+                    if (this.darkMode === 'auto') {
+                        return this.isDarkFromBrowser() ? 'icon-light' : 'icon-dark';
+                    }
+
+                    return this.darkMode === 'dark' ? 'icon-light' : 'icon-dark';
+                },
+
+                toggleTitle() {
+                    if (this.darkMode === 'auto') {
+                        return 'Theme: Auto';
+                    }
+
+                    return this.darkMode === 'dark' ? 'Theme: Dark' : 'Theme: Light';
+                },
             },
 
             methods: {
                 toggle() {
-                    this.isDarkMode = parseInt(this.isDarkModeCookie()) ? 0 : 1;
+                    const sequence = ['auto', 'dark', 'light'];
+                    const currentIndex = sequence.indexOf(this.darkMode);
+                    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % sequence.length;
 
-                    var expiryDate = new Date();
+                    this.darkMode = sequence[nextIndex];
 
-                    expiryDate.setMonth(expiryDate.getMonth() + 1);
+                    this.applyTheme(this.darkMode, true);
+                },
 
-                    document.cookie = 'dark_mode=' + this.isDarkMode + '; path=/; expires=' + expiryDate.toGMTString();
+                applyTheme(mode, persist = false) {
+                    const shouldUseDark = mode === 'dark' || (mode === 'auto' && this.isDarkFromBrowser());
 
-                    document.documentElement.classList.toggle('dark', this.isDarkMode === 1);
+                    document.documentElement.classList.toggle('dark', shouldUseDark);
 
-                    if (this.isDarkMode) {
-                        this.$emitter.emit('change-theme', 'dark');
+                    this.$emitter.emit('change-theme', shouldUseDark ? 'dark' : 'light');
 
-                        document.getElementById('logo-image').src = this.dark_logo;
-                    } else {
-                        this.$emitter.emit('change-theme', 'light');
+                    const logoImage = document.getElementById('logo-image');
 
-                        document.getElementById('logo-image').src = this.logo;
+                    if (logoImage) {
+                        logoImage.src = shouldUseDark ? this.dark_logo : this.logo;
+                    }
+
+                    if (persist) {
+                        const expiryDate = new Date();
+
+                        expiryDate.setMonth(expiryDate.getMonth() + 1);
+
+                        document.cookie = `dark_mode=${mode}; path=/; expires=${expiryDate.toUTCString()}`;
                     }
                 },
 
-                isDarkModeCookie() {
-                    const cookies = document.cookie.split(';');
+                isDarkFromBrowser() {
+                    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+                },
 
-                    for (const cookie of cookies) {
-                        const [name, value] = cookie.trim().split('=');
+                normalizeMode(mode) {
+                    if (mode === '1') {
+                        return 'dark';
+                    }
 
-                        if (name === 'dark_mode') {
-                            return value;
+                    if (mode === '0') {
+                        return 'light';
+                    }
+
+                    return ['light', 'dark', 'auto'].includes(mode) ? mode : 'auto';
+                },
+            },
+
+            mounted() {
+                this.darkMode = this.normalizeMode(this.darkMode);
+
+                this.applyTheme(this.darkMode);
+
+                this.mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+                if (this.mediaQuery?.addEventListener) {
+                    this.mediaQuery.addEventListener('change', () => {
+                        if (this.darkMode === 'auto') {
+                            this.applyTheme('auto');
                         }
-                    }
-
-                    return 0;
-                },
+                    });
+                }
             },
         });
     </script>

--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
@@ -1,5 +1,10 @@
 @php
     $admin = auth()->guard('admin')->user();
+    $themeToggleTitles = [
+        'auto'  => trans('admin::app.components.layouts.header.theme-auto'),
+        'dark'  => trans('admin::app.components.layouts.header.theme-dark'),
+        'light' => trans('admin::app.components.layouts.header.theme-light'),
+    ];
 @endphp
 
 <header class="flex justify-between items-center px-4 py-2.5 bg-white dark:bg-cherry-700  border-b dark:border-cherry-800 sticky top-0 z-[10001]">
@@ -343,11 +348,7 @@
                     darkMode: @json(request()->cookie('dark_mode', 'auto')),
 
                     mediaQuery: null,
-                    titleMap: @json([
-                        'auto'  => trans('admin::app.components.layouts.header.theme-auto'),
-                        'dark'  => trans('admin::app.components.layouts.header.theme-dark'),
-                        'light' => trans('admin::app.components.layouts.header.theme-light'),
-                    ]),
+                    titleMap: @json($themeToggleTitles),
                 };
             },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php
@@ -21,8 +21,14 @@
                 />
             @else
                 <img
-                    src="{{ in_array(request()->cookie('dark_mode'), ['1', 'dark'], true) ? unopim_asset('images/dark_logo.svg') : unopim_asset('images/logo.svg') }}"
-                    id="logo-image"
+                    src="{{ unopim_asset('images/logo.svg') }}"
+                    class="theme-logo-light block dark:hidden"
+                    alt="{{ config('app.name') }}"
+                />
+
+                <img
+                    src="{{ unopim_asset('images/dark_logo.svg') }}"
+                    class="theme-logo-dark hidden dark:block"
                     alt="{{ config('app.name') }}"
                 />
             @endif
@@ -132,8 +138,14 @@
                 />
             @else
                 <img
-                    src="{{ in_array(request()->cookie('dark_mode'), ['1', 'dark'], true) ? unopim_asset('images/dark_logo.svg') : unopim_asset('images/logo.svg') }}"
-                    id="logo-image"
+                    src="{{ unopim_asset('images/logo.svg') }}"
+                    class="theme-logo-light block dark:hidden"
+                    alt="{{ config('app.name') }}"
+                />
+
+                <img
+                    src="{{ unopim_asset('images/dark_logo.svg') }}"
+                    class="theme-logo-dark hidden dark:block"
                     alt="{{ config('app.name') }}"
                 />
             @endif
@@ -328,13 +340,14 @@
 
             data() {
                 return {
-                    darkMode: "{{ request()->cookie('dark_mode', 'auto') }}",
-
-                    logo: "{{ unopim_asset('images/logo.svg') }}",
-
-                    dark_logo: "{{ unopim_asset('images/dark_logo.svg') }}",
+                    darkMode: @json(request()->cookie('dark_mode', 'auto')),
 
                     mediaQuery: null,
+                    titleMap: @json([
+                        'auto'  => trans('admin::app.components.layouts.header.theme-auto'),
+                        'dark'  => trans('admin::app.components.layouts.header.theme-dark'),
+                        'light' => trans('admin::app.components.layouts.header.theme-light'),
+                    ]),
                 };
             },
 
@@ -348,11 +361,7 @@
                 },
 
                 toggleTitle() {
-                    if (this.darkMode === 'auto') {
-                        return 'Theme: Auto';
-                    }
-
-                    return this.darkMode === 'dark' ? 'Theme: Dark' : 'Theme: Light';
+                    return this.titleMap[this.darkMode] ?? this.titleMap.auto;
                 },
             },
 
@@ -373,12 +382,6 @@
                     document.documentElement.classList.toggle('dark', shouldUseDark);
 
                     this.$emitter.emit('change-theme', shouldUseDark ? 'dark' : 'light');
-
-                    const logoImage = document.getElementById('logo-image');
-
-                    if (logoImage) {
-                        logoImage.src = shouldUseDark ? this.dark_logo : this.logo;
-                    }
 
                     if (persist) {
                         const expiryDate = new Date();

--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/index.blade.php
@@ -1,5 +1,8 @@
+@php
+    $darkModePreference = request()->cookie('dark_mode', 'auto');
+@endphp
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}" dir="ltr" class="{{ (request()->cookie('dark_mode') ?? 0) ? 'dark' : '' }}">
+<html lang="{{ app()->getLocale() }}" dir="ltr" class="{{ $darkModePreference === 'dark' || $darkModePreference === '1' ? 'dark' : '' }}">
     <head>
         <title>{{ $title ?? '' }}</title>
 
@@ -9,6 +12,23 @@
         <meta name="base-url" content="{{ url()->to('/') }}">
         <meta name="currency-code" content="{{ core()->getBaseCurrencyCode() }}">
         <meta http-equiv="content-language" content="{{ app()->getLocale() }}">
+
+        <script>
+            (() => {
+                const getCookie = (name) => {
+                    const value = `; ${document.cookie}`;
+                    const parts = value.split(`; ${name}=`);
+
+                    return parts.length === 2 ? parts.pop().split(';').shift() : null;
+                };
+
+                const preference = getCookie('dark_mode') || 'auto';
+                const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+                const shouldUseDark = preference === 'dark' || preference === '1' || (preference === 'auto' && prefersDark);
+
+                document.documentElement.classList.toggle('dark', shouldUseDark);
+            })();
+        </script>
 
         @stack('meta')
 

--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/with-history/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/with-history/index.blade.php
@@ -3,8 +3,12 @@
     'historyId' => null,
 ])
 
+@php
+    $darkModePreference = request()->cookie('dark_mode', 'auto');
+@endphp
+
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}" dir="ltr" class="{{ (request()->cookie('dark_mode') ?? 0) ? 'dark' : '' }}">
+<html lang="{{ app()->getLocale() }}" dir="ltr" class="{{ $darkModePreference === 'dark' || $darkModePreference === '1' ? 'dark' : '' }}">
     <head>
         <title>{{ $title ?? '' }}</title>
 
@@ -14,6 +18,23 @@
         <meta name="base-url" content="{{ url()->to('/') }}">
         <meta name="currency-code" content="{{ core()->getBaseCurrencyCode() }}">
         <meta http-equiv="content-language" content="{{ app()->getLocale() }}">
+
+        <script>
+            (() => {
+                const getCookie = (name) => {
+                    const value = `; ${document.cookie}`;
+                    const parts = value.split(`; ${name}=`);
+
+                    return parts.length === 2 ? parts.pop().split(';').shift() : null;
+                };
+
+                const preference = getCookie('dark_mode') || 'auto';
+                const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+                const shouldUseDark = preference === 'dark' || preference === '1' || (preference === 'auto' && prefersDark);
+
+                document.documentElement.classList.toggle('dark', shouldUseDark);
+            })();
+        </script>
 
         @stack('meta')
 


### PR DESCRIPTION
## Summary
- add a 3-state admin theme preference: `light`, `dark`, `auto`
- extend the header toggle to cycle through auto -> dark -> light
- implement browser-based auto mode via `prefers-color-scheme`
- keep backward compatibility for existing cookie values `0/1`
- ensure theme class is applied early in layout render to avoid flicker

## Technical details
- update dark mode handling in header Vue component
- persist string-based cookie values (`dark_mode=auto|dark|light`)
- map legacy cookie values (`1` => dark, `0` => light)
- apply effective theme in both standard and history layouts
- keep logo switching aligned with effective theme

## Files changed
- `packages/Webkul/Admin/src/Resources/views/components/layouts/header/index.blade.php`
- `packages/Webkul/Admin/src/Resources/views/components/layouts/index.blade.php`
- `packages/Webkul/Admin/src/Resources/views/components/layouts/with-history/index.blade.php`
