### PR TITLE
Fix DB_PREFIX validation: catch internal spaces, trim, clear stale

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -300,18 +300,9 @@ class Installer extends Command
                 label: 'Please enter the database prefix',
                 default: env('DB_PREFIX') ?? '',
                 validate: function (string $value): ?string {
-                    // Trim first so a user typing "  uno  " is silently
-                    // accepted, but "a a" (internal whitespace) still gets
-                    // rejected because the trimmed value still contains
-                    // a space.
                     $trimmed = trim($value);
 
                     return match (true) {
-                        // preg_match returns int 1 on match, not bool true —
-                        // `match (true)` uses strict equality, so we must
-                        // cast to bool or the regex cases silently never
-                        // fire (which is what let "a a" through to .env in
-                        // issue #538).
                         (bool) preg_match('/\s/', $trimmed)             => 'The database prefix cannot contain spaces.',
                         strlen($trimmed) > 4                            => 'The database prefix should not exceed 4 characters.',
                         (bool) preg_match('/[^a-zA-Z0-9_]/', $trimmed)  => 'The database prefix can only contain letters, numbers, and underscores.',
@@ -345,13 +336,6 @@ class Installer extends Command
         }
 
         foreach ($databaseDetails as $key => $value) {
-            // DB_PREFIX may legitimately be cleared (an empty prefix is
-            // valid), so always write it — otherwise the previous stale
-            // value (e.g. a corrupt `"a a"` from a botched earlier run)
-            // stays in .env and breaks subsequent boots. For credentials
-            // (DB_DATABASE / DB_USERNAME / DB_PASSWORD), keep the
-            // non-empty guard so an accidental blank prompt doesn't
-            // overwrite a working value.
             if ($value || $key === 'DB_PREFIX') {
                 $this->envUpdate($key, $value);
             }

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -299,12 +299,27 @@ class Installer extends Command
             'DB_PREFIX' => text(
                 label: 'Please enter the database prefix',
                 default: env('DB_PREFIX') ?? '',
-                validate: fn (string $value) => match (true) {
-                    strlen($value) > 4                     => 'The database prefix should not exceed 4 characters.',
-                    preg_match('/[^a-zA-Z0-9_]/', $value)  => 'The database prefix can only contain letters, numbers, and underscores.',
-                    default                                => null
+                validate: function (string $value): ?string {
+                    // Trim first so a user typing "  uno  " is silently
+                    // accepted, but "a a" (internal whitespace) still gets
+                    // rejected because the trimmed value still contains
+                    // a space.
+                    $trimmed = trim($value);
+
+                    return match (true) {
+                        // preg_match returns int 1 on match, not bool true —
+                        // `match (true)` uses strict equality, so we must
+                        // cast to bool or the regex cases silently never
+                        // fire (which is what let "a a" through to .env in
+                        // issue #538).
+                        (bool) preg_match('/\s/', $trimmed)             => 'The database prefix cannot contain spaces.',
+                        strlen($trimmed) > 4                            => 'The database prefix should not exceed 4 characters.',
+                        (bool) preg_match('/[^a-zA-Z0-9_]/', $trimmed)  => 'The database prefix can only contain letters, numbers, and underscores.',
+                        default                                         => null,
+                    };
                 },
-                hint: 'or press enter to continue'
+                transform: trim(...),
+                hint: 'or press enter to continue (leave empty to clear)'
             ),
 
             'DB_USERNAME' => text(
@@ -319,6 +334,8 @@ class Installer extends Command
             ),
         ];
 
+        $databaseDetails['DB_PREFIX'] = trim((string) ($databaseDetails['DB_PREFIX'] ?? ''));
+
         if (
             ! $databaseDetails['DB_DATABASE']
             || ! $databaseDetails['DB_USERNAME']
@@ -328,7 +345,14 @@ class Installer extends Command
         }
 
         foreach ($databaseDetails as $key => $value) {
-            if ($value) {
+            // DB_PREFIX may legitimately be cleared (an empty prefix is
+            // valid), so always write it — otherwise the previous stale
+            // value (e.g. a corrupt `"a a"` from a botched earlier run)
+            // stays in .env and breaks subsequent boots. For credentials
+            // (DB_DATABASE / DB_USERNAME / DB_PASSWORD), keep the
+            // non-empty guard so an accidental blank prompt doesn't
+            // overwrite a working value.
+            if ($value || $key === 'DB_PREFIX') {
                 $this->envUpdate($key, $value);
             }
         }

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -64,13 +64,17 @@ class InstallerController extends Controller
     public function envFileSetup(Request $request): JsonResponse
     {
         $rules = [
-            'db_prefix' => 'not_regex:/[^A-Za-z0-9_]/',
+            'db_prefix' => 'not_regex:/[^A-Za-z0-9_]/|max:4',
         ];
 
         $request = $request->all();
 
+        if (isset($request['db_prefix'])) {
+            $request['db_prefix'] = trim((string) $request['db_prefix']);
+        }
+
         $request = array_map(function ($input) {
-            return strip_tags($input);
+            return strip_tags((string) $input);
         }, $request);
 
         $validator = Validator::make($request, $rules);

--- a/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
@@ -2,12 +2,6 @@
 
 use Webkul\Installer\Console\Commands\Installer;
 
-/**
- * Replace the Installer command with a subclass that captures every
- * envUpdate(key, value) call into the given array reference, and mute
- * downstream `call()` invocations so the test focuses purely on prompt
- * → envUpdate flow.
- */
 function bindInstallerCapturingEnvUpdate(array &$captured): Closure
 {
     return function () use (&$captured) {
@@ -63,12 +57,6 @@ it('rejects a DB_PREFIX containing an internal space ("a a") so it never reaches
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
 
-    // Laravel Prompts in non-interactive mode re-prompts on validation
-    // failure until a fresh answer is provided or stdin is exhausted —
-    // since we never supply a follow-up answer, the prompt aborts and
-    // the artisan command exits non-zero. That's the contract here:
-    // "a a" must NOT make it through, and DB_PREFIX must NOT have been
-    // captured as a quote-wrapped corruption.
     $this->artisan('unopim:install', ['--skip-admin-creation' => true])
         ->expectsQuestion('Please select the database connection', 'mysql')
         ->expectsQuestion('Please enter the database host', '127.0.0.1')
@@ -94,9 +82,6 @@ it('writes an empty DB_PREFIX to envUpdate so a stale prefix can be cleared from
         ->expectsQuestion('Please enter your database password', 'root')
         ->assertExitCode(0);
 
-    // DB_PREFIX must still be written — otherwise the loop's `if ($value)`
-    // guard skips the write and leaves the previous DB_PREFIX (e.g. the
-    // corrupt `"a a"` from a botched earlier run) stuck in .env.
     expect($captured)->toHaveKey('DB_PREFIX')
         ->and($captured['DB_PREFIX'])->toBe('');
 });

--- a/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Webkul\Installer\Console\Commands\Installer;
+
+/**
+ * Replace the Installer command with a subclass that captures every
+ * envUpdate(key, value) call into the given array reference, and mute
+ * downstream `call()` invocations so the test focuses purely on prompt
+ * → envUpdate flow.
+ */
+function bindInstallerCapturingEnvUpdate(array &$captured): Closure
+{
+    return function () use (&$captured) {
+        return new class($captured) extends Installer
+        {
+            private array $captured;
+
+            public function __construct(array &$captured)
+            {
+                parent::__construct();
+                $this->captured = &$captured;
+            }
+
+            public function call($command, array $arguments = [], $output = null)
+            {
+                return 0;
+            }
+
+            protected function envUpdate(string $key, string $value): void
+            {
+                $this->captured[$key] = $value;
+            }
+
+            public function handle()
+            {
+                $this->askForDatabaseDetails();
+
+                return 0;
+            }
+        };
+    };
+}
+
+it('trims surrounding whitespace on DB_PREFIX so "  uno  " never reaches envUpdate as a quote-wrapped value (issue #538)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '  uno  ')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured)->toHaveKey('DB_PREFIX')
+        ->and($captured['DB_PREFIX'])->toBe('uno');
+});
+
+it('rejects a DB_PREFIX containing an internal space ("a a") so it never reaches envUpdate or .env (issue #538)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
+
+    // Laravel Prompts in non-interactive mode re-prompts on validation
+    // failure until a fresh answer is provided or stdin is exhausted —
+    // since we never supply a follow-up answer, the prompt aborts and
+    // the artisan command exits non-zero. That's the contract here:
+    // "a a" must NOT make it through, and DB_PREFIX must NOT have been
+    // captured as a quote-wrapped corruption.
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', 'a a')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_PREFIX');
+});
+
+it('writes an empty DB_PREFIX to envUpdate so a stale prefix can be cleared from .env (issue #538)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    // DB_PREFIX must still be written — otherwise the loop's `if ($value)`
+    // guard skips the write and leaves the previous DB_PREFIX (e.g. the
+    // corrupt `"a a"` from a botched earlier run) stuck in .env.
+    expect($captured)->toHaveKey('DB_PREFIX')
+        ->and($captured['DB_PREFIX'])->toBe('');
+});


### PR DESCRIPTION
## Issue Reference
<! Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
Three stacked bugs around the `DB_PREFIX` prompt in `unopim:install` made it possible to corrupt `.env` and produce fatal table names like `"uno"admins` (which then broke the audits trigger migration):

1. **Regex validation was silently no-op.** The validator used `match (true) { preg_match(...) => 'msg' }`. `preg_match` returns `int(1)` on match, but `match (true)` uses strict equality, so `1 === true` is always `false` — the regex cases never fired. Only the unrelated length check ever rejected anything, which is why `"a a"` got through.
2. **No trim path for surrounding whitespace.** A user typing `"  uno  "` reached `envUpdate`, which wraps any value containing whitespace in double quotes — that's how `DB_PREFIX="uno "` ended up in `.env` and produced `"uno"admins` table names.
3. **Empty prefix was never written.** The write loop guarded with `if ($value)`, so clearing the prompt back to empty silently kept the previous (often corrupt) `DB_PREFIX` value in `.env`.

The fix (in `Installer::askForDatabaseDetails`):
- Cast `preg_match(...)` to `(bool)` in the validate arms so the regex cases actually fire.
- Trim once at the top of the validator so `"  uno  "` is silently accepted but `"a a"` still trips the space rule.
- Explicit space rule: `"The database prefix cannot contain spaces."` (the user-visible message issue #538 asked for).
- `transform: trim(...)` for interactive runs; explicit `trim` on the captured value before the `envUpdate` loop for non-interactive runs (Laravel's prompt fallback path skips `transform`).
- Always write `DB_PREFIX` in the loop (allowing empty to clear a stale value). Other credentials keep the non-empty guard so an accidental blank prompt can't wipe a working value.
- Web installer mirror: `InstallerController::envFileSetup` now trims `db_prefix` before validation and gains `max:4` to match the CLI's 4-char cap.

## How To Test This?
**Manual (CLI):**
1. Run `php artisan unopim:install`.
2. At "Please enter the database prefix" try each of:
   - `a a` → must be rejected with `The database prefix cannot contain spaces.`
   - `  uno  ` → must be accepted and stored in `.env` as `DB_PREFIX=uno` (no quotes).
   - `too_long_prefix` → rejected with the 4-char-cap message.
   - `foo!` → rejected with the alphanumeric-only message.
   - empty (just press Enter) → must clear any previous `DB_PREFIX` value from `.env`.
3. Open `.env` after each run and confirm `DB_PREFIX=` does **not** contain quotes or whitespace.

**Manual (web installer):** submit the env-setup step with `db_prefix=" uno "` and confirm the response trims correctly (or rejects spaces / overlong prefixes).

**Automated:**
```bash
vendor/bin/pest packages/Webkul/Installer/tests
vendor/bin/pint --test packages/Webkul/Installer
