### PR TITLE
fix(magic-ai): preserve all paragraphs when translating HTML fields

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/MagicAI/MagicAIController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/MagicAI/MagicAIController.php
@@ -379,7 +379,7 @@ class MagicAIController extends Controller
         $magicAi = $this->resolveTranslationPlatform();
 
         foreach ($targetLocales as $locale) {
-            $p = "Translate @$field into $locale. Return only the translated value wrapped in a single <p> tag. Do not include any additional text, descriptions, or explanations.";
+            $p = "Translate @$field into $locale. Preserve the original HTML structure (every <p>, <br>, list and inline tag). Return only the translated HTML, with no commentary, no wrapper, and no extra text.";
             $prompt = $this->promptService->getPrompt(
                 $p,
                 request()->input('resource_id'),
@@ -390,9 +390,9 @@ class MagicAIController extends Controller
                 ->setModel(request()->input('model'))
                 ->setPrompt($prompt)
                 ->ask();
-            preg_match_all('/<p>(.*?)<\/p>/', $response, $matches);
+            preg_match_all('/<p\b[^>]*>.*?<\/p>/s', $response, $matches);
 
-            $value = end($matches[1]);
+            $value = empty($matches[0]) ? trim($response) : implode('', $matches[0]);
             $translatedData[] = [
                 'locale'  => $locale,
                 'content' => $value,
@@ -468,7 +468,7 @@ class MagicAIController extends Controller
             foreach ($attributes as $key => $attribute) {
                 $field = $attribute['fieldName'];
 
-                $p = "Translate @$field into $locale. Return only the translated value wrapped in a single <p> tag. Do not include any additional text, descriptions, or explanations.";
+                $p = "Translate @$field into $locale. Preserve the original HTML structure (every <p>, <br>, list and inline tag). Return only the translated HTML, with no commentary, no wrapper, and no extra text.";
 
                 $prompt = $this->promptService->getPrompt(
                     $p,
@@ -481,8 +481,8 @@ class MagicAIController extends Controller
                     ->setPrompt($prompt)
                     ->ask();
 
-                preg_match_all('/<p>(.*?)<\/p>/', $response, $matches);
-                $value = end($matches[1]);
+                preg_match_all('/<p\b[^>]*>.*?<\/p>/s', $response, $matches);
+                $value = empty($matches[0]) ? trim($response) : implode('', $matches[0]);
 
                 $translatedDataForLocale[$field] = [
                     'field'   => $field,


### PR DESCRIPTION
## Summary

- Fixes #377 — Magic AI translation was dropping every `<p>` block except the last one when translating HTML fields like a product `description`.
- Two changes inside `MagicAIController` (in both `translateToManyLocale` and `translateAllAttribute`):
  - prompt now asks the model to preserve the original HTML structure instead of "wrap in a single `<p>`";
  - response parsing now keeps every `<p>` block (with attributes / multiline tolerated) and falls back to the raw response when the model returns plain text. The previous code captured every paragraph correctly with `preg_match_all` and then discarded all but the last via `end($matches[1])`.

## Before / after

**Before** — 3-paragraph `en_GB` description translated to `fr_FR`: only the 3rd paragraph survived in the saved value.

**After** — all 3 paragraphs are translated and saved, structure preserved.

## Test plan

- [x] Patch applied on a UnoPim `v1.0.0` instance, `optimize:clear` run.
- [x] Re-ran AI translation `en_GB` → `fr_FR` on a 3-paragraph product description: all paragraphs are now translated and stored under `channel_locale_specific.<channel>.fr_FR.description`.
- [x] Re-ran translation on a single-paragraph short description: still translated correctly (no regression on simple inputs).
- [ ] CI on upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)