### PR TITLE
fix: honour runtime DB_CONNECTION when re-running installer after dri…

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -557,7 +557,10 @@ class Installer extends Command
          */
         $databaseConnection = $this->getEnvAtRuntime('DB_CONNECTION');
 
+        $previousDefault = config('database.default');
+
         config([
+            'database.default'                                    => $databaseConnection,
             "database.connections.{$databaseConnection}.host"     => $this->getEnvAtRuntime('DB_HOST'),
             "database.connections.{$databaseConnection}.port"     => $this->getEnvAtRuntime('DB_PORT'),
             "database.connections.{$databaseConnection}.database" => $this->getEnvAtRuntime('DB_DATABASE'),
@@ -565,6 +568,12 @@ class Installer extends Command
             "database.connections.{$databaseConnection}.password" => $this->getEnvAtRuntime('DB_PASSWORD'),
             "database.connections.{$databaseConnection}.prefix"   => $this->getEnvAtRuntime('DB_PREFIX'),
         ]);
+
+        DB::setDefaultConnection($databaseConnection);
+
+        if ($previousDefault && $previousDefault !== $databaseConnection) {
+            DB::purge($previousDefault);
+        }
 
         DB::purge($databaseConnection);
 

--- a/packages/Webkul/Installer/tests/Unit/InstallerLoadEnvDatabaseDefaultTest.php
+++ b/packages/Webkul/Installer/tests/Unit/InstallerLoadEnvDatabaseDefaultTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Console\OutputStyle;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Webkul\Installer\Console\Commands\Installer;
+
+describe('Installer::loadEnvConfigAtRuntime DB default override (issue #797)', function () {
+    it('overrides database.default to match the .env DB_CONNECTION at runtime', function () {
+        config(['database.default' => 'mysql']);
+
+        $original = $_ENV;
+
+        $_ENV['DB_CONNECTION'] = 'pgsql';
+        $_ENV['DB_HOST'] = '127.0.0.1';
+        $_ENV['DB_PORT'] = '5432';
+        $_ENV['DB_DATABASE'] = 'unopim';
+        $_ENV['DB_USERNAME'] = 'postgres';
+        $_ENV['DB_PASSWORD'] = 'postgres';
+        $_ENV['DB_PREFIX'] = '';
+        $_ENV['APP_ENV'] = 'local';
+        $_ENV['APP_NAME'] = 'UnoPim';
+        $_ENV['APP_URL'] = 'http://localhost';
+        $_ENV['APP_TIMEZONE'] = 'UTC';
+        $_ENV['APP_LOCALE'] = 'en_US';
+        $_ENV['APP_CURRENCY'] = 'USD';
+
+        try {
+            $cmd = app(Installer::class);
+            $cmd->setLaravel(app());
+            $cmd->setInput(new ArrayInput([]));
+            $cmd->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+
+            $reflection = new ReflectionMethod($cmd, 'loadEnvConfigAtRuntime');
+            $reflection->setAccessible(true);
+            $reflection->invoke($cmd);
+
+            expect(config('database.default'))->toBe('pgsql');
+        } finally {
+            $_ENV = $original;
+        }
+    });
+});


### PR DESCRIPTION
…ver switch

When a user switched DB_CONNECTION in .env (e.g. MySQL -> PostgreSQL) and re-ran `php artisan unopim:install`, migrations targeted the OLD driver if a stale config cache pinned `database.default`. The installer overrode per-connection settings but never updated `database.default` or the active connection, so `migrate:fresh` kept using the cached default. Tables were created in the old DB, the new DB stayed empty, and the app blew up at runtime with relations not existing.

`loadEnvConfigAtRuntime` now also sets `database.default` to the runtime value, calls `DB::setDefaultConnection`, and purges the previous default so leftover PDO handles cannot be reused.

Skipped Playwright E2E: install runs as an artisan command, no UI surface for this code path. Reproduced manually with a stale config cache pointing at MySQL while .env held pgsql; pre-fix the installer populated MySQL (66 tables) and left pgsql empty (0); post-fix pgsql gets all 65 tables and MySQL stays untouched.

## Issue Reference
<! Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<! Please describe your changes in detail. -->

## How To Test This?
<! Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<! Please describe in detail what needs to be changed. >

## Branch Selection
<! Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Pint
<!  Please make sure all the pint tests are passed. -->

## Tailwind Reordering
<! Please make sure all the Tailwind classes are reordered. -->
