### PR TITLE
fix: gate MySQL bulk-mode session vars by driver in product importer

### DIFF
--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
@@ -1252,8 +1252,7 @@ class Importer extends AbstractImporter
          * for 2-3x faster INSERT/UPSERT. Safe because data is pre-validated.
          */
         if ($useBulkMode) {
-            DB::statement('SET SESSION unique_checks=0');
-            DB::statement('SET SESSION foreign_key_checks=0');
+            $this->toggleMysqlBulkMode(false);
         }
 
         try {
@@ -1297,12 +1296,28 @@ class Importer extends AbstractImporter
             $this->saveProducts($products);
         } finally {
             if ($useBulkMode) {
-                DB::statement('SET SESSION unique_checks=1');
-                DB::statement('SET SESSION foreign_key_checks=1');
+                $this->toggleMysqlBulkMode(true);
             }
         }
 
         return true;
+    }
+
+    /**
+     * Toggle MySQL-only bulk-mode session vars. No-ops on non-MySQL drivers
+     * (e.g. pgsql, sqlite) since `unique_checks` and `foreign_key_checks`
+     * are MySQL-specific.
+     */
+    protected function toggleMysqlBulkMode(bool $enable): void
+    {
+        if (DB::connection()->getDriverName() !== 'mysql') {
+            return;
+        }
+
+        $value = $enable ? 1 : 0;
+
+        DB::statement("SET SESSION unique_checks={$value}");
+        DB::statement("SET SESSION foreign_key_checks={$value}");
     }
 
     /**\n     * Prepare products from current batch.\n     *\n     * Optimized: Uses indexed attribute family lookup (O(1)) instead of\n     * Collection->where()->first() (O(n)) per row.\n     */

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Importers/PgsqlBulkModeCompatibilityTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Importers/PgsqlBulkModeCompatibilityTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\DataTransfer\Helpers\Importers\Product\Importer;
+
+describe('Product Importer pgsql bulk-mode compatibility (issue #798)', function () {
+    it('does not issue MySQL-only SET SESSION statements when driver is not mysql', function () {
+        config()->set('import.mysql_bulk_mode', true);
+
+        $importer = app(Importer::class);
+
+        $reflection = new ReflectionClass($importer);
+
+        expect($reflection->hasMethod('toggleMysqlBulkMode'))
+            ->toBeTrue('Importer must expose toggleMysqlBulkMode helper that gates MySQL session vars by driver');
+
+        $method = $reflection->getMethod('toggleMysqlBulkMode');
+        $method->setAccessible(true);
+
+        $original = DB::getDefaultConnection();
+
+        config()->set('database.connections.fake_pgsql', [
+            'driver'   => 'pgsql',
+            'host'     => '127.0.0.1',
+            'port'     => 5432,
+            'database' => 'unopim_fake',
+            'username' => 'postgres',
+            'password' => 'postgres',
+        ]);
+
+        DB::setDefaultConnection('fake_pgsql');
+
+        try {
+            $method->invoke($importer, false);
+            $method->invoke($importer, true);
+        } finally {
+            DB::setDefaultConnection($original);
+        }
+
+        expect(true)->toBeTrue();
+    });
+});


### PR DESCRIPTION
Product import on PostgreSQL crashed in saveProductsData with SQLSTATE[42704] "unrecognized configuration parameter unique_checks" because the importer issued raw `SET SESSION unique_checks=0` / `foreign_key_checks=0` statements unconditionally — both are MySQL-only session vars.

Extracted the toggle into a `toggleMysqlBulkMode(bool)` helper that no-ops when `DB::connection()->getDriverName()` is not `mysql`, so imports work cleanly on pgsql (and sqlite) while keeping the bulk performance path intact on MySQL.

Skipped Playwright E2E: bug surfaces inside a queue worker (job lands in failed_jobs), not on a user-visible synchronous flow, and the default test instance is MySQL.

## Issue Reference
<! Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<! Please describe your changes in detail. -->

## How To Test This?
<! Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<! Please describe in detail what needs to be changed. >

## Branch Selection
<! Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Pint
<!  Please make sure all the pint tests are passed. -->

## Tailwind Reordering
<! Please make sure all the Tailwind classes are reordered. -->
