### PR TITLE
fix/installer-drops-orphan-tables-across-prefix-changes

### DIFF
--- a/packages/Webkul/Completeness/src/Jobs/BulkProductCompletenessJob.php
+++ b/packages/Webkul/Completeness/src/Jobs/BulkProductCompletenessJob.php
@@ -144,8 +144,8 @@ class BulkProductCompletenessJob implements ShouldBeUnique, ShouldQueue
 
         if (empty($userIds)) {
             $admins = DB::table('admins')
-                ->join('admin_roles', 'admins.role_id', '=', 'admin_roles.id')
-                ->where('admin_roles.permission_type', 'all')
+                ->join('roles', 'admins.role_id', '=', 'roles.id')
+                ->where('roles.permission_type', 'all')
                 ->select('admins.id', 'admins.email')
                 ->get();
 

--- a/packages/Webkul/Completeness/tests/Feature/BulkProductCompletenessJobNotificationTest.php
+++ b/packages/Webkul/Completeness/tests/Feature/BulkProductCompletenessJobNotificationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Webkul\Completeness\Jobs\BulkProductCompletenessJob;
+
+it('joins the roles table (not admin_roles) when looking up admins to notify so the post-seed completeness step does not crash with a missing-table error', function () {
+
+    expect(fn () => BulkProductCompletenessJob::sendCompletionNotification(
+        totalProducts: 0,
+        userId: null,
+        familyId: null,
+    ))->not->toThrow(QueryException::class);
+});
+
+it('selects admins via the roles join when no specific userId is supplied', function () {
+
+    $roleId = DB::table('roles')->insertGetId([
+        'name'            => 'TestAllRole',
+        'description'     => 'all-perm role for completeness notification test',
+        'permission_type' => 'all',
+        'permissions'     => null,
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    $adminId = DB::table('admins')->insertGetId([
+        'name'       => 'Completeness Notify Target',
+        'email'      => 'notify-target+'.uniqid().'@example.test',
+        'password'   => bcrypt('test'),
+        'status'     => 1,
+        'role_id'    => $roleId,
+        'timezone'   => 'UTC',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $hits = DB::table('admins')
+        ->join('roles', 'admins.role_id', '=', 'roles.id')
+        ->where('roles.permission_type', 'all')
+        ->where('admins.id', $adminId)
+        ->count();
+
+    expect($hits)->toBe(1);
+});

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -300,18 +300,9 @@ class Installer extends Command
                 label: 'Please enter the database prefix',
                 default: env('DB_PREFIX') ?? '',
                 validate: function (string $value): ?string {
-                    // Trim first so a user typing "  uno  " is silently
-                    // accepted, but "a a" (internal whitespace) still gets
-                    // rejected because the trimmed value still contains
-                    // a space.
                     $trimmed = trim($value);
 
                     return match (true) {
-                        // preg_match returns int 1 on match, not bool true —
-                        // `match (true)` uses strict equality, so we must
-                        // cast to bool or the regex cases silently never
-                        // fire (which is what let "a a" through to .env in
-                        // issue #538).
                         (bool) preg_match('/\s/', $trimmed)             => 'The database prefix cannot contain spaces.',
                         strlen($trimmed) > 4                            => 'The database prefix should not exceed 4 characters.',
                         (bool) preg_match('/[^a-zA-Z0-9_]/', $trimmed)  => 'The database prefix can only contain letters, numbers, and underscores.',
@@ -345,13 +336,6 @@ class Installer extends Command
         }
 
         foreach ($databaseDetails as $key => $value) {
-            // DB_PREFIX may legitimately be cleared (an empty prefix is
-            // valid), so always write it — otherwise the previous stale
-            // value (e.g. a corrupt `"a a"` from a botched earlier run)
-            // stays in .env and breaks subsequent boots. For credentials
-            // (DB_DATABASE / DB_USERNAME / DB_PASSWORD), keep the
-            // non-empty guard so an accidental blank prompt doesn't
-            // overwrite a working value.
             if ($value || $key === 'DB_PREFIX') {
                 $this->envUpdate($key, $value);
             }

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -299,12 +299,27 @@ class Installer extends Command
             'DB_PREFIX' => text(
                 label: 'Please enter the database prefix',
                 default: env('DB_PREFIX') ?? '',
-                validate: fn (string $value) => match (true) {
-                    strlen($value) > 4                     => 'The database prefix should not exceed 4 characters.',
-                    preg_match('/[^a-zA-Z0-9_]/', $value)  => 'The database prefix can only contain letters, numbers, and underscores.',
-                    default                                => null
+                validate: function (string $value): ?string {
+                    // Trim first so a user typing "  uno  " is silently
+                    // accepted, but "a a" (internal whitespace) still gets
+                    // rejected because the trimmed value still contains
+                    // a space.
+                    $trimmed = trim($value);
+
+                    return match (true) {
+                        // preg_match returns int 1 on match, not bool true —
+                        // `match (true)` uses strict equality, so we must
+                        // cast to bool or the regex cases silently never
+                        // fire (which is what let "a a" through to .env in
+                        // issue #538).
+                        (bool) preg_match('/\s/', $trimmed)             => 'The database prefix cannot contain spaces.',
+                        strlen($trimmed) > 4                            => 'The database prefix should not exceed 4 characters.',
+                        (bool) preg_match('/[^a-zA-Z0-9_]/', $trimmed)  => 'The database prefix can only contain letters, numbers, and underscores.',
+                        default                                         => null,
+                    };
                 },
-                hint: 'or press enter to continue'
+                transform: trim(...),
+                hint: 'or press enter to continue (leave empty to clear)'
             ),
 
             'DB_USERNAME' => text(
@@ -319,6 +334,8 @@ class Installer extends Command
             ),
         ];
 
+        $databaseDetails['DB_PREFIX'] = trim((string) ($databaseDetails['DB_PREFIX'] ?? ''));
+
         if (
             ! $databaseDetails['DB_DATABASE']
             || ! $databaseDetails['DB_USERNAME']
@@ -328,7 +345,14 @@ class Installer extends Command
         }
 
         foreach ($databaseDetails as $key => $value) {
-            if ($value) {
+            // DB_PREFIX may legitimately be cleared (an empty prefix is
+            // valid), so always write it — otherwise the previous stale
+            // value (e.g. a corrupt `"a a"` from a botched earlier run)
+            // stays in .env and breaks subsequent boots. For credentials
+            // (DB_DATABASE / DB_USERNAME / DB_PASSWORD), keep the
+            // non-empty guard so an accidental blank prompt doesn't
+            // overwrite a working value.
+            if ($value || $key === 'DB_PREFIX') {
                 $this->envUpdate($key, $value);
             }
         }

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -122,6 +122,9 @@ class Installer extends Command
             }
         }
 
+        $this->warn('Step: Dropping any tables left over from a previous install...');
+        $this->dropAllTablesInConfiguredSchema();
+
         $this->warn('Step: Migrating all tables...');
         $this->call('migrate:fresh');
 
@@ -535,6 +538,54 @@ class Installer extends Command
         } finally {
             config(['queue.default' => $originalDefault]);
         }
+    }
+
+    /**
+     * Drop every table in the connection's current database. Used to
+     * scrub residue from prior installs (different prefixes, partial
+     * runs) before migrate:fresh recreates the schema.
+     */
+    protected function dropAllTablesInConfiguredSchema(): void
+    {
+        $connection = DB::connection();
+        $database = $connection->getDatabaseName();
+
+        if (! $database) {
+            $this->warn('No database selected; skipping pre-migration drop.');
+
+            return;
+        }
+
+        $tables = $this->listTablesInConfiguredSchema();
+
+        if (empty($tables)) {
+            return;
+        }
+
+        $quoted = array_map(static fn (string $t): string => '`'.str_replace('`', '``', $t).'`', $tables);
+
+        $connection->statement('SET FOREIGN_KEY_CHECKS = 0');
+        try {
+            $connection->statement('DROP TABLE IF EXISTS '.implode(',', $quoted));
+        } finally {
+            $connection->statement('SET FOREIGN_KEY_CHECKS = 1');
+        }
+
+        $this->info('Dropped '.\count($tables).' table(s) from `'.$database.'`.');
+    }
+
+    /**
+     * Names of every table visible in the current MySQL schema.
+     *s
+     *
+     * @return list<string>
+     */
+    protected function listTablesInConfiguredSchema(): array
+    {
+        return array_map(
+            static fn (object $row): string => array_values((array) $row)[0],
+            DB::connection()->select('SHOW TABLES')
+        );
     }
 
     /**

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -544,6 +544,12 @@ class Installer extends Command
      * Drop every table in the connection's current database. Used to
      * scrub residue from prior installs (different prefixes, partial
      * runs) before migrate:fresh recreates the schema.
+     *
+     * Uses Laravel's driver-aware Schema::dropAllTables() rather than
+     * raw `SHOW TABLES` + `DROP TABLE` so the same code works on MySQL,
+     * PostgreSQL and SQLite — `SHOW TABLES` is MySQL-only and blew up
+     * the PostgreSQL CI install with SQLSTATE[42704] "unrecognized
+     * configuration parameter 'tables'".
      */
     protected function dropAllTablesInConfiguredSchema(): void
     {
@@ -556,36 +562,33 @@ class Installer extends Command
             return;
         }
 
-        $tables = $this->listTablesInConfiguredSchema();
+        $tablesBefore = $this->listTablesInConfiguredSchema();
 
-        if (empty($tables)) {
+        if (empty($tablesBefore)) {
             return;
         }
 
-        $quoted = array_map(static fn (string $t): string => '`'.str_replace('`', '``', $t).'`', $tables);
+        $connection->getSchemaBuilder()->dropAllTables();
 
-        $connection->statement('SET FOREIGN_KEY_CHECKS = 0');
-        try {
-            $connection->statement('DROP TABLE IF EXISTS '.implode(',', $quoted));
-        } finally {
-            $connection->statement('SET FOREIGN_KEY_CHECKS = 1');
-        }
-
-        $this->info('Dropped '.\count($tables).' table(s) from `'.$database.'`.');
+        $this->info('Dropped '.\count($tablesBefore).' table(s) from `'.$database.'`.');
     }
 
     /**
-     * Names of every table visible in the current MySQL schema.
-     *s
+     * Names of every table in the configured schema, driver-agnostic.
+     * Split out so orphan-prefix cleanup can be exercised by tests
+     * without the destructive DROP that dropAllTablesInConfiguredSchema
+     * executes.
      *
      * @return list<string>
      */
     protected function listTablesInConfiguredSchema(): array
     {
-        return array_map(
-            static fn (object $row): string => array_values((array) $row)[0],
-            DB::connection()->select('SHOW TABLES')
-        );
+        // Pass the current schema explicitly — calling getTableListing()
+        // with no args lists every table from every schema on the
+        // server, which would over-report in shared-MySQL environments.
+        $schema = DB::connection()->getDatabaseName();
+
+        return DB::connection()->getSchemaBuilder()->getTableListing($schema, false);
     }
 
     /**

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -64,13 +64,17 @@ class InstallerController extends Controller
     public function envFileSetup(Request $request): JsonResponse
     {
         $rules = [
-            'db_prefix' => 'not_regex:/[^A-Za-z0-9_]/',
+            'db_prefix' => 'not_regex:/[^A-Za-z0-9_]/|max:4',
         ];
 
         $request = $request->all();
 
+        if (isset($request['db_prefix'])) {
+            $request['db_prefix'] = trim((string) $request['db_prefix']);
+        }
+
         $request = array_map(function ($input) {
-            return strip_tags($input);
+            return strip_tags((string) $input);
         }, $request);
 
         $validator = Validator::make($request, $rules);

--- a/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
@@ -2,12 +2,6 @@
 
 use Webkul\Installer\Console\Commands\Installer;
 
-/**
- * Replace the Installer command with a subclass that captures every
- * envUpdate(key, value) call into the given array reference, and mute
- * downstream `call()` invocations so the test focuses purely on prompt
- * → envUpdate flow.
- */
 function bindInstallerCapturingEnvUpdate(array &$captured): Closure
 {
     return function () use (&$captured) {
@@ -63,12 +57,6 @@ it('rejects a DB_PREFIX containing an internal space ("a a") so it never reaches
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
 
-    // Laravel Prompts in non-interactive mode re-prompts on validation
-    // failure until a fresh answer is provided or stdin is exhausted —
-    // since we never supply a follow-up answer, the prompt aborts and
-    // the artisan command exits non-zero. That's the contract here:
-    // "a a" must NOT make it through, and DB_PREFIX must NOT have been
-    // captured as a quote-wrapped corruption.
     $this->artisan('unopim:install', ['--skip-admin-creation' => true])
         ->expectsQuestion('Please select the database connection', 'mysql')
         ->expectsQuestion('Please enter the database host', '127.0.0.1')
@@ -94,9 +82,6 @@ it('writes an empty DB_PREFIX to envUpdate so a stale prefix can be cleared from
         ->expectsQuestion('Please enter your database password', 'root')
         ->assertExitCode(0);
 
-    // DB_PREFIX must still be written — otherwise the loop's `if ($value)`
-    // guard skips the write and leaves the previous DB_PREFIX (e.g. the
-    // corrupt `"a a"` from a botched earlier run) stuck in .env.
     expect($captured)->toHaveKey('DB_PREFIX')
         ->and($captured['DB_PREFIX'])->toBe('');
 });

--- a/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabasePrefixTrimTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Webkul\Installer\Console\Commands\Installer;
+
+/**
+ * Replace the Installer command with a subclass that captures every
+ * envUpdate(key, value) call into the given array reference, and mute
+ * downstream `call()` invocations so the test focuses purely on prompt
+ * → envUpdate flow.
+ */
+function bindInstallerCapturingEnvUpdate(array &$captured): Closure
+{
+    return function () use (&$captured) {
+        return new class($captured) extends Installer
+        {
+            private array $captured;
+
+            public function __construct(array &$captured)
+            {
+                parent::__construct();
+                $this->captured = &$captured;
+            }
+
+            public function call($command, array $arguments = [], $output = null)
+            {
+                return 0;
+            }
+
+            protected function envUpdate(string $key, string $value): void
+            {
+                $this->captured[$key] = $value;
+            }
+
+            public function handle()
+            {
+                $this->askForDatabaseDetails();
+
+                return 0;
+            }
+        };
+    };
+}
+
+it('trims surrounding whitespace on DB_PREFIX so "  uno  " never reaches envUpdate as a quote-wrapped value (issue #538)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '  uno  ')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured)->toHaveKey('DB_PREFIX')
+        ->and($captured['DB_PREFIX'])->toBe('uno');
+});
+
+it('rejects a DB_PREFIX containing an internal space ("a a") so it never reaches envUpdate or .env (issue #538)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
+
+    // Laravel Prompts in non-interactive mode re-prompts on validation
+    // failure until a fresh answer is provided or stdin is exhausted —
+    // since we never supply a follow-up answer, the prompt aborts and
+    // the artisan command exits non-zero. That's the contract here:
+    // "a a" must NOT make it through, and DB_PREFIX must NOT have been
+    // captured as a quote-wrapped corruption.
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', 'a a')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_PREFIX');
+});
+
+it('writes an empty DB_PREFIX to envUpdate so a stale prefix can be cleared from .env (issue #538)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    // DB_PREFIX must still be written — otherwise the loop's `if ($value)`
+    // guard skips the write and leaves the previous DB_PREFIX (e.g. the
+    // corrupt `"a a"` from a botched earlier run) stuck in .env.
+    expect($captured)->toHaveKey('DB_PREFIX')
+        ->and($captured['DB_PREFIX'])->toBe('');
+});

--- a/packages/Webkul/Installer/tests/Feature/InstallerOrphanPrefixCleanupTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerOrphanPrefixCleanupTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\Installer\Console\Commands\Installer;
+
+it('lists every table in the configured schema regardless of prefix, so orphan tables from prior installs (e.g. pim_*) are picked up for cleanup', function () {
+    $markers = [
+        '__test_pim_orphan_'.uniqid(),
+        '__test_add_orphan_'.uniqid(),
+        '__test_orphan_'.uniqid(),
+    ];
+
+    foreach ($markers as $name) {
+        DB::statement("CREATE TABLE IF NOT EXISTS `$name` (id INT PRIMARY KEY)");
+    }
+
+    try {
+        $installer = app(Installer::class);
+
+        $listed = (new ReflectionClass($installer))
+            ->getMethod('listTablesInConfiguredSchema')
+            ->invoke($installer);
+
+        foreach ($markers as $name) {
+            expect($listed)->toContain($name);
+        }
+    } finally {
+
+        foreach ($markers as $name) {
+            DB::statement("DROP TABLE IF EXISTS `$name`");
+        }
+    }
+});


### PR DESCRIPTION
## Issue Reference
 Drop all tables before migrate: fresh so prefix changes don't leave orphans

 - Table is roles, query uses admin_roles
