### PR TITLE
Fix: fixed the docker APP_KEY empty issue

### DIFF
--- a/dockerfiles/fpm-entrypoint.sh
+++ b/dockerfiles/fpm-entrypoint.sh
@@ -3,6 +3,13 @@ set -e
 
 LOCK_FILE="/var/www/html/storage/unopim.lock"
 
+# Generate APP_KEY if empty (must happen before any artisan/composer step)
+if grep -q '^APP_KEY=$' /var/www/html/.env; then
+    KEY="base64:$(openssl rand -base64 32)"
+    sed -i "s|^APP_KEY=$|APP_KEY=${KEY}|" /var/www/html/.env
+fi
+export APP_KEY=$(grep '^APP_KEY=' /var/www/html/.env | cut -d= -f2-)
+
 # ─── First-time setup ───────────────────────────────────────────────
 if [ ! -f "$LOCK_FILE" ]; then
 
@@ -30,14 +37,6 @@ if [ ! -f "$LOCK_FILE" ]; then
         # Sync APP_URL with APP_PORT if port was changed
         if [ -n "$APP_PORT" ] && [ "$APP_PORT" != "8000" ] && [ -f /var/www/html/.env ]; then
             sed -i "s|APP_URL=http://localhost:8000|APP_URL=http://localhost:${APP_PORT}|" /var/www/html/.env
-        fi
-
-        # Generate APP_KEY if not already set in .env
-        if grep -q "^APP_KEY=$" /var/www/html/.env 2>/dev/null || [ -z "$APP_KEY" ]; then
-            echo "→ Generating application key..."
-            php artisan key:generate --force
-            # Export into current process so PHP-FPM inherits the new key
-            export APP_KEY=$(grep "^APP_KEY=" /var/www/html/.env | cut -d '=' -f 2-)
         fi
 
         echo "→ Running database migrations..."

--- a/dockerfiles/q-entrypoint.sh
+++ b/dockerfiles/q-entrypoint.sh
@@ -25,6 +25,9 @@ while [ ! -f "$LOCK_FILE" ]; do
 done
 echo "Application ready."
 
+# Pick up APP_KEY from .env (fpm container wrote it after we started).
+export APP_KEY=$(grep '^APP_KEY=' /var/www/html/.env | cut -d= -f2-)
+
 echo "Starting queue worker: queues=${QUEUE_NAMES}"
 
 # Drop to www-data and start queue:work

--- a/dockerfiles/scheduler-entrypoint.sh
+++ b/dockerfiles/scheduler-entrypoint.sh
@@ -18,6 +18,9 @@ while [ ! -f "$LOCK_FILE" ]; do
 done
 echo "Application ready."
 
+# Pick up APP_KEY from .env (fpm container wrote it after we started).
+export APP_KEY=$(grep '^APP_KEY=' /var/www/html/.env | cut -d= -f2-)
+
 echo "Starting Laravel scheduler (runs every minute)..."
 
 # Drop to www-data and start scheduler


### PR DESCRIPTION
  ## Summary

  `.env.docker` ships with `APP_KEY=` empty. The old entrypoint tried to generate it, but only *after* composer/artisan steps that could fail first under `set
   -e` — so on first `docker compose up` the key never got written and the app loaded blank. Users had to `down` + `up` again to fix it.

  - **`fpm-entrypoint.sh`** — generate `APP_KEY` as the very first step using `openssl` (no Laravel needed), write it to `.env`.
  - **`q-entrypoint.sh` / `scheduler-entrypoint.sh`** — re-export `APP_KEY` from `.env` after the setup lock file appears. `env_file: .env` in compose caches
  values at container creation, so these workers otherwise stay stuck with the empty key.

  ## Test plan

  - Fresh `cp .env.docker .env` + `docker compose up -d` → app reachable on first try.
  - `.env` on host has a real `APP_KEY=base64:...` after boot.
  - Queue + scheduler logs show no "No application encryption key" errors.

