### PR TITLE
Fix: Docker setup failures, product/category grid 503, and AI agent locale content generation

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -90,9 +90,9 @@ FORWARD_MAILPIT_SMTP_PORT=1025
 # MySQL root password (used only during initial database creation)
 DB_ROOT_PASSWORD=password
 
-# Elasticsearch disk watermarks (defaults are production-safe).
-# If ES cluster goes RED due to disk space, raise these values.
-# For development on fuller disks, try: 90%, 95%, 97%
-# ELASTICSEARCH_DISK_WATERMARK_LOW=85%
-# ELASTICSEARCH_DISK_WATERMARK_HIGH=90%
-# ELASTICSEARCH_DISK_WATERMARK_FLOOD_STAGE=95%
+# Elasticsearch disk watermarks (defaults suit development environments).
+# If ES cluster goes RED due to disk space, raise these values further.
+# For stricter production limits, lower these values (e.g. 85%, 90%, 95%).
+# ELASTICSEARCH_DISK_WATERMARK_LOW=90%
+# ELASTICSEARCH_DISK_WATERMARK_HIGH=95%
+# ELASTICSEARCH_DISK_WATERMARK_FLOOD_STAGE=97%

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,9 +185,9 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - cluster.routing.allocation.disk.watermark.low=${ELASTICSEARCH_DISK_WATERMARK_LOW:-85%}
-      - cluster.routing.allocation.disk.watermark.high=${ELASTICSEARCH_DISK_WATERMARK_HIGH:-90%}
-      - cluster.routing.allocation.disk.watermark.flood_stage=${ELASTICSEARCH_DISK_WATERMARK_FLOOD_STAGE:-95%}
+      - cluster.routing.allocation.disk.watermark.low=${ELASTICSEARCH_DISK_WATERMARK_LOW:-90%}
+      - cluster.routing.allocation.disk.watermark.high=${ELASTICSEARCH_DISK_WATERMARK_HIGH:-95%}
+      - cluster.routing.allocation.disk.watermark.flood_stage=${ELASTICSEARCH_DISK_WATERMARK_FLOOD_STAGE:-97%}
     volumes:
       - unopim-elasticsearch-data:/usr/share/elasticsearch/data
     ports:

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
@@ -217,14 +217,10 @@ class CategoryDataGrid extends DataGrid
                 ]
             );
         } catch (\Exception $e) {
-            if (str_contains($e->getMessage(), 'index_not_found_exception')) {
-                Log::error('Elasticsearch index not found. Please create an index first.');
-                parent::processRequest();
+            Log::error('Elasticsearch unavailable, falling back to database query: '.$e->getMessage());
+            parent::processRequest();
 
-                return;
-            } else {
-                throw $e;
-            }
+            return;
         }
     }
 

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -496,11 +496,10 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
                 ]
             );
         } catch (\Exception $e) {
-            if (str_contains($e->getMessage(), 'index_not_found_exception')) {
-                Log::error('Elasticsearch index not found. Please create an index first.');
-            }
+            Log::error('Elasticsearch unavailable, falling back to database query: '.$e->getMessage());
+            parent::processRequest();
 
-            throw $e;
+            return;
         }
     }
 

--- a/packages/Webkul/Admin/tests/Feature/Catalog/CategoryTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/CategoryTest.php
@@ -250,6 +250,9 @@ it('should not mass delete a category linked to a channel', function () {
 it('should fall back to database query when Elasticsearch throws an exception on category grid', function () {
     $this->loginAsAdmin();
 
+    // Create the category while ES is disabled so the observer does not attempt a real connection
+    $category = Category::factory()->create();
+
     config([
         'elasticsearch.enabled'                      => true,
         'elasticsearch.prefix'                       => 'testing',
@@ -257,13 +260,11 @@ it('should fall back to database query when Elasticsearch throws an exception on
         'elasticsearch.connections.default.hosts.0'  => 'testhost:9200',
     ]);
 
-    $category = Category::factory()->create();
-
     $elasticClientMock = Mockery::mock('Webkul\ElasticSearch\Client\Fake\FakeElasticClient');
     ElasticSearch::shouldReceive('makeConnection')->andReturn($elasticClientMock);
     ElasticSearch::shouldReceive('search')
         ->once()
-        ->andThrow(new \Exception('No alive nodes found in your cluster'));
+        ->andThrow(new Exception('No alive nodes found in your cluster'));
 
     $response = $this->withHeaders([
         'X-Requested-With' => 'XMLHttpRequest',

--- a/packages/Webkul/Admin/tests/Feature/Catalog/CategoryTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/CategoryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Webkul\Category\Models\Category;
+use Webkul\Core\Facades\ElasticSearch;
 use Webkul\Core\Models\Channel;
 
 it('should return the category index page', function () {
@@ -244,4 +245,34 @@ it('should not mass delete a category linked to a channel', function () {
     $this->assertDatabaseHas($this->getFullTableName(Category::class), [
         'id' => $channelLinkedCategory,
     ]);
+});
+
+it('should fall back to database query when Elasticsearch throws an exception on category grid', function () {
+    $this->loginAsAdmin();
+
+    config([
+        'elasticsearch.enabled'                      => true,
+        'elasticsearch.prefix'                       => 'testing',
+        'elasticsearch.connection'                   => 'default',
+        'elasticsearch.connections.default.hosts.0'  => 'testhost:9200',
+    ]);
+
+    $category = Category::factory()->create();
+
+    $elasticClientMock = Mockery::mock('Webkul\ElasticSearch\Client\Fake\FakeElasticClient');
+    ElasticSearch::shouldReceive('makeConnection')->andReturn($elasticClientMock);
+    ElasticSearch::shouldReceive('search')
+        ->once()
+        ->andThrow(new \Exception('No alive nodes found in your cluster'));
+
+    $response = $this->withHeaders([
+        'X-Requested-With' => 'XMLHttpRequest',
+    ])->json('GET', route('admin.catalog.categories.index'));
+
+    $response->assertOk();
+    $data = $response->json();
+    $this->assertArrayHasKey('records', $data);
+    $this->assertNotEmpty($data['records']);
+
+    config(['elasticsearch.enabled' => false]);
 });

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductFilterWithElasticSearchTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductFilterWithElasticSearchTest.php
@@ -1324,7 +1324,7 @@ it('should fall back to database query when Elasticsearch throws an exception on
 
     ElasticSearch::shouldReceive('search')
         ->once()
-        ->andThrow(new \Exception('No alive nodes found in your cluster'));
+        ->andThrow(new Exception('No alive nodes found in your cluster'));
 
     $response = $this->withHeaders([
         'X-Requested-With' => 'XMLHttpRequest',

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductFilterWithElasticSearchTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductFilterWithElasticSearchTest.php
@@ -1317,6 +1317,28 @@ it('should filter products by gallery attribute using Elasticsearch', function (
     $response->assertOk();
 });
 
+it('should fall back to database query when Elasticsearch throws an exception on product grid', function () {
+    config(['elasticsearch.enabled' => false]);
+    Product::factory()->create(['sku' => 'fallback-test-sku']);
+    config(['elasticsearch.enabled' => true]);
+
+    ElasticSearch::shouldReceive('search')
+        ->once()
+        ->andThrow(new \Exception('No alive nodes found in your cluster'));
+
+    $response = $this->withHeaders([
+        'X-Requested-With' => 'XMLHttpRequest',
+    ])->json('GET', route('admin.catalog.products.index'), [
+        'pagination' => [
+            'page'     => 1,
+            'per_page' => 10,
+        ],
+    ]);
+
+    $response->assertOk();
+    expect($response->json())->toHaveKey('records');
+});
+
 it('should filter products by uppercase SKU using Elasticsearch (case-insensitive)', function () {
     $data = [
         'pagination' => [

--- a/packages/Webkul/AiAgent/src/Chat/Tools/GenerateContent.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/GenerateContent.php
@@ -43,11 +43,11 @@ class GenerateContent implements PimTool
                 $common = $values['common'] ?? [];
                 $channelLocale = $values['channel_locale_specific'][$context->channel][$context->locale] ?? [];
 
-                // Build existing attributes for enrichment context
-                $existing = array_merge($common, $channelLocale);
-
+                // Use only the locale-specific bucket for the completeness check so that
+                // content present in another locale (e.g. en_US) does not falsely mark
+                // this locale as already filled.
                 $ctx = new ImageProductContext(
-                    attributes: $existing,
+                    attributes: $channelLocale,
                     detectedProduct: $common['product_type'] ?? null,
                     category: ($values['categories'][0] ?? null),
                 );
@@ -71,6 +71,7 @@ class GenerateContent implements PimTool
                         options: [
                             'locale'      => $context->locale,
                             'instruction' => $instruction ?? '',
+                            'common'      => $common,
                         ],
                     );
 

--- a/packages/Webkul/AiAgent/src/Jobs/AutoEnrichProductJob.php
+++ b/packages/Webkul/AiAgent/src/Jobs/AutoEnrichProductJob.php
@@ -74,12 +74,14 @@ class AutoEnrichProductJob implements ShouldQueue
         $common = $values['common'] ?? [];
         $cl = $values['channel_locale_specific'][$this->channel][$this->locale] ?? [];
 
-        // Only enrich if key fields are missing
-        $hasName = ! empty($cl['name'] ?? $common['name'] ?? null);
-        $hasDescription = ! empty($cl['description'] ?? $common['description'] ?? null);
+        // Check completeness against the locale-specific bucket only — do not
+        // fall back to $common so that en_US content does not suppress generation
+        // for fr_FR or de_DE.
+        $hasName = ! empty($cl['name'] ?? null);
+        $hasDescription = ! empty($cl['description'] ?? null);
 
         if ($hasName && $hasDescription) {
-            return; // Product already has core content
+            return; // Product already has core content for this locale
         }
 
         // Resolve AI platform
@@ -103,9 +105,10 @@ class AutoEnrichProductJob implements ShouldQueue
                 model: $platform->model_list[0] ?? 'gpt-4o',
             ));
 
-            $existing = array_merge($common, $cl);
+            // Pass only the locale-specific bucket as attributes so the completeness
+            // check inside EnrichmentService is not fooled by $common data.
             $ctx = new ImageProductContext(
-                attributes: $existing,
+                attributes: $cl,
                 detectedProduct: $common['product_type'] ?? null,
                 category: $values['categories'][0] ?? null,
             );
@@ -114,7 +117,7 @@ class AutoEnrichProductJob implements ShouldQueue
                 ctx: $ctx,
                 credentialId: 0,
                 apiClient: $apiClient,
-                options: ['locale' => $this->locale],
+                options: ['locale' => $this->locale, 'common' => $common],
             );
 
             $generated = $enriched->enrichment;

--- a/packages/Webkul/AiAgent/src/Services/EnrichmentService.php
+++ b/packages/Webkul/AiAgent/src/Services/EnrichmentService.php
@@ -43,6 +43,10 @@ class EnrichmentService
      */
     public function enrich(ImageProductContext $ctx, int $credentialId = 0, ?AiApiClient $apiClient = null, array $options = []): ImageProductContext
     {
+        // Check completeness against locale-specific data only.  Merging with
+        // $ctx->enrichment (previously generated fields from this same run) is
+        // still correct; the caller must NOT merge $common into $ctx->attributes
+        // so that content from another locale does not suppress generation here.
         $existing = array_merge($ctx->enrichment, $ctx->attributes);
 
         $missing = array_filter(
@@ -68,8 +72,12 @@ class EnrichmentService
 
         $locale = $options['locale'] ?? 'en';
         $instruction = $options['instruction'] ?? '';
+        // $common holds product-level fields (e.g. English content) passed as
+        // reference so the AI can translate/adapt, without polluting the
+        // completeness check above.
+        $common = $options['common'] ?? [];
 
-        $messages = $this->buildMessages($existing, array_values($missing), $locale, $instruction, $ctx);
+        $messages = $this->buildMessages($existing, array_values($missing), $locale, $instruction, $ctx, $common);
 
         $response = $this->apiClient->chat(messages: $messages, maxTokens: 2048, temperature: 0.6);
         $generated = $this->parseResponse($response['content'] ?? '');
@@ -105,8 +113,13 @@ class EnrichmentService
         string $locale,
         string $instruction,
         ImageProductContext $ctx,
+        array $common = [],
     ): array {
-        $existingJson = json_encode($existing, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        // Merge common (product-level) data with locale-specific data so the AI
+        // has full product context (e.g. English copy to translate from) while
+        // the completeness check that determined $missing used locale-only data.
+        $contextData = empty($common) ? $existing : array_merge($common, $existing);
+        $existingJson = json_encode($contextData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         $targetKeys = json_encode($missing);
 
         $extra = '';

--- a/packages/Webkul/AiAgent/tests/Unit/EnrichmentLocaleAwarenessTest.php
+++ b/packages/Webkul/AiAgent/tests/Unit/EnrichmentLocaleAwarenessTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Webkul\AiAgent\DTOs\ImageProductContext;
+use Webkul\AiAgent\Services\EnrichmentService;
+
+describe('EnrichmentService locale-aware completeness check', function () {
+
+    it('detects missing fields when locale-specific bucket is empty even though common has content', function () {
+        // Simulate: common has full English content, fr_FR channel_locale bucket is empty.
+        // The caller (GenerateContent / AutoEnrichProductJob) must pass only the locale-specific
+        // bucket as $ctx->attributes — NOT merged with common.
+        $channelLocale = [];  // fr_FR has nothing yet
+
+        $ctx = new ImageProductContext(
+            attributes: $channelLocale,
+            detectedProduct: 'Electronics',
+        );
+
+        // $ctx->attributes is empty → every TARGETS key is missing.
+        // Verify that merging enrichment (empty) with attributes (empty) yields all targets as missing.
+        $existing = array_merge($ctx->enrichment, $ctx->attributes);
+
+        $targets = (new ReflectionClassConstant(EnrichmentService::class, 'TARGETS'))->getValue();
+
+        $missing = array_filter($targets, fn (string $key) => empty($existing[$key]));
+
+        expect($missing)->not->toBeEmpty()
+            ->and(in_array('name', $missing))->toBeTrue()
+            ->and(in_array('description', $missing))->toBeTrue()
+            ->and(in_array('meta_title', $missing))->toBeTrue();
+    });
+
+    it('reports no missing fields when locale-specific bucket already has all target content', function () {
+        $channelLocale = [
+            'name'              => 'Produit en Français',
+            'short_description' => 'Courte description',
+            'description'       => 'Description complète du produit',
+            'meta_title'        => 'Titre SEO',
+            'meta_description'  => 'Description SEO',
+            'meta_keywords'     => 'mots-clés',
+            'product_number'    => 'FR-001',
+        ];
+
+        $ctx = new ImageProductContext(attributes: $channelLocale);
+
+        $existing = array_merge($ctx->enrichment, $ctx->attributes);
+
+        $targets = (new ReflectionClassConstant(EnrichmentService::class, 'TARGETS'))->getValue();
+
+        $missing = array_filter($targets, fn (string $key) => empty($existing[$key]));
+
+        expect($missing)->toBeEmpty();
+    });
+
+    it('does not treat common-bucket English content as filling the fr_FR locale bucket', function () {
+        // Bug scenario: common has English content (name, description, meta fields),
+        // but fr_FR channel_locale bucket is empty.
+        // The old code did array_merge($common, $channelLocale) before the completeness check,
+        // which caused English content to mask the missing fr_FR fields.
+        $common = [
+            'name'             => 'English Product Name',
+            'description'      => 'English description',
+            'meta_title'       => 'English SEO title',
+            'meta_description' => 'English SEO description',
+            'meta_keywords'    => 'english, keywords',
+        ];
+
+        $frChannelLocale = [];  // fr_FR has no locale-specific content
+
+        $targets = (new ReflectionClassConstant(EnrichmentService::class, 'TARGETS'))->getValue();
+
+        // Old (buggy) approach: merging common into attributes hides the missing fr_FR fields.
+        $mergedWrong = array_merge($common, $frChannelLocale);
+        $ctxWrong = new ImageProductContext(attributes: $mergedWrong);
+        $existingWrong = array_merge($ctxWrong->enrichment, $ctxWrong->attributes);
+        $missingWrong = array_filter($targets, fn (string $key) => empty($existingWrong[$key]));
+
+        // With the wrong approach, 'name', 'description', and meta fields are hidden
+        // because common filled them in — they incorrectly appear NOT missing.
+        expect(in_array('name', $missingWrong))->toBeFalse()
+            ->and(in_array('description', $missingWrong))->toBeFalse()
+            ->and(in_array('meta_title', $missingWrong))->toBeFalse();
+
+        // Correct (fixed) approach: only the locale-specific bucket determines completeness.
+        $ctxCorrect = new ImageProductContext(attributes: $frChannelLocale);
+        $existingCorrect = array_merge($ctxCorrect->enrichment, $ctxCorrect->attributes);
+        $missingCorrect = array_filter($targets, fn (string $key) => empty($existingCorrect[$key]));
+
+        // With the fix, fr_FR is correctly identified as fully missing — generate everything.
+        expect($missingCorrect)->not->toBeEmpty()
+            ->and(in_array('name', $missingCorrect))->toBeTrue()
+            ->and(in_array('description', $missingCorrect))->toBeTrue()
+            ->and(in_array('meta_title', $missingCorrect))->toBeTrue();
+    });
+
+    it('correctly identifies partially filled locale bucket', function () {
+        // de_DE has a name but no description or SEO fields.
+        $deChannelLocale = [
+            'name' => 'Deutsches Produkt',
+        ];
+
+        $ctx = new ImageProductContext(attributes: $deChannelLocale);
+        $existing = array_merge($ctx->enrichment, $ctx->attributes);
+        $targets = (new ReflectionClassConstant(EnrichmentService::class, 'TARGETS'))->getValue();
+        $missing = array_filter($targets, fn (string $key) => empty($existing[$key]));
+
+        expect($missing)->not->toBeEmpty()
+            ->and(in_array('name', $missing))->toBeFalse()      // name is present
+            ->and(in_array('description', $missing))->toBeTrue() // description is missing
+            ->and(in_array('meta_title', $missing))->toBeTrue(); // SEO is missing
+    });
+});


### PR DESCRIPTION
## Summary                                                

  - **Seeder FK violation** — `AttributeFamilyTableSeeder` crashed on re-run due to                                                                           
    `products` FK constraint. Fix: wrap delete with `SET FOREIGN_KEY_CHECKS = 0/1`.
                                                                                                                                                              
  - **Missing APP_KEY on restart** — `fpm-entrypoint.sh` skipped `key:generate` in                                                                            
    the "existing DB detected" path, causing 500 on every page. Fix: add the key                                                                              
    generation guard to that branch.                                                                                                                          
                                                            
  - **Product/category grid 503** — When Elasticsearch cluster goes RED (disk                                                                                 
    watermark exceeded), both DataGrids rethrew the exception instead of falling                                                                              
    back to the DB query. Fix: catch any ES exception and call                                                                                                
    `parent::processRequest()`. Also raised Docker default watermarks from                                                                                    
    `85/90/95%` to `90/95/97%` to prevent the cluster going RED on developer                                                                                  
    machines.                                                                                                                                                 
                                                            
  - **AI Agent "already filled" on missing locales** — `GenerateContent` and                                                                                  
    `AutoEnrichProductJob` merged `$common` (English content) with the target                                                                                 
    locale bucket before the completeness check, so `fr_FR`/`de_DE` fields always                                                                             
    appeared filled. Fix: pass only the locale-specific bucket for the completeness                                                                           
    check; forward `$common` separately as AI context for translation.                                                                                        
                                                                                                                                                              
  ## Checks                                                 
  - [x] Pint                                                                                                                                                  
  - [x] Translations                                                                                                                                          
  - [x] Pest (all new tests pass)