### PR TITLE
fix: resolve PostgreSQL incompatibility in AiAgent tools and DataGrids

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeOptionDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/AttributeOptionDataGrid.php
@@ -4,6 +4,7 @@ namespace Webkul\Admin\DataGrids\Catalog;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 use Webkul\DataGrid\DataGrid;
 
 class AttributeOptionDataGrid extends DataGrid
@@ -64,9 +65,12 @@ class AttributeOptionDataGrid extends DataGrid
             ));
         }
 
+        $grammar = GrammarQueryManager::getGrammar();
+
         $this->addFilter('id', 'attribute_options.id');
 
-        $this->addFilter('code', DB::raw("(SELECT GROUP_CONCAT(CONCAT({$tablePrefix}attribute_options.code, ' ', label)  SEPARATOR ' ') FROM {$tablePrefix}attribute_option_translations WHERE attribute_option_id = {$tablePrefix}attribute_options.id)"));
+        $concatExpr = $grammar->concat("{$tablePrefix}attribute_options.code", "' '", 'label');
+        $this->addFilter('code', DB::raw("(SELECT {$grammar->groupConcat($concatExpr, separator: ' ')} FROM {$tablePrefix}attribute_option_translations WHERE attribute_option_id = {$tablePrefix}attribute_options.id)"));
 
         return $queryBuilder;
     }

--- a/packages/Webkul/Admin/src/DataGrids/Settings/ChannelDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/ChannelDataGrid.php
@@ -4,6 +4,7 @@ namespace Webkul\Admin\DataGrids\Settings;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 use Webkul\DataGrid\DataGrid;
 
 class ChannelDataGrid extends DataGrid
@@ -22,6 +23,7 @@ class ChannelDataGrid extends DataGrid
         $tableCategories = DB::table('categories')->select('id', 'code', 'additional_data->locale_specific->'.$requestedLocaleCode.'->name as name');
 
         $tablePrefix = DB::getTablePrefix();
+        $grammar = GrammarQueryManager::getGrammar();
 
         $queryBuilder = DB::table('channels')
             ->leftJoin('channel_translations as requested_channel_translation', function ($leftJoin) use ($requestedLocaleCode) {
@@ -42,13 +44,13 @@ class ChannelDataGrid extends DataGrid
                 'channels.code',
                 'channels.root_category_id',
                 DB::raw('(CASE WHEN CHAR_LENGTH(TRIM('.$tablePrefix.'requested_channel_translation.name)) < 1 THEN '.$tablePrefix.'fallback_channel_translation.name ELSE '.$tablePrefix.'requested_channel_translation.name END) as translated_name'),
-                DB::raw('(CASE WHEN '.$tablePrefix.'categories.name IS NOT NULL THEN REPLACE('.$tablePrefix."categories.name, '\"', '') ELSE CONCAT('[', ".$tablePrefix."categories.code, ']') END) as translated_category_name")
+                DB::raw('(CASE WHEN '.$tablePrefix.'categories.name IS NOT NULL THEN REPLACE('.$tablePrefix."categories.name, '\"', '') ELSE ".$grammar->concat("'['", "{$tablePrefix}categories.code", "']'").' END) as translated_category_name')
             );
 
         $this->addFilter('id', 'channels.id');
         $this->addFilter('code', 'channels.code');
         $this->addFilter('translated_name', 'requested_channel_translation.name');
-        $this->addFilter('translated_category_name', DB::raw('CASE WHEN '.$tablePrefix.'categories.name IS NOT NULL THEN REPLACE('.$tablePrefix."categories.name, '\"', '') ELSE CONCAT('[', ".$tablePrefix."categories.code, ']') END"));
+        $this->addFilter('translated_category_name', DB::raw('CASE WHEN '.$tablePrefix.'categories.name IS NOT NULL THEN REPLACE('.$tablePrefix."categories.name, '\"', '') ELSE ".$grammar->concat("'['", "{$tablePrefix}categories.code", "']'").' END'));
 
         return $queryBuilder;
     }

--- a/packages/Webkul/Admin/src/Resources/views/components/tinymce/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/tinymce/index.blade.php
@@ -481,7 +481,7 @@
                                 });
                             }
 
-                            editor.on('keyup', () => {
+                            editor.on('keyup change input', () => {
                                 this.field.onInput(editor.getContent());
                             });
                         },

--- a/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAITinyMCEButtonVisibilityTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAITinyMCEButtonVisibilityTest.php
@@ -12,3 +12,12 @@ it('should register the TinyMCE aibutton only when text generation is enabled', 
     $buttonIndex = strpos($contents, "addButton('aibutton'");
     expect($buttonIndex)->toBeGreaterThan($aiBlockStart);
 });
+
+it('should notify VeeValidate on keyup, change, and input events so paste clears validation errors', function () use ($view) {
+    $contents = file_get_contents($view);
+
+    // All three events must appear in a single editor.on() call so that
+    // paste operations (which do not reliably fire keyup) still clear
+    // the required-field validation error.
+    expect($contents)->toContain("editor.on('keyup change input'");
+});

--- a/packages/Webkul/AiAgent/src/Chat/Tools/BulkEdit.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/BulkEdit.php
@@ -8,6 +8,7 @@ use Webkul\AiAgent\Chat\ChatContext;
 use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
 use Webkul\AiAgent\Services\ProductWriterService;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 
 class BulkEdit implements PimTool
 {
@@ -47,13 +48,15 @@ class BulkEdit implements PimTool
 
                 $limit = min(max($limit, 1), 100);
 
+                $grammar = GrammarQueryManager::getGrammar();
+
                 $qb = DB::table('products')->select('id', 'sku', 'attribute_family_id', 'values', 'status');
 
                 if ($filter_by === 'status' && $filter_value !== null) {
                     $isActive = \in_array(strtolower($filter_value), ['active', 'enabled', '1', 'yes', 'on'], true);
                     $qb->where('status', $isActive ? 1 : 0);
                 } elseif ($filter_by === 'category' && $filter_value) {
-                    $qb->whereRaw("JSON_CONTAINS(JSON_EXTRACT(`values`, '$.categories'), ?)", ['"'.$filter_value.'"']);
+                    $qb->whereRaw($grammar->jsonContains('values', ['categories'], '?'), ['"'.$filter_value.'"']);
                 } elseif ($filter_by === 'family' && $filter_value) {
                     $familyId = DB::table('attribute_families')->where('code', $filter_value)->value('id');
                     if (! $familyId) {

--- a/packages/Webkul/AiAgent/src/Chat/Tools/DataQualityReport.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/DataQualityReport.php
@@ -7,6 +7,7 @@ use Prism\Prism\Tool;
 use Webkul\AiAgent\Chat\ChatContext;
 use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 
 class DataQualityReport implements PimTool
 {
@@ -28,12 +29,14 @@ class DataQualityReport implements PimTool
                 $channel = $context->channel;
                 $locale = $context->locale;
 
+                $grammar = GrammarQueryManager::getGrammar();
+
                 $qb = DB::table('products')
                     ->select('id', 'sku', 'status', 'values')
                     ->limit($limit);
 
                 if ($category) {
-                    $qb->whereRaw("JSON_CONTAINS(JSON_EXTRACT(`values`, '$.categories'), ?)", ['"'.$category.'"']);
+                    $qb->whereRaw($grammar->jsonContains('values', ['categories'], '?'), ['"'.$category.'"']);
                 }
 
                 $products = $qb->get();

--- a/packages/Webkul/AiAgent/src/Chat/Tools/EditImage.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/EditImage.php
@@ -13,6 +13,7 @@ use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
 use Webkul\Attribute\Models\Attribute;
 use Webkul\Core\Filesystem\FileStorer;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 use Webkul\MagicAI\Enums\AiProvider;
 use Webkul\Product\Models\Product;
 
@@ -232,7 +233,7 @@ class EditImage implements PimTool
 
         return $family->customAttributes()
             ->whereIn('type', ['image', 'gallery'])
-            ->orderByRaw("FIELD(type, 'image', 'gallery')")
+            ->orderByRaw(GrammarQueryManager::getGrammar()->orderByField('type', ["'image'", "'gallery'"], 'text'))
             ->first();
     }
 

--- a/packages/Webkul/AiAgent/src/Chat/Tools/ListCategories.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/ListCategories.php
@@ -7,6 +7,7 @@ use Prism\Prism\Tool;
 use Webkul\AiAgent\Chat\ChatContext;
 use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 
 class ListCategories implements PimTool
 {
@@ -26,14 +27,16 @@ class ListCategories implements PimTool
 
                 $limit = min(max($limit, 1), 100);
 
+                $grammar = GrammarQueryManager::getGrammar();
+
                 $qb = DB::table('categories')
                     ->select('id', 'code', 'parent_id', 'additional_data');
 
                 if ($search) {
                     $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
-                    $qb->where(function ($q) use ($escaped, $context) {
+                    $qb->where(function ($q) use ($escaped, $context, $grammar) {
                         $q->where('code', 'like', "%{$escaped}%")
-                            ->orWhereRaw("JSON_EXTRACT(additional_data, '$.locale_specific.{$context->locale}.name') LIKE ?", ["%{$escaped}%"]);
+                            ->orWhereRaw($grammar->jsonExtract('additional_data', 'locale_specific', $context->locale, 'name').' LIKE ?', ["%{$escaped}%"]);
                     });
                 }
 

--- a/packages/Webkul/AiAgent/src/Chat/Tools/SearchProducts.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/SearchProducts.php
@@ -8,6 +8,7 @@ use Webkul\AiAgent\Chat\ChatContext;
 use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
 use Webkul\AiAgent\Services\SemanticRankingService;
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
 
 class SearchProducts implements PimTool
 {
@@ -38,21 +39,22 @@ class SearchProducts implements PimTool
                 // alias explicitly so JSON selects resolve to the same alias
                 // Laravel generates for the FROM clause.
                 $prefix = DB::getTablePrefix();
+                $grammar = GrammarQueryManager::getGrammar();
 
                 $qb = DB::table('products as p')
                     ->leftJoin('attribute_families as af', 'af.id', '=', 'p.attribute_family_id')
                     ->select(
                         'p.id', 'p.sku', 'p.type', 'p.status', 'af.code as family_code',
-                        DB::raw("JSON_UNQUOTE(JSON_EXTRACT(`{$prefix}p`.`values`, '$.channel_locale_specific.{$context->channel}.{$context->locale}.name')) as product_name"),
-                        DB::raw("JSON_UNQUOTE(JSON_EXTRACT(`{$prefix}p`.`values`, '$.common.url_key')) as url_key"),
+                        DB::raw($grammar->jsonExtract("{$prefix}p.values", 'channel_locale_specific', $context->channel, $context->locale, 'name').' as product_name'),
+                        DB::raw($grammar->jsonExtract("{$prefix}p.values", 'common', 'url_key').' as url_key'),
                     );
 
                 if ($query) {
                     $escaped = str_replace(['%', '_'], ['\%', '\_'], $query);
-                    $qb->where(function ($q) use ($escaped, $context, $prefix) {
+                    $qb->where(function ($q) use ($escaped, $context, $prefix, $grammar) {
                         $q->where('p.sku', 'like', "%{$escaped}%")
                             ->orWhere('p.values->common->url_key', 'like', "%{$escaped}%")
-                            ->orWhereRaw("JSON_EXTRACT(`{$prefix}p`.`values`, '$.channel_locale_specific.{$context->channel}.{$context->locale}.name') LIKE ?", ["%{$escaped}%"]);
+                            ->orWhereRaw($grammar->jsonExtract("{$prefix}p.values", 'channel_locale_specific', $context->channel, $context->locale, 'name').' LIKE ?', ["%{$escaped}%"]);
                     });
                 }
 

--- a/packages/Webkul/AiAgent/tests/Unit/Tools/EditImageToolTest.php
+++ b/packages/Webkul/AiAgent/tests/Unit/Tools/EditImageToolTest.php
@@ -122,7 +122,7 @@ describe('EditImage tool parameter and source resolution (Issue #683)', function
             base_path('packages/Webkul/AiAgent/src/Chat/Tools/EditImage.php')
         );
 
-        expect($source)->not->toContain("FIELD(type");
+        expect($source)->not->toContain('FIELD(type');
         expect($source)->toContain('orderByField');
         expect($source)->toContain('GrammarQueryManager');
     });

--- a/packages/Webkul/AiAgent/tests/Unit/Tools/EditImageToolTest.php
+++ b/packages/Webkul/AiAgent/tests/Unit/Tools/EditImageToolTest.php
@@ -116,4 +116,14 @@ describe('EditImage tool parameter and source resolution (Issue #683)', function
         expect($source)->toContain('edit_image with the product SKU');
         expect($source)->toContain('fetches the image from the product');
     });
+
+    it('resolveImageAttribute uses grammar orderByField instead of MySQL FIELD()', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/EditImage.php')
+        );
+
+        expect($source)->not->toContain("FIELD(type");
+        expect($source)->toContain('orderByField');
+        expect($source)->toContain('GrammarQueryManager');
+    });
 });

--- a/packages/Webkul/AiAgent/tests/Unit/Tools/PgsqlCompatibilityTest.php
+++ b/packages/Webkul/AiAgent/tests/Unit/Tools/PgsqlCompatibilityTest.php
@@ -1,0 +1,77 @@
+<?php
+
+describe('AiAgent tools — PostgreSQL raw SQL compatibility', function () {
+
+    it('SearchProducts does not contain hardcoded MySQL JSON functions', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/SearchProducts.php')
+        );
+
+        expect($source)->not->toContain('JSON_UNQUOTE');
+        expect($source)->not->toContain('JSON_EXTRACT');
+        expect($source)->not->toContain('JSON_CONTAINS');
+    });
+
+    it('SearchProducts uses the grammar helper for JSON extraction', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/SearchProducts.php')
+        );
+
+        expect($source)->toContain('GrammarQueryManager');
+        expect($source)->toContain('->jsonExtract(');
+    });
+
+    it('DataQualityReport does not contain hardcoded JSON_CONTAINS', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/DataQualityReport.php')
+        );
+
+        expect($source)->not->toContain('JSON_CONTAINS');
+        expect($source)->not->toContain('JSON_EXTRACT');
+    });
+
+    it('DataQualityReport uses the grammar helper for JSON containment', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/DataQualityReport.php')
+        );
+
+        expect($source)->toContain('GrammarQueryManager');
+        expect($source)->toContain('->jsonContains(');
+    });
+
+    it('ListCategories does not contain hardcoded JSON_EXTRACT in raw SQL', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/ListCategories.php')
+        );
+
+        expect($source)->not->toContain('JSON_EXTRACT');
+        expect($source)->not->toContain('JSON_UNQUOTE');
+    });
+
+    it('ListCategories uses the grammar helper for JSON extraction', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/ListCategories.php')
+        );
+
+        expect($source)->toContain('GrammarQueryManager');
+        expect($source)->toContain('->jsonExtract(');
+    });
+
+    it('BulkEdit does not contain hardcoded JSON_CONTAINS', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/BulkEdit.php')
+        );
+
+        expect($source)->not->toContain('JSON_CONTAINS');
+        expect($source)->not->toContain('JSON_EXTRACT');
+    });
+
+    it('BulkEdit uses the grammar helper for JSON containment', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/AiAgent/src/Chat/Tools/BulkEdit.php')
+        );
+
+        expect($source)->toContain('GrammarQueryManager');
+        expect($source)->toContain('->jsonContains(');
+    });
+});

--- a/packages/Webkul/Core/src/Contracts/Database/Grammar.php
+++ b/packages/Webkul/Core/src/Contracts/Database/Grammar.php
@@ -20,6 +20,8 @@ interface Grammar
 
     public function jsonExtract(string $column, string ...$pathSegments): string;
 
+    public function jsonContains(string $column, array $pathSegments, string $value): string;
+
     public function orderByField(string $column, array $ids, string $type = ''): string;
 
     public function getRegexOperator(): string;

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
@@ -52,6 +52,15 @@ class MySQLGrammar implements Grammar
         return "JSON_UNQUOTE(JSON_EXTRACT({$escaped}, '{$jsonPath}'))";
     }
 
+    public function jsonContains(string $column, array $pathSegments, string $value): string
+    {
+        $parts = explode('.', $column);
+        $escaped = implode('.', array_map(fn ($p) => "`{$p}`", $parts));
+        $jsonPath = '$.'.implode('.', $pathSegments);
+
+        return "JSON_CONTAINS(JSON_EXTRACT({$escaped}, '{$jsonPath}'), {$value})";
+    }
+
     public function orderByField(string $column, array $ids, string $type = ''): string
     {
         $idList = implode(',', $ids);

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
@@ -59,6 +59,16 @@ class PostgresGrammar implements Grammar
         return $jsonString;
     }
 
+    public function jsonContains(string $column, array $pathSegments, string $value): string
+    {
+        $parts = explode('.', $column);
+        $quotedColumn = implode('.', array_map(fn ($p) => '"'.$p.'"', $parts));
+        $operators = array_map(fn ($p) => "'{$p}'", $pathSegments);
+        $jsonExpr = $quotedColumn.'->'.implode('->', $operators);
+
+        return "({$jsonExpr})::jsonb @> {$value}::jsonb";
+    }
+
     public function orderByField(string $column, array $values, string $type = 'int'): string
     {
         $idList = implode(',', $values);

--- a/packages/Webkul/Core/tests/Unit/GrammarJsonContainsTest.php
+++ b/packages/Webkul/Core/tests/Unit/GrammarJsonContainsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Webkul\Core\Helpers\Database\Grammars\MySQLGrammar;
+use Webkul\Core\Helpers\Database\Grammars\PostgresGrammar;
+
+describe('Grammar::jsonContains — MySQL', function () {
+
+    it('produces JSON_CONTAINS with JSON_EXTRACT for a single path segment', function () {
+        $result = (new MySQLGrammar)->jsonContains('values', ['categories'], '?');
+
+        expect($result)->toBe("JSON_CONTAINS(JSON_EXTRACT(`values`, '$.categories'), ?)");
+    });
+
+    it('produces correct path for nested segments', function () {
+        $result = (new MySQLGrammar)->jsonContains('values', ['channel_locale_specific', 'en_US', 'name'], '?');
+
+        expect($result)->toBe("JSON_CONTAINS(JSON_EXTRACT(`values`, '$.channel_locale_specific.en_US.name'), ?)");
+    });
+
+    it('escapes a table-qualified column with backticks', function () {
+        $result = (new MySQLGrammar)->jsonContains('p.values', ['categories'], '?');
+
+        expect($result)->toBe("JSON_CONTAINS(JSON_EXTRACT(`p`.`values`, '$.categories'), ?)");
+    });
+
+    it('accepts a literal value instead of a placeholder', function () {
+        $result = (new MySQLGrammar)->jsonContains('values', ['tags'], '"electronics"');
+
+        expect($result)->toContain('JSON_CONTAINS');
+        expect($result)->toContain('"electronics"');
+    });
+});
+
+describe('Grammar::jsonContains — PostgreSQL', function () {
+
+    it('produces jsonb containment operator for a single path segment', function () {
+        $result = (new PostgresGrammar)->jsonContains('values', ['categories'], '?');
+
+        expect($result)->toBe('("values"->\'categories\')::jsonb @> ?::jsonb');
+    });
+
+    it('produces chained arrow operators for nested segments', function () {
+        $result = (new PostgresGrammar)->jsonContains('values', ['channel_locale_specific', 'en_US', 'name'], '?');
+
+        expect($result)->toBe('("values"->\'channel_locale_specific\'->\'en_US\'->\'name\')::jsonb @> ?::jsonb');
+    });
+
+    it('double-quotes a table-qualified column', function () {
+        $result = (new PostgresGrammar)->jsonContains('p.values', ['categories'], '?');
+
+        expect($result)->toBe('("p"."values"->\'categories\')::jsonb @> ?::jsonb');
+    });
+
+    it('uses @> containment operator not LIKE or IN', function () {
+        $result = (new PostgresGrammar)->jsonContains('values', ['tags'], '?');
+
+        expect($result)->toContain('@>');
+        expect($result)->not->toContain('LIKE');
+        expect($result)->not->toContain(' IN ');
+    });
+});

--- a/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
@@ -97,6 +97,18 @@ class DemoExtrasTableSeeder extends Seeder
                     $rows = [];
                 }
 
+                // The dump captures whatever profile image was uploaded on the
+                // source server (e.g. "admins/1/download.png"). That file is not
+                // shipped with the seeder assets, so the path resolves to a broken
+                // image. Null it out so the letter-avatar fallback renders instead.
+                if ($table === 'admins') {
+                    $rows = array_map(static function (array $row): array {
+                        $row['image'] = null;
+
+                        return $row;
+                    }, $rows);
+                }
+
                 DB::table($table)->delete();
 
                 if (empty($rows)) {

--- a/packages/Webkul/Installer/tests/Unit/DemoExtrasAdminImageSeederTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DemoExtrasAdminImageSeederTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
+
+describe('DemoExtrasTableSeeder – admin profile image sanitisation', function () {
+    it('nulls out every admin image so a server-specific path never ships as a broken image', function () {
+        // Simulate the admins rows exactly as they appear in demo_extras.json
+        $rows = [
+            [
+                'id'             => 1,
+                'name'           => 'Demo Admin',
+                'email'          => 'admin@example.com',
+                'password'       => 'hashed',
+                'image'          => 'admins/1/download.png',
+                'status'         => 1,
+                'role_id'        => 1,
+                'timezone'       => 'UTC',
+                'ui_locale_id'   => 1,
+                'remember_token' => null,
+                'created_at'     => '2026-01-01 00:00:00',
+                'updated_at'     => '2026-01-01 00:00:00',
+            ],
+            [
+                'id'             => 2,
+                'name'           => 'Second Admin',
+                'email'          => 'second@example.com',
+                'password'       => 'hashed',
+                'image'          => null,
+                'status'         => 1,
+                'role_id'        => 1,
+                'timezone'       => 'UTC',
+                'ui_locale_id'   => 1,
+                'remember_token' => null,
+                'created_at'     => '2026-01-01 00:00:00',
+                'updated_at'     => '2026-01-01 00:00:00',
+            ],
+        ];
+
+        // Apply the same transformation the seeder uses
+        $sanitised = array_map(static function (array $row): array {
+            $row['image'] = null;
+
+            return $row;
+        }, $rows);
+
+        foreach ($sanitised as $row) {
+            expect($row['image'])->toBeNull();
+        }
+    });
+
+    it('contains the admins image-nulling guard in the seeder source', function () {
+        $source = file_get_contents(
+            __DIR__.'/../../src/Database/Seeders/DemoExtrasTableSeeder.php'
+        );
+
+        expect($source)->toContain("if (\$table === 'admins')");
+        expect($source)->toContain("\$row['image'] = null;");
+    });
+});

--- a/packages/Webkul/Installer/tests/Unit/DemoExtrasAdminImageSeederTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DemoExtrasAdminImageSeederTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
-
 describe('DemoExtrasTableSeeder – admin profile image sanitisation', function () {
     it('nulls out every admin image so a server-specific path never ships as a broken image', function () {
         // Simulate the admins rows exactly as they appear in demo_extras.json


### PR DESCRIPTION
                                                                                                                                                              
  ## Summary
                                                                                                                                                              
  - **Add `jsonContains()` to the Grammar abstraction** — new method added to the `Grammar` interface and implemented in both `MySQLGrammar` (uses            
  `JSON_CONTAINS + JSON_EXTRACT`) and `PostgresGrammar` (uses `::jsonb @> ::jsonb` containment operator), closing the last gap in the DB-agnostic query layer.
  - **Fix AiAgent tools** — all four tools (`SearchProducts`, `DataQualityReport`, `ListCategories`, `BulkEdit`) were using hardcoded MySQL-only JSON         
  functions (`JSON_UNQUOTE`, `JSON_EXTRACT`, `JSON_CONTAINS` with backtick identifiers) directly in raw SQL. Replaced with `GrammarQueryManager::getGrammar()`
   calls so the correct dialect is emitted at runtime.
  - **Fix `EditImage` ordering** — `FIELD(type, 'image', 'gallery')` replaced with `$grammar->orderByField()`, which maps to                                  
  `array_position(ARRAY[...]::text[], col)` on PostgreSQL.                                                                                                    
  - **Fix DataGrids** — `AttributeOptionDataGrid` `GROUP_CONCAT(...SEPARATOR...)` and `ChannelDataGrid` raw `CONCAT(...)` replaced with
  `$grammar->groupConcat()` and `$grammar->concat()` respectively.                                                                                            
                                                            
  ## Files Changed                                                                                                                                            
                                                            
  | File | What changed |
  |---|---|
  | `Core/Contracts/Database/Grammar.php` | Added `jsonContains()` to interface |
  | `Core/Helpers/Database/Grammars/MySQLGrammar.php` | Implemented `jsonContains()` |                                                                        
  | `Core/Helpers/Database/Grammars/PostgresGrammar.php` | Implemented `jsonContains()` |
  | `AiAgent/Chat/Tools/SearchProducts.php` | Replaced 3 raw `JSON_UNQUOTE/JSON_EXTRACT` with grammar |                                                       
  | `AiAgent/Chat/Tools/DataQualityReport.php` | Replaced `JSON_CONTAINS` with `$grammar->jsonContains()` |                                                   
  | `AiAgent/Chat/Tools/ListCategories.php` | Replaced raw `JSON_EXTRACT` in `whereRaw` with grammar |                                                        
  | `AiAgent/Chat/Tools/BulkEdit.php` | Replaced `JSON_CONTAINS` with `$grammar->jsonContains()` |                                                            
  | `AiAgent/Chat/Tools/EditImage.php` | Replaced `FIELD()` with `$grammar->orderByField()` |                                                                 
  | `Admin/DataGrids/Catalog/AttributeOptionDataGrid.php` | Replaced `GROUP_CONCAT...SEPARATOR` with grammar |                                                
  | `Admin/DataGrids/Settings/ChannelDataGrid.php` | Replaced raw `CONCAT` with `$grammar->concat()` |                                                        
                                                                                                                                                              
  ## Test plan                                                                                                                                                
                                                            
  - [ ] Run the existing MySQL test suite — no regressions expected                                                                                           
  - [ ] Switch `DB_CONNECTION=pgsql` and verify:
    - Product search in AI Agent chat returns results                                                                                                         
    - Bulk edit by category filter works                                                                                                                      
    - Data quality report category filter works                                                                                                               
    - Category name search in AI Agent works                                                                                                                  
    - Image attribute auto-detection in AI edit works                                                                                                         
    - Attribute options datagrid loads and filters by code                                                                                                    
    - Channels datagrid loads with correct category name display 