### PR TITLE
Fix: PostgreSQL datagrid filter, product status update, and empty label fallback in selectors

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/VueJsSelect/AbstractOptionsController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/VueJsSelect/AbstractOptionsController.php
@@ -78,13 +78,30 @@ class AbstractOptionsController extends Controller
     }
 
     /**
-     * Get translated label for the entity
+     * Get translated label for the entity.
+     *
+     * Tries the requested locale first; falls back to any locale that has a
+     * non-empty label; returns null when no label exists in any locale.
      */
-    protected function getTranslatedLabel(string $currentLocaleCode, TranslatableModel $option, string $entityName = ''): string
+    protected function getTranslatedLabel(string $currentLocaleCode, TranslatableModel $option, string $entityName = ''): ?string
     {
-        $translation = $option->translate($currentLocaleCode);
+        $column = $this->getTranslationColumnName($entityName);
 
-        return $translation?->{$this->getTranslationColumnName($entityName)};
+        $label = $option->translate($currentLocaleCode)?->{$column};
+
+        if (! empty($label)) {
+            return $label;
+        }
+
+        foreach ($option->translations as $translation) {
+            $label = $translation->{$column};
+
+            if (! empty($label)) {
+                return $label;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/packages/Webkul/Product/src/Filter/Database/SkuOrUniversalFilter.php
+++ b/packages/Webkul/Product/src/Filter/Database/SkuOrUniversalFilter.php
@@ -28,26 +28,28 @@ class SkuOrUniversalFilter extends AbstractDatabaseAttributeFilter
             throw new \LogicException('The search query builder is not initialized in the filter.');
         }
 
-        foreach ($fields as $attribute) {
-            $attribute = $this->attributeService->findAttributeByCode($attribute);
-            if (! $attribute) {
-                continue;
+        $escapedValue = QueryString::escapeValue(current((array) $value));
+
+        $this->queryBuilder->where(function ($query) use ($fields, $options, $escapedValue) {
+            foreach ($fields as $attribute) {
+                $attribute = $this->attributeService->findAttributeByCode($attribute);
+                if (! $attribute) {
+                    continue;
+                }
+
+                $locale = $attribute->value_per_locale ? $options['locale'] : null;
+                $channel = $attribute->value_per_channel ? $options['channel'] : null;
+
+                $attributePath = $this->getScopedAttributePath($attribute, $locale, $channel);
+
+                $searchPath = DB::rawQueryGrammar()->jsonExtract($this->getSearchTablePath($options), ...$attributePath);
+
+                $query->orWhereRaw(
+                    sprintf("LOWER($searchPath) LIKE ?"),
+                    '%'.strtolower($escapedValue).'%'
+                );
             }
-
-            $locale = $attribute->value_per_locale ? $options['locale'] : null;
-            $channel = $attribute->value_per_channel ? $options['channel'] : null;
-
-            $attributePath = $this->getScopedAttributePath($attribute, $locale, $channel);
-
-            $escapedValue = QueryString::escapeValue(current((array) $value));
-
-            $searchPath = DB::rawQueryGrammar()->jsonExtract($this->getSearchTablePath($options), ...$attributePath);
-
-            $this->queryBuilder->orWhereRaw(
-                sprintf("LOWER($searchPath) LIKE ?"),
-                '%'.strtolower($escapedValue).'%'
-            );
-        }
+        });
 
         return $this;
     }

--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -151,8 +151,10 @@ abstract class AbstractType
 
         $product->values = $productValues;
 
+        $product->fill($data);
+
         if ($product->isDirty()) {
-            $product->update($data);
+            $product->save();
         }
 
         return $product;

--- a/packages/Webkul/Product/tests/Unit/Filter/Database/SkuOrUniversalFilterTest.php
+++ b/packages/Webkul/Product/tests/Unit/Filter/Database/SkuOrUniversalFilterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\Attribute\Services\AttributeService;
+use Webkul\ElasticSearch\Enums\FilterOperators;
+use Webkul\Product\Filter\Database\SkuOrUniversalFilter;
+
+beforeEach(function () {
+    config(['elasticsearch.enabled' => false]);
+});
+
+describe('SkuOrUniversalFilter groups OR conditions correctly when combined with other filters', function () {
+
+    it('wraps multiple OR conditions in a WHERE group so AND filters are not broken', function () {
+        $attributeService = app(AttributeService::class);
+
+        $filter = new SkuOrUniversalFilter($attributeService);
+
+        $qb = DB::table('products')->whereIn('products.status', ['1']);
+
+        $filter->setQueryManager($qb);
+
+        $filter->applyUnfilteredFilter(
+            ['sku', 'name'],
+            FilterOperators::WILDCARD,
+            'test',
+            ['locale' => 'en_US', 'channel' => 'default']
+        );
+
+        $sql = $qb->toSql();
+
+        // Without the fix, the SQL is:
+        //   WHERE "products"."status" IN (?) OR LOWER(...sku...) LIKE ? OR LOWER(...name...) LIKE ?
+        // This incorrectly allows rows that match sku OR name regardless of status,
+        // because OR has lower precedence than AND.
+        //
+        // With the fix the SQL must be:
+        //   WHERE "products"."status" IN (?) AND (LOWER(...sku...) LIKE ? OR LOWER(...name...) LIKE ?)
+        //
+        // We detect this by checking that the OR conditions are inside a parenthesised group
+        // that is connected to the outer conditions with AND (not at the top level).
+        expect($sql)->toContain('and (');
+        expect($sql)->not->toMatch('/\) or lower/i');
+    });
+
+    it('produces correct SQL even when "all" search is the only filter', function () {
+        $attributeService = app(AttributeService::class);
+
+        $filter = new SkuOrUniversalFilter($attributeService);
+
+        $qb = DB::table('products');
+
+        $filter->setQueryManager($qb);
+
+        $filter->applyUnfilteredFilter(
+            ['sku', 'name'],
+            FilterOperators::WILDCARD,
+            'hello',
+            ['locale' => 'en_US', 'channel' => 'default']
+        );
+
+        $sql = $qb->toSql();
+
+        // Even with no preceding filters, both sku and name conditions must appear
+        expect(strtolower($sql))->toContain('lower(');
+        expect(strtolower($sql))->toContain('like ?');
+    });
+});

--- a/tests/e2e-pw/tests/01-catalog/productGridFilter.spec.js
+++ b/tests/e2e-pw/tests/01-catalog/productGridFilter.spec.js
@@ -1,0 +1,138 @@
+const { test, expect } = require('../../utils/fixtures');
+const { navigateTo, generateUid } = require('../../utils/helpers');
+
+/**
+ * Create a simple product and return to the product listing.
+ */
+async function createSimpleProduct(adminPage, sku) {
+  await navigateTo(adminPage, 'products');
+  await adminPage.getByRole('button', { name: 'Create Product' }).click();
+  await adminPage.waitForLoadState('networkidle');
+
+  // Select type
+  const typeWrapper = adminPage.locator('input[name="type"]').locator('..');
+  await typeWrapper.locator('.multiselect__tags').click();
+  await typeWrapper.locator('.multiselect__content-wrapper').first().waitFor({ state: 'visible', timeout: 5000 });
+  await adminPage.getByRole('option', { name: 'Simple' }).first().click();
+  await adminPage.keyboard.press('Escape');
+
+  // Select attribute family (pick first available)
+  const familyWrapper = adminPage.locator('input[name="attribute_family_id"]').locator('..');
+  await familyWrapper.locator('.multiselect__tags').click();
+  await familyWrapper.locator('.multiselect__content-wrapper').first().waitFor({ state: 'visible', timeout: 5000 });
+  await familyWrapper
+    .locator('.multiselect__element:not(.multiselect__element--disabled) .multiselect__option:not(.multiselect__option--disabled)')
+    .first()
+    .click();
+  await adminPage.keyboard.press('Escape');
+
+  await adminPage.locator('input[name="sku"]').fill(sku);
+  await adminPage.getByRole('button', { name: 'Save Product' }).click();
+  await adminPage.waitForURL(/\/admin\/catalog\/products\/edit\//, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await adminPage.waitForLoadState('networkidle').catch(() => {});
+  return sku;
+}
+
+/**
+ * Delete a product by SKU.
+ */
+async function deleteProductBySku(adminPage, sku) {
+  await navigateTo(adminPage, 'products');
+  const searchInput = adminPage.getByPlaceholder('Search').first();
+  await searchInput.waitFor({ state: 'visible', timeout: 30000 });
+  await searchInput.fill(sku);
+  await adminPage.keyboard.press('Enter');
+  await adminPage.waitForLoadState('load');
+  await adminPage.waitForTimeout(500);
+
+  const deleteIcon = adminPage.locator('span[title="Delete"]').first();
+  const visible = await deleteIcon.isVisible({ timeout: 3000 }).catch(() => false);
+  if (!visible) return;
+  await deleteIcon.click();
+  await adminPage.getByRole('button', { name: 'Delete' }).click();
+  await adminPage.waitForLoadState('networkidle').catch(() => {});
+}
+
+/**
+ * Call the product datagrid endpoint with given filter params and return the response.
+ */
+async function getDatagridResponse(adminPage, params) {
+  const url = new URL('/admin/catalog/products', adminPage.url());
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      value.forEach(v => url.searchParams.append(`${key}[]`, v));
+    } else {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  return adminPage.request.get(url.toString(), {
+    headers: { 'X-Requested-With': 'XMLHttpRequest', accept: 'application/json' },
+  });
+}
+
+test.describe('Product Grid Filter - PostgreSQL compatibility', () => {
+  test('38 - combined search (all) and status filter returns 200 not 500', async ({ adminPage }) => {
+    test.setTimeout(90000);
+    const sku = `filtst-${generateUid()}`;
+    await createSimpleProduct(adminPage, sku);
+
+    await navigateTo(adminPage, 'products');
+    await adminPage.waitForLoadState('networkidle');
+
+    // Request the DataGrid with both "all" (search) and "status" filters combined.
+    // Before the fix this generated broken SQL that caused a 500 in PostgreSQL.
+    const response = await getDatagridResponse(adminPage, {
+      all: sku,
+      status: ['1'],
+    });
+
+    expect(response.status()).toBe(200);
+
+    // Cleanup
+    await deleteProductBySku(adminPage, sku);
+  });
+
+  test('39 - combined search (all) and type filter returns 200 not 500', async ({ adminPage }) => {
+    test.setTimeout(90000);
+    const sku = `filtty-${generateUid()}`;
+    await createSimpleProduct(adminPage, sku);
+
+    await navigateTo(adminPage, 'products');
+    await adminPage.waitForLoadState('networkidle');
+
+    // "all" + "type" combination
+    const response = await getDatagridResponse(adminPage, {
+      all: sku,
+      type: ['simple'],
+    });
+
+    expect(response.status()).toBe(200);
+
+    // Cleanup
+    await deleteProductBySku(adminPage, sku);
+  });
+
+  test('40 - "all" search in product grid returns matching product', async ({ adminPage }) => {
+    test.setTimeout(90000);
+    const sku = `srchall-${generateUid()}`;
+    await createSimpleProduct(adminPage, sku);
+
+    await navigateTo(adminPage, 'products');
+    await adminPage.waitForLoadState('networkidle');
+
+    const searchInput = adminPage.getByPlaceholder('Search').first();
+    await searchInput.waitFor({ state: 'visible', timeout: 30000 });
+    await searchInput.fill(sku);
+    await adminPage.keyboard.press('Enter');
+    await adminPage.waitForLoadState('load');
+    await adminPage.waitForTimeout(1000);
+
+    // The search result should show 1 result
+    await expect(adminPage.locator('#app').getByText('1 Results')).toBeVisible({ timeout: 20000 });
+    await expect(adminPage.locator('#app').getByText(sku)).toBeVisible();
+
+    // Cleanup
+    await deleteProductBySku(adminPage, sku);
+  });
+});

--- a/tests/e2e-pw/tests/06-product-completeness/02.product-completeness-functionality.spec.js
+++ b/tests/e2e-pw/tests/06-product-completeness/02.product-completeness-functionality.spec.js
@@ -103,7 +103,9 @@ test.describe('Verify the behaviour of Product Completeness feature', () => {
       // All already assigned — toggle one by removing and re-adding
       await adminPage.locator('.multiselect__tag-icon').first().click();
       await expect(adminPage.locator('#app').getByText('Completeness updated successfully Close').first()).toBeVisible();
-      await adminPage.locator('.multiselect__tags', { hasText: 'Select option' }).first().click();
+      // Wait for Vue to re-render the multiselect placeholder after tag removal
+      await adminPage.locator('.multiselect__tags').filter({ hasText: 'Select option' }).first().waitFor({ state: 'visible', timeout: 10000 });
+      await adminPage.locator('.multiselect__tags').filter({ hasText: 'Select option' }).first().click();
       await adminPage.getByRole('option', { name: 'Default' }).first().click();
     }
     await expect(adminPage.locator('#app').getByText('Completeness updated successfully Close').first()).toBeVisible();

--- a/tests/e2e-pw/utils/helpers.js
+++ b/tests/e2e-pw/utils/helpers.js
@@ -109,16 +109,18 @@ async function clickSaveAndExpect(page, buttonName, toastPattern, urlPattern) {
   const currentUrl = page.url();
   const regex = toastPattern instanceof RegExp ? toastPattern : new RegExp(toastPattern, 'i');
 
+  // Register the URL watcher BEFORE clicking to avoid missing fast redirects.
+  const navPromise = urlPattern
+    ? page.waitForURL(urlPattern, { timeout: 20000 })
+    : page.waitForURL((url) => url.toString() !== currentUrl, { timeout: 20000 });
+
   await page.getByRole('button', { name: buttonName }).click();
+
+  const toastPromise = page.locator('#app').getByText(regex).first().waitFor({ state: 'visible', timeout: 20000 });
 
   // Either toast appears OR URL changes (redirect after save).
   // Uses Promise.any — fails only if BOTH timeout (real failure).
-  await Promise.any([
-    page.locator('#app').getByText(regex).first().waitFor({ state: 'visible', timeout: 20000 }),
-    urlPattern
-      ? page.waitForURL(urlPattern, { timeout: 20000 })
-      : page.waitForURL((url) => url.toString() !== currentUrl, { timeout: 20000 }),
-  ]);
+  await Promise.any([toastPromise, navPromise]);
 }
 
 /**


### PR DESCRIPTION
## Description
  - **SkuOrUniversalFilter:** Wrapped `orWhereRaw` calls inside a `where()` closure so OR conditions don't break AND filters (status, type, etc.) when combined — fixes broken results on PostgreSQL.                                
                  
  - **AbstractType:** Replaced `$product->update($data)` with `fill()` +  `save()` so the `isDirty()` check works as expected when saving product status.                                                                       
                  
  - **AbstractOptionsController:** `getTranslatedLabel()` now falls back to any available locale when the current locale has no label, preventing empty entries in selectors.                                                         
                  
  ## How to Test                                                                
  1. Go to **Catalog → Products**, apply the search filter along with a status or type filter — should return results without errors.
  2. Edit a product, toggle its status, save — status should persist on reload. 
  3. Open a selector for an option that has a label in only one locale — label should still appear regardless of active locale.                              
   
  ## Tests Added                                                                
  - Pest unit test: `SkuOrUniversalFilterTest` — verifies correct AND/OR grouping in SQL 
  - Playwright E2E: `productGridFilter.spec.js` — covers combined filter and search scenarios
