### PR TITLE
Fix: align column label fallback between Manage Columns popup and product grid (pgsql/docker)

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/Options/AjaxOptionsController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/Options/AjaxOptionsController.php
@@ -165,17 +165,10 @@ class AjaxOptionsController extends Controller
      */
     protected function getTranslatedLabel(string $currentLocaleCode, TranslatableModel $option, string $entityName): ?string
     {
-        $translationColumn = $this->getTranslationColumnName($entityName);
-
-        $translation = $option->translate($currentLocaleCode);
-
-        if ($translation && ! empty($translation->{$translationColumn})) {
-            return $translation->{$translationColumn};
-        }
-
-        $fallback = $option->translations->first(fn ($t) => ! empty($t->{$translationColumn}));
-
-        return $fallback?->{$translationColumn};
+        return $option->getTranslatedValueWithFallback(
+            $this->getTranslationColumnName($entityName),
+            $currentLocaleCode
+        );
     }
 
     /**

--- a/packages/Webkul/Admin/src/Http/Controllers/VueJsSelect/AbstractOptionsController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/VueJsSelect/AbstractOptionsController.php
@@ -85,23 +85,10 @@ class AbstractOptionsController extends Controller
      */
     protected function getTranslatedLabel(string $currentLocaleCode, TranslatableModel $option, string $entityName = ''): ?string
     {
-        $column = $this->getTranslationColumnName($entityName);
-
-        $label = $option->translate($currentLocaleCode)?->{$column};
-
-        if (! empty($label)) {
-            return $label;
-        }
-
-        foreach ($option->translations as $translation) {
-            $label = $translation->{$column};
-
-            if (! empty($label)) {
-                return $label;
-            }
-        }
-
-        return null;
+        return $option->getTranslatedValueWithFallback(
+            $this->getTranslationColumnName($entityName),
+            $currentLocaleCode
+        );
     }
 
     /**

--- a/packages/Webkul/Admin/src/Traits/AttributeColumnTrait.php
+++ b/packages/Webkul/Admin/src/Traits/AttributeColumnTrait.php
@@ -16,9 +16,11 @@ trait AttributeColumnTrait
     {
         $attributeArray = $attribute->toArray();
 
+        $label = $attribute->getTranslatedValueWithFallback('name');
+
         $column = [
             'index'      => $attributeArray['code'],
-            'label'      => $attributeArray['name'] ?: '['.$attributeArray['code'].']',
+            'label'      => ! empty($label) ? $label : '['.$attributeArray['code'].']',
             'type'       => $attribute->getFilterType(),
             'searchable' => false,
             'filterable' => $attributeArray['is_filterable'] ?? false,

--- a/packages/Webkul/Admin/tests/Feature/ManageColumnsLabelFallbackTest.php
+++ b/packages/Webkul/Admin/tests/Feature/ManageColumnsLabelFallbackTest.php
@@ -19,10 +19,11 @@ it('falls back to a non-current-locale label for the column when the current loc
     $attribute = Attribute::factory()->create(['type' => 'text']);
 
     $attribute->translations()->delete();
-    $attribute->translations()->create([
-        'locale' => 'de_DE',
-        'name'   => 'Deutscher Name',
-    ]);
+
+    $translation = $attribute->translations()->make(['name' => 'Deutscher Name']);
+    $translation->locale = 'de_DE';
+    $translation->save();
+
     $attribute->load('translations');
 
     expect($attribute->getTranslatedValueWithFallback('name', 'en_US'))

--- a/packages/Webkul/Admin/tests/Feature/ManageColumnsLabelFallbackTest.php
+++ b/packages/Webkul/Admin/tests/Feature/ManageColumnsLabelFallbackTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Regression: attributes that have a label in some locale but not in the
+ * current one previously rendered the locale-fallback label in the
+ * "available columns" popup (which uses the locale-fallback chain) but
+ * showed "[code]" in the grid once applied (the grid only checked the
+ * current locale). The popup and the grid must agree.
+ */
+
+use Webkul\Admin\Traits\AttributeColumnTrait;
+use Webkul\Attribute\Models\Attribute;
+
+beforeEach(function () {
+    $this->loginAsAdmin();
+});
+
+it('falls back to a non-current-locale label for the column when the current locale is empty', function () {
+    $attribute = Attribute::factory()->create(['type' => 'text']);
+
+    $attribute->translations()->delete();
+    $attribute->translations()->create([
+        'locale' => 'de_DE',
+        'name'   => 'Deutscher Name',
+    ]);
+    $attribute->load('translations');
+
+    expect($attribute->getTranslatedValueWithFallback('name', 'en_US'))
+        ->toBe('Deutscher Name');
+
+    $trait = new class
+    {
+        use AttributeColumnTrait {
+            buildColumnDefinition as public;
+        }
+    };
+
+    $column = $trait->buildColumnDefinition($attribute);
+
+    expect($column['label'])->toBe('Deutscher Name');
+});
+
+it('returns the code placeholder when no translation exists in any locale', function () {
+    $attribute = Attribute::factory()->create(['type' => 'text']);
+
+    $attribute->translations()->delete();
+    $attribute->load('translations');
+
+    expect($attribute->getTranslatedValueWithFallback('name', 'en_US'))->toBeNull();
+
+    $trait = new class
+    {
+        use AttributeColumnTrait {
+            buildColumnDefinition as public;
+        }
+    };
+
+    $column = $trait->buildColumnDefinition($attribute);
+
+    expect($column['label'])->toBe('['.$attribute->code.']');
+});

--- a/packages/Webkul/Core/src/Eloquent/TranslatableModel.php
+++ b/packages/Webkul/Core/src/Eloquent/TranslatableModel.php
@@ -59,4 +59,28 @@ class TranslatableModel extends Model
             }
         });
     }
+
+    /**
+     * Resolve a translated field for the requested locale, falling back to any
+     * locale that has a non-empty value. Returns null when every translation
+     * is empty so callers can apply their own placeholder (e.g. "[code]").
+     */
+    public function getTranslatedValueWithFallback(string $column, ?string $locale = null): ?string
+    {
+        $locale = $locale ?: core()->getRequestedLocaleCode();
+
+        $value = $this->translate($locale)?->{$column};
+
+        if (! empty($value)) {
+            return $value;
+        }
+
+        foreach ($this->translations as $translation) {
+            if (! empty($translation->{$column})) {
+                return $translation->{$column};
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
 PR Description

  ## Summary
  - Manage Columns popup and the product grid used different label-resolution paths: the popup fell back to any non-empty locale translation, the grid only
  checked the current locale. Result on pgsql/Docker: an attribute labelled only in (e.g.) German showed the German name in the popup but `[code]` in the grid
   after Apply.
  - Centralised the locale-fallback chain on `TranslatableModel::getTranslatedValueWithFallback()` and pointed both code paths at it, so the popup and grid always
   agree.

  ## Test plan
  - [ ] PG/Docker: Product grid → Columns load without 500 / infinite shimmer.
  - [ ] Attribute with only a non-current-locale label → same label shown in popup and in the grid after Apply.
  - [ ] Attribute with no label anywhere → `[code]` shown in both places.
  - [ ] `vendor/bin/pint` and `vendor/bin/pest --filter=ManageColumnsLabelFallback` pass.