### PR TITLE
Fix/installer UI and docker sample data

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -7,11 +7,9 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Webkul\Core\ElasticSearch;
-use Webkul\Installer\Database\Seeders\CategoryDemoTableSeeder;
 use Webkul\Installer\Database\Seeders\DatabaseSeeder as UnoPimDatabaseSeeder;
-use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
-use Webkul\Installer\Database\Seeders\ProductTableSeeder;
 use Webkul\Installer\Events\ComposerEvents;
+use Webkul\Installer\Helpers\DemoDataInstaller;
 
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\password;
@@ -491,49 +489,13 @@ class Installer extends Command
 
     protected function seedSampleProducts(): void
     {
-        try {
-            $this->warn('Step: Seeding demo extras (channels, attributes, families, core config, ...)...');
-            app(DemoExtrasTableSeeder::class)->run();
+        $result = app(DemoDataInstaller::class)
+            ->seed(fn (string $message) => $this->warn('Step: '.$message));
 
-            $this->warn('Step: Seeding demo categories...');
-            app(CategoryDemoTableSeeder::class)->run();
-
-            $this->warn('Step: Seeding sample products...');
-            app(ProductTableSeeder::class)->run();
-
+        if ($result['success']) {
             $this->info('Sample products seeded successfully.');
-
-            if (config('elasticsearch.enabled') == 'true') {
-                $this->warn('Step: Re-indexing categories to Elasticsearch...');
-                $this->call('unopim:category:index');
-
-                $this->warn('Step: Re-indexing products to Elasticsearch...');
-                $this->call('unopim:product:index');
-            }
-
-            $this->warn('Step: Recalculating product completeness...');
-            $this->recalculateCompleteness();
-        } catch (\Exception $e) {
-            $this->error("Failed to seed sample products: {$e->getMessage()}");
-        }
-    }
-
-    /**
-     * Recalculate product completeness synchronously. The
-     * `unopim:completeness:recalculate` command dispatches queue jobs, so
-     * we temporarily force the sync driver to guarantee the jobs run
-     * before the installer finishes.
-     */
-    protected function recalculateCompleteness(): void
-    {
-        $originalDefault = config('queue.default');
-
-        try {
-            config(['queue.default' => 'sync']);
-
-            $this->call('unopim:completeness:recalculate', ['--all' => true]);
-        } finally {
-            config(['queue.default' => $originalDefault]);
+        } else {
+            $this->error("Failed to seed sample products: {$result['error']}");
         }
     }
 

--- a/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
+++ b/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Webkul\Installer\Console\Commands;
+
+use Illuminate\Console\Command;
+use Webkul\Installer\Helpers\DemoDataInstaller;
+
+/**
+ * Seeds demo extras, demo categories, and sample products.
+ *
+ * Exists so non-interactive callers (docker-compose entrypoint scripts,
+ * CI smoke tests) can opt into the same demo data that the CLI
+ * installer's `--with-demo-data` flag and the UI installer's
+ * "sample products?" checkbox produce.
+ */
+class SeedDemoData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'unopim:install:demo-data
+        { --force : Re-seed even when demo data is already present. }';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Seed demo extras, categories, and sample products into an installed UnoPim database.';
+
+    /**
+     * Execute the command.
+     */
+    public function handle(DemoDataInstaller $installer): int
+    {
+        $result = $installer->seed(
+            fn (string $message) => $this->warn('Step: '.$message),
+            (bool) $this->option('force'),
+        );
+
+        if (! ($result['success'] ?? false)) {
+            $this->error("Failed to seed sample data: {$result['error']}");
+
+            return self::FAILURE;
+        }
+
+        if ($result['skipped'] ?? false) {
+            $this->info('Demo data is already seeded — nothing to do. Re-run with --force to re-seed.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Sample products seeded successfully.');
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
+++ b/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Webkul\Installer\Helpers;
+
+use Closure;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+use Webkul\Installer\Database\Seeders\CategoryDemoTableSeeder;
+use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
+use Webkul\Installer\Database\Seeders\ProductTableSeeder;
+
+/**
+ * Runs the demo extras, demo categories, and sample products seeders
+ * plus Elasticsearch reindexing and completeness recalculation.
+ *
+ * Shared by the CLI installer, the UI installer endpoint, and the
+ * `unopim:install:demo-data` command used by docker-compose so all
+ * three install paths emit identical seeded data.
+ */
+class DemoDataInstaller
+{
+    /**
+     * Run every demo seeder synchronously.
+     *
+     * The optional reporter closure receives short status strings so
+     * callers (artisan commands, controllers, tests) can surface them.
+     *
+     * Idempotent: when demo data is already present (a non-root
+     * category exists, which the base installer never creates), the
+     * call short-circuits with `skipped: true`. Pass `$force: true`
+     * to re-run the seeders even when data is already present.
+     *
+     * @return array{success: bool, skipped?: bool, error?: string}
+     */
+    public function seed(?Closure $reporter = null, bool $force = false): array
+    {
+        $report = $reporter ?? static fn (string $message) => null;
+
+        if (! $force && $this->isAlreadySeeded()) {
+            $report('Demo data is already seeded; skipping. Pass --force to re-seed.');
+
+            return ['success' => true, 'skipped' => true];
+        }
+
+        try {
+            $report('Seeding demo extras (channels, attributes, families, core config, ...)...');
+            app(DemoExtrasTableSeeder::class)->run();
+
+            $report('Seeding demo categories...');
+            app(CategoryDemoTableSeeder::class)->run();
+
+            $report('Seeding sample products...');
+            app(ProductTableSeeder::class)->run();
+
+            if (config('elasticsearch.enabled') == 'true') {
+                $report('Re-indexing categories to Elasticsearch...');
+                Artisan::call('unopim:category:index');
+
+                $report('Re-indexing products to Elasticsearch...');
+                Artisan::call('unopim:product:index');
+            }
+
+            $report('Recalculating product completeness...');
+            $this->recalculateCompleteness();
+
+            return ['success' => true];
+        } catch (Throwable $e) {
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Returns true when demo data is already present in the database.
+     *
+     * Probes for any non-root category — the base installer only
+     * creates the root row, while CategoryDemoTableSeeder inserts the
+     * full demo tree under it. A child category therefore proves the
+     * demo pipeline has already run.
+     */
+    public function isAlreadySeeded(): bool
+    {
+        try {
+            return DB::table('categories')->whereNotNull('parent_id')->exists();
+        } catch (Throwable) {
+            // Table missing / DB not migrated yet → treat as not seeded
+            // so the caller can decide how to handle the failure mode.
+            return false;
+        }
+    }
+
+    /**
+     * Recalculate product completeness synchronously. The
+     * `unopim:completeness:recalculate` command dispatches queue jobs,
+     * so the sync driver is forced while it runs to guarantee work
+     * lands before the installer finishes.
+     */
+    protected function recalculateCompleteness(): void
+    {
+        $originalDefault = config('queue.default');
+
+        try {
+            config(['queue.default' => 'sync']);
+
+            Artisan::call('unopim:completeness:recalculate', ['--all' => true]);
+        } finally {
+            config(['queue.default' => $originalDefault]);
+        }
+    }
+}

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
 use Webkul\Installer\Helpers\DatabaseManager;
+use Webkul\Installer\Helpers\DemoDataInstaller;
 use Webkul\Installer\Helpers\EnvironmentManager;
 use Webkul\Installer\Helpers\ServerRequirements;
 
@@ -63,10 +64,6 @@ class InstallerController extends Controller
      */
     public function envFileSetup(Request $request): JsonResponse
     {
-        $rules = [
-            'db_prefix' => 'not_regex:/[^A-Za-z0-9_]/|max:4',
-        ];
-
         $request = $request->all();
 
         if (isset($request['db_prefix'])) {
@@ -77,10 +74,20 @@ class InstallerController extends Controller
             return strip_tags((string) $input);
         }, $request);
 
-        $validator = Validator::make($request, $rules);
+        // Match the CLI installer's prefix validation 1:1 so both install
+        // paths surface the same migration-blocking errors up-front.
+        $validator = Validator::make($request, [
+            'db_prefix' => ['nullable', 'string', 'max:4', 'regex:/^[A-Za-z0-9_]*$/'],
+        ], [
+            'db_prefix.max'   => 'The database prefix should not exceed 4 characters.',
+            'db_prefix.regex' => 'The database prefix can only contain letters, numbers, and underscores.',
+        ]);
 
         if ($validator->fails()) {
-            return response()->json(['error' => 'Failed to parse dotenv file due to some invalid values'], 422);
+            return response()->json([
+                'error'  => $validator->errors()->first('db_prefix') ?: 'Failed to parse dotenv file due to some invalid values',
+                'errors' => $validator->errors()->toArray(),
+            ], 422);
         }
 
         $message = $this->environmentManager->generateEnv($request);
@@ -172,6 +179,27 @@ class InstallerController extends Controller
         } catch (\Throwable $th) {
             dd($th);
         }
+    }
+
+    /**
+     * Run the demo extras, demo categories, and sample product seeders.
+     *
+     * Invoked from the UI installer when the operator opts into sample
+     * data on the create-admin step. Returns 200 with `success: true`
+     * on success, 500 with the seeder error message otherwise.
+     */
+    public function seedSampleData(DemoDataInstaller $installer): JsonResponse
+    {
+        $result = $installer->seed();
+
+        if (! ($result['success'] ?? false)) {
+            return new JsonResponse([
+                'success' => false,
+                'error'   => $result['error'] ?? 'Failed to seed sample data.',
+            ], 500);
+        }
+
+        return new JsonResponse(['success' => true]);
     }
 
     /**

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -19,10 +19,12 @@ class CanInstall
     {
         if (Str::contains($request->getPathInfo(), '/install')) {
             if ($this->isAlreadyInstalled() && ! $request->ajax()) {
-                if (file_exists(realpath(__DIR__.'/../../../../../../public/install.php'))) {
-                    unlink(realpath(__DIR__.'/../../../../../../public/install.php'));
-                }
-
+                // Previously this branch unlinked `public/install.php` (the
+                // pre-Laravel composer bootstrap) on every "installed app
+                // visited /install" hit. That broke re-install workflows
+                // (DB driver switch, demo-data reseed, CI feature tests)
+                // and added no real security — the bootstrap is idempotent
+                // once `vendor/` exists. Redirect-only is enough.
                 return redirect()->route('admin.dashboard.index');
             }
         } else {

--- a/packages/Webkul/Installer/src/Providers/InstallerServiceProvider.php
+++ b/packages/Webkul/Installer/src/Providers/InstallerServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Webkul\Installer\Console\Commands\DefaultUser as DefaultUserCommand;
 use Webkul\Installer\Console\Commands\Installer as InstallerCommand;
 use Webkul\Installer\Console\Commands\PurgeUnusedImages as PurgeUnusedImagesCommand;
+use Webkul\Installer\Console\Commands\SeedDemoData as SeedDemoDataCommand;
 use Webkul\Installer\Http\Middleware\CanInstall;
 use Webkul\Installer\Http\Middleware\Locale;
 use Webkul\Installer\Listeners\Installer;
@@ -51,6 +52,7 @@ class InstallerServiceProvider extends ServiceProvider
                 InstallerCommand::class,
                 DefaultUserCommand::class,
                 PurgeUnusedImagesCommand::class,
+                SeedDemoDataCommand::class,
             ]);
         }
     }

--- a/packages/Webkul/Installer/src/Resources/lang/ar_AE/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/ar_AE/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'مسؤل',
-                'unopim'           => 'أونوبيم',
-                'confirm-password' => 'تأكيد كلمة المرور',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'بريد إلكتروني',
-                'password'         => 'كلمة المرور',
-                'title'            => 'إنشاء المسؤول',
+                'admin'                   => 'مسؤل',
+                'unopim'                  => 'أونوبيم',
+                'confirm-password'        => 'تأكيد كلمة المرور',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'بريد إلكتروني',
+                'password'                => 'كلمة المرور',
+                'title'                   => 'إنشاء المسؤول',
+                'seed-sample-data'        => 'تثبيت منتجات وبيانات تجريبية',
+                'seeding-sample-data'     => 'جارٍ إنشاء منتجات العينة وبيانات التجريب، قد يستغرق ذلك بضع دقائق...',
+                'seed-sample-data-failed' => 'تعذر تثبيت البيانات التجريبية. يمكنك تثبيتها لاحقًا عبر `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'العملات المسموح بها',

--- a/packages/Webkul/Installer/src/Resources/lang/ca_ES/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/ca_ES/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrador',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirma la contrasenya',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Correu electrònic',
-                'password'         => 'Contrasenya',
-                'title'            => 'Crea administrador',
+                'admin'                   => 'Administrador',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirma la contrasenya',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Correu electrònic',
+                'password'                => 'Contrasenya',
+                'title'                   => 'Crea administrador',
+                'seed-sample-data'        => 'Instal·la productes de mostra i dades de demostració',
+                'seeding-sample-data'     => 'Carregant productes de mostra i dades de demostració, això pot trigar uns minuts...',
+                'seed-sample-data-failed' => 'No s\'han pogut carregar les dades de mostra. Pots instal·lar-les més tard mitjançant `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Monedes permeses',

--- a/packages/Webkul/Installer/src/Resources/lang/da_DK/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/da_DK/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrator',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Bekræft adgangskode',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-mail',
-                'password'         => 'Adgangskode',
-                'title'            => 'Opret administrator',
+                'admin'                   => 'Administrator',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Bekræft adgangskode',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Adgangskode',
+                'title'                   => 'Opret administrator',
+                'seed-sample-data'        => 'Installer demoprodukter og demodata',
+                'seeding-sample-data'     => 'Indlæser demoprodukter og demodata, dette kan tage et par minutter...',
+                'seed-sample-data-failed' => 'Demodata kunne ikke indlæses. Du kan installere dem senere via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Tilladte valutaer',

--- a/packages/Webkul/Installer/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/de_DE/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Admin',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Passwort bestätigen',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-Mail',
-                'password'         => 'Passwort',
-                'title'            => 'Erstellen Sie einen Administrator',
+                'admin'                   => 'Admin',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Passwort bestätigen',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-Mail',
+                'password'                => 'Passwort',
+                'title'                   => 'Erstellen Sie einen Administrator',
+                'seed-sample-data'        => 'Beispielprodukte und Demodaten installieren',
+                'seeding-sample-data'     => 'Beispielprodukte und Demodaten werden geladen, dies kann einige Minuten dauern...',
+                'seed-sample-data-failed' => 'Demodaten konnten nicht geladen werden. Sie können sie später über `php artisan unopim:install:demo-data` installieren.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Zulässige Währungen',

--- a/packages/Webkul/Installer/src/Resources/lang/en_AU/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/en_AU/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Admin',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirm Password',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Password',
-                'title'            => 'Create Administrator',
+                'admin'                   => 'Admin',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirm Password',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Password',
+                'title'                   => 'Create Administrator',
+                'seed-sample-data'        => 'Install sample products and demo data',
+                'seeding-sample-data'     => 'Seeding sample products and demo data, this may take a few minutes...',
+                'seed-sample-data-failed' => 'Sample data could not be seeded. You can install it later via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Allowed Currencies',

--- a/packages/Webkul/Installer/src/Resources/lang/en_GB/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/en_GB/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Admin',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirm Password',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Password',
-                'title'            => 'Create Administrator',
+                'admin'                   => 'Admin',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirm Password',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Password',
+                'title'                   => 'Create Administrator',
+                'seed-sample-data'        => 'Install sample products and demo data',
+                'seeding-sample-data'     => 'Seeding sample products and demo data, this may take a few minutes...',
+                'seed-sample-data-failed' => 'Sample data could not be seeded. You can install it later via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Allowed Currencies',

--- a/packages/Webkul/Installer/src/Resources/lang/en_NZ/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/en_NZ/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Admin',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirm Password',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Password',
-                'title'            => 'Create Administrator',
+                'admin'                   => 'Admin',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirm Password',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Password',
+                'title'                   => 'Create Administrator',
+                'seed-sample-data'        => 'Install sample products and demo data',
+                'seeding-sample-data'     => 'Seeding sample products and demo data, this may take a few minutes...',
+                'seed-sample-data-failed' => 'Sample data could not be seeded. You can install it later via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Allowed Currencies',

--- a/packages/Webkul/Installer/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/en_US/app.php
@@ -111,13 +111,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Admin',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirm Password',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Password',
-                'title'            => 'Create Administrator',
+                'admin'                    => 'Admin',
+                'unopim'                   => 'UnoPim',
+                'confirm-password'         => 'Confirm Password',
+                'email-address'            => 'admin@example.com',
+                'email'                    => 'Email',
+                'password'                 => 'Password',
+                'title'                    => 'Create Administrator',
+                'seed-sample-data'         => 'Install sample products and demo data',
+                'seeding-sample-data'      => 'Seeding sample products and demo data, this may take a few minutes...',
+                'seed-sample-data-failed'  => 'Sample data could not be seeded. You can install it later via `php artisan unopim:install:demo-data`.',
             ],
 
             'environment-configuration' => [

--- a/packages/Webkul/Installer/src/Resources/lang/es_ES/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/es_ES/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administración',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'confirmar Contraseña',
-                'email-address'    => 'administrador@ejemplo.com',
-                'email'            => 'Correo electrónico',
-                'password'         => 'Contraseña',
-                'title'            => 'Crear administrador',
+                'admin'                   => 'Administración',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'confirmar Contraseña',
+                'email-address'           => 'administrador@ejemplo.com',
+                'email'                   => 'Correo electrónico',
+                'password'                => 'Contraseña',
+                'title'                   => 'Crear administrador',
+                'seed-sample-data'        => 'Instalar productos de muestra y datos de demostración',
+                'seeding-sample-data'     => 'Sembrando productos de muestra y datos de demostración, esto puede tardar unos minutos...',
+                'seed-sample-data-failed' => 'No se pudieron sembrar los datos de muestra. Puede instalarlos más tarde mediante `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Monedas permitidas',

--- a/packages/Webkul/Installer/src/Resources/lang/es_VE/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/es_VE/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrador',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirmar Contraseña',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Correo Electrónico',
-                'password'         => 'Contraseña',
-                'title'            => 'Crear Administrador',
+                'admin'                   => 'Administrador',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirmar Contraseña',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Correo Electrónico',
+                'password'                => 'Contraseña',
+                'title'                   => 'Crear Administrador',
+                'seed-sample-data'        => 'Instalar productos de muestra y datos de demostración',
+                'seeding-sample-data'     => 'Sembrando productos de muestra y datos de demostración, esto puede tardar unos minutos...',
+                'seed-sample-data-failed' => 'No se pudieron sembrar los datos de muestra. Puede instalarlos más tarde mediante `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Monedas Permitidas',

--- a/packages/Webkul/Installer/src/Resources/lang/fi_FI/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/fi_FI/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Ylläpitäjä',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Vahvista salasana',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Sähköposti',
-                'password'         => 'Salasana',
-                'title'            => 'Luo Ylläpitäjä',
+                'admin'                   => 'Ylläpitäjä',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Vahvista salasana',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Sähköposti',
+                'password'                => 'Salasana',
+                'title'                   => 'Luo Ylläpitäjä',
+                'seed-sample-data'        => 'Asenna esimerkkituotteet ja demodata',
+                'seeding-sample-data'     => 'Esimerkkituotteita ja demodataa luodaan, tämä voi kestää muutaman minuutin...',
+                'seed-sample-data-failed' => 'Demodataa ei voitu luoda. Voit asentaa sen myöhemmin komennolla `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Sallitut valuutat',

--- a/packages/Webkul/Installer/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/fr_FR/app.php
@@ -108,9 +108,9 @@ return [
                 'email'                   => 'E-mail',
                 'password'                => 'Mot de passe',
                 'title'                   => 'Créer un administrateur',
-                'seed-sample-data'        => 'Install sample products and demo data',
-                'seeding-sample-data'     => 'Seeding sample products and demo data, this may take a few minutes...',
-                'seed-sample-data-failed' => 'Sample data could not be seeded. You can install it later via `php artisan unopim:install:demo-data`.',
+                'seed-sample-data'        => 'Installer les produits d\'exemple et les données de démonstration',
+                'seeding-sample-data'     => 'Création des produits d\'exemple et des données de démonstration, cela peut prendre quelques minutes...',
+                'seed-sample-data-failed' => 'Les données d\'exemple n\'ont pas pu être installées. Vous pouvez les installer plus tard via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Devises autorisées',

--- a/packages/Webkul/Installer/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/fr_FR/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrateur',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirmez le mot de passe',
-                'email-address'    => 'admin@exemple.com',
-                'email'            => 'E-mail',
-                'password'         => 'Mot de passe',
-                'title'            => 'Créer un administrateur',
+                'admin'                   => 'Administrateur',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirmez le mot de passe',
+                'email-address'           => 'admin@exemple.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Mot de passe',
+                'title'                   => 'Créer un administrateur',
+                'seed-sample-data'        => 'Install sample products and demo data',
+                'seeding-sample-data'     => 'Seeding sample products and demo data, this may take a few minutes...',
+                'seed-sample-data-failed' => 'Sample data could not be seeded. You can install it later via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Devises autorisées',

--- a/packages/Webkul/Installer/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/hi_IN/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'व्यवस्थापक',
-                'unopim'           => 'यूनोपिम',
-                'confirm-password' => 'पासवर्ड की पुष्टि कीजिये',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'ईमेल',
-                'password'         => 'पासवर्ड',
-                'title'            => 'व्यवस्थापक बनाएँ',
+                'admin'                   => 'व्यवस्थापक',
+                'unopim'                  => 'यूनोपिम',
+                'confirm-password'        => 'पासवर्ड की पुष्टि कीजिये',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'ईमेल',
+                'password'                => 'पासवर्ड',
+                'title'                   => 'व्यवस्थापक बनाएँ',
+                'seed-sample-data'        => 'नमूना उत्पाद और डेमो डेटा स्थापित करें',
+                'seeding-sample-data'     => 'नमूना उत्पाद और डेमो डेटा बनाया जा रहा है, इसमें कुछ मिनट लग सकते हैं...',
+                'seed-sample-data-failed' => 'नमूना डेटा सीड नहीं हो सका। आप इसे बाद में `php artisan unopim:install:demo-data` के माध्यम से स्थापित कर सकते हैं।',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'अनुमत मुद्राएँ',

--- a/packages/Webkul/Installer/src/Resources/lang/hr_HR/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/hr_HR/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrator',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Potvrdite Lozinku',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-mail',
-                'password'         => 'Lozinka',
-                'title'            => 'Kreiraj Administratora',
+                'admin'                   => 'Administrator',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Potvrdite Lozinku',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Lozinka',
+                'title'                   => 'Kreiraj Administratora',
+                'seed-sample-data'        => 'Instaliraj ogledne proizvode i demo podatke',
+                'seeding-sample-data'     => 'Stvaranje oglednih proizvoda i demo podataka, ovo može potrajati nekoliko minuta...',
+                'seed-sample-data-failed' => 'Demo podaci nisu mogli biti učitani. Možete ih instalirati kasnije putem `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Dopuštene Valute',

--- a/packages/Webkul/Installer/src/Resources/lang/id_ID/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/id_ID/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Admin',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Konfirmasi Kata Sandi',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Kata Sandi',
-                'title'            => 'Buat Administrator',
+                'admin'                   => 'Admin',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Konfirmasi Kata Sandi',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Kata Sandi',
+                'title'                   => 'Buat Administrator',
+                'seed-sample-data'        => 'Instal produk contoh dan data demo',
+                'seeding-sample-data'     => 'Menanamkan produk contoh dan data demo, ini mungkin memakan waktu beberapa menit...',
+                'seed-sample-data-failed' => 'Data contoh tidak dapat ditanam. Anda dapat menginstalnya nanti melalui `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Mata Uang yang Diizinkan',

--- a/packages/Webkul/Installer/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/it_IT/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Amministratore',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Conferma Password',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Password',
-                'title'            => 'Crea Amministratore',
+                'admin'                   => 'Amministratore',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Conferma Password',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Password',
+                'title'                   => 'Crea Amministratore',
+                'seed-sample-data'        => 'Installa prodotti di esempio e dati demo',
+                'seeding-sample-data'     => 'Caricamento prodotti di esempio e dati demo, l\'operazione potrebbe richiedere alcuni minuti...',
+                'seed-sample-data-failed' => 'Impossibile caricare i dati di esempio. Puoi installarli in seguito tramite `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Valute Consentite',

--- a/packages/Webkul/Installer/src/Resources/lang/ja_JP/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/ja_JP/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => '管理者',
-                'unopim'           => 'ウノピム',
-                'confirm-password' => 'パスワードを認証する',
-                'email-address'    => 'admin@example.com',
-                'email'            => '電子メール',
-                'password'         => 'パスワード',
-                'title'            => '管理者の作成',
+                'admin'                   => '管理者',
+                'unopim'                  => 'ウノピム',
+                'confirm-password'        => 'パスワードを認証する',
+                'email-address'           => 'admin@example.com',
+                'email'                   => '電子メール',
+                'password'                => 'パスワード',
+                'title'                   => '管理者の作成',
+                'seed-sample-data'        => 'サンプル商品とデモデータをインストール',
+                'seeding-sample-data'     => 'サンプル商品とデモデータを生成しています。数分かかる場合があります…',
+                'seed-sample-data-failed' => 'サンプルデータを生成できませんでした。後で `php artisan unopim:install:demo-data` を実行してインストールできます。',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => '使用できる通貨',

--- a/packages/Webkul/Installer/src/Resources/lang/ko_KR/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/ko_KR/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => '관리자',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => '비밀번호 확인',
-                'email-address'    => 'admin@example.com',
-                'email'            => '이메일',
-                'password'         => '비밀번호',
-                'title'            => '관리자 생성',
+                'admin'                   => '관리자',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => '비밀번호 확인',
+                'email-address'           => 'admin@example.com',
+                'email'                   => '이메일',
+                'password'                => '비밀번호',
+                'title'                   => '관리자 생성',
+                'seed-sample-data'        => '샘플 제품 및 데모 데이터 설치',
+                'seeding-sample-data'     => '샘플 제품 및 데모 데이터를 생성 중입니다. 몇 분 정도 걸릴 수 있습니다...',
+                'seed-sample-data-failed' => '샘플 데이터를 생성하지 못했습니다. 나중에 `php artisan unopim:install:demo-data` 명령으로 설치할 수 있습니다.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => '허용된 통화',

--- a/packages/Webkul/Installer/src/Resources/lang/mn_MN/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/mn_MN/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Админ',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Нууц үг баталгаажуулах',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Имэйл',
-                'password'         => 'Нууц үг',
-                'title'            => 'Администратор үүсгэх',
+                'admin'                   => 'Админ',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Нууц үг баталгаажуулах',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Имэйл',
+                'password'                => 'Нууц үг',
+                'title'                   => 'Администратор үүсгэх',
+                'seed-sample-data'        => 'Жишээ бүтээгдэхүүн ба демо өгөгдлийг суулгах',
+                'seeding-sample-data'     => 'Жишээ бүтээгдэхүүн ба демо өгөгдөл үүсгэж байна, энэ хэдэн минут үргэлжилж болно...',
+                'seed-sample-data-failed' => 'Жишээ өгөгдлийг үүсгэж чадсангүй. Та `php artisan unopim:install:demo-data` тушаалаар дараа суулгаж болно.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Зөвшөөрөгдсөн валютууд',

--- a/packages/Webkul/Installer/src/Resources/lang/nl_NL/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/nl_NL/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Beheerder',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Bevestig wachtwoord',
-                'email-address'    => 'beheerder@voorbeeld.com',
-                'email'            => 'E-mail',
-                'password'         => 'Wachtwoord',
-                'title'            => 'Beheerder aanmaken',
+                'admin'                   => 'Beheerder',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Bevestig wachtwoord',
+                'email-address'           => 'beheerder@voorbeeld.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Wachtwoord',
+                'title'                   => 'Beheerder aanmaken',
+                'seed-sample-data'        => 'Voorbeeldproducten en demogegevens installeren',
+                'seeding-sample-data'     => 'Voorbeeldproducten en demogegevens worden geladen, dit kan enkele minuten duren...',
+                'seed-sample-data-failed' => 'Demogegevens konden niet worden geladen. U kunt ze later installeren via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Toegestane valuta\'s',

--- a/packages/Webkul/Installer/src/Resources/lang/no_NO/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/no_NO/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrator',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Bekreft passord',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-post',
-                'password'         => 'Passord',
-                'title'            => 'Opprett Administrator',
+                'admin'                   => 'Administrator',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Bekreft passord',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-post',
+                'password'                => 'Passord',
+                'title'                   => 'Opprett Administrator',
+                'seed-sample-data'        => 'Installer demoprodukter og demodata',
+                'seeding-sample-data'     => 'Laster demoprodukter og demodata, dette kan ta noen minutter...',
+                'seed-sample-data-failed' => 'Demodata kunne ikke lastes. Du kan installere det senere via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Tillatte valutaer',

--- a/packages/Webkul/Installer/src/Resources/lang/pl_PL/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/pl_PL/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrator',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Potwierdź hasło',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-mail',
-                'password'         => 'Hasło',
-                'title'            => 'Utwórz Administratora',
+                'admin'                   => 'Administrator',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Potwierdź hasło',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Hasło',
+                'title'                   => 'Utwórz Administratora',
+                'seed-sample-data'        => 'Zainstaluj przykładowe produkty i dane demonstracyjne',
+                'seeding-sample-data'     => 'Ładowanie przykładowych produktów i danych demonstracyjnych, może to potrwać kilka minut...',
+                'seed-sample-data-failed' => 'Nie udało się załadować danych przykładowych. Możesz je zainstalować później poleceniem `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Dozwolone waluty',

--- a/packages/Webkul/Installer/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/pt_BR/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrador',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirme sua senha',
-                'email-address'    => 'admin@exemplo.com',
-                'email'            => 'E-mail',
-                'password'         => 'Senha',
-                'title'            => 'Criar administrador',
+                'admin'                   => 'Administrador',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirme sua senha',
+                'email-address'           => 'admin@exemplo.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Senha',
+                'title'                   => 'Criar administrador',
+                'seed-sample-data'        => 'Instalar produtos de amostra e dados de demonstração',
+                'seeding-sample-data'     => 'Semeando produtos de amostra e dados de demonstração, isso pode levar alguns minutos...',
+                'seed-sample-data-failed' => 'Não foi possível semear os dados de amostra. Você pode instalá-los depois com `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Moedas permitidas',

--- a/packages/Webkul/Installer/src/Resources/lang/pt_PT/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/pt_PT/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrador',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirmar Palavra-passe',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-mail',
-                'password'         => 'Palavra-passe',
-                'title'            => 'Criar Administrador',
+                'admin'                   => 'Administrador',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirmar Palavra-passe',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-mail',
+                'password'                => 'Palavra-passe',
+                'title'                   => 'Criar Administrador',
+                'seed-sample-data'        => 'Instalar produtos de amostra e dados de demonstração',
+                'seeding-sample-data'     => 'A semear produtos de amostra e dados de demonstração, isto pode demorar alguns minutos...',
+                'seed-sample-data-failed' => 'Não foi possível semear os dados de amostra. Pode instalá-los mais tarde através de `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Moedas Permitidas',

--- a/packages/Webkul/Installer/src/Resources/lang/ro_RO/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/ro_RO/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administrator',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Confirmare Parolă',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Parolă',
-                'title'            => 'Creare Administrator',
+                'admin'                   => 'Administrator',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Confirmare Parolă',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Parolă',
+                'title'                   => 'Creare Administrator',
+                'seed-sample-data'        => 'Instalează produse de eșantion și date demo',
+                'seeding-sample-data'     => 'Se inserează produse de eșantion și date demo, această operațiune poate dura câteva minute...',
+                'seed-sample-data-failed' => 'Datele de eșantion nu au putut fi inserate. Le poți instala mai târziu prin `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Monede Permise',

--- a/packages/Webkul/Installer/src/Resources/lang/ru_RU/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/ru_RU/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Админ',
-                'unopim'           => 'УноПим',
-                'confirm-password' => 'Подтвердите пароль',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Электронная почта',
-                'password'         => 'Пароль',
-                'title'            => 'Создать администратора',
+                'admin'                   => 'Админ',
+                'unopim'                  => 'УноПим',
+                'confirm-password'        => 'Подтвердите пароль',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Электронная почта',
+                'password'                => 'Пароль',
+                'title'                   => 'Создать администратора',
+                'seed-sample-data'        => 'Установить демонстрационные товары и данные',
+                'seeding-sample-data'     => 'Создание демонстрационных товаров и данных, это может занять несколько минут...',
+                'seed-sample-data-failed' => 'Не удалось создать демонстрационные данные. Вы можете установить их позже через `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Разрешенные валюты',

--- a/packages/Webkul/Installer/src/Resources/lang/sv_SE/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/sv_SE/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Administratör',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Bekräfta Lösenord',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-post',
-                'password'         => 'Lösenord',
-                'title'            => 'Skapa Administratör',
+                'admin'                   => 'Administratör',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Bekräfta Lösenord',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-post',
+                'password'                => 'Lösenord',
+                'title'                   => 'Skapa Administratör',
+                'seed-sample-data'        => 'Installera exempelprodukter och demodata',
+                'seeding-sample-data'     => 'Skapar exempelprodukter och demodata, detta kan ta några minuter...',
+                'seed-sample-data-failed' => 'Demodata kunde inte skapas. Du kan installera det senare via `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Tillåtna Valutor',

--- a/packages/Webkul/Installer/src/Resources/lang/tl_PH/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/tl_PH/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Tagapangasiwa',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Kumpirmahin ang Password',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Password',
-                'title'            => 'Lumikha ng Tagapangasiwa',
+                'admin'                   => 'Tagapangasiwa',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Kumpirmahin ang Password',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Password',
+                'title'                   => 'Lumikha ng Tagapangasiwa',
+                'seed-sample-data'        => 'I-install ang sample na produkto at demo data',
+                'seeding-sample-data'     => 'Naglalagay ng sample na produkto at demo data, maaaring tumagal ito ng ilang minuto...',
+                'seed-sample-data-failed' => 'Hindi na-seed ang sample data. Maaari mo itong i-install mamaya sa pamamagitan ng `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Mga Pinahihintulutang Pera',

--- a/packages/Webkul/Installer/src/Resources/lang/tr_TR/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/tr_TR/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Yönetici',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Şifreyi Onayla',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'E-posta',
-                'password'         => 'Şifre',
-                'title'            => 'Yönetici Oluştur',
+                'admin'                   => 'Yönetici',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Şifreyi Onayla',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'E-posta',
+                'password'                => 'Şifre',
+                'title'                   => 'Yönetici Oluştur',
+                'seed-sample-data'        => 'Örnek ürünleri ve demo verileri kur',
+                'seeding-sample-data'     => 'Örnek ürünler ve demo veriler oluşturuluyor, bu işlem birkaç dakika sürebilir...',
+                'seed-sample-data-failed' => 'Örnek veriler oluşturulamadı. Daha sonra `php artisan unopim:install:demo-data` komutuyla kurabilirsiniz.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'İzin Verilen Para Birimleri',

--- a/packages/Webkul/Installer/src/Resources/lang/uk_UA/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/uk_UA/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Адміністратор',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Підтвердити пароль',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Електронна пошта',
-                'password'         => 'Пароль',
-                'title'            => 'Створити адміністратора',
+                'admin'                   => 'Адміністратор',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Підтвердити пароль',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Електронна пошта',
+                'password'                => 'Пароль',
+                'title'                   => 'Створити адміністратора',
+                'seed-sample-data'        => 'Встановити демонстраційні товари та дані',
+                'seeding-sample-data'     => 'Створення демонстраційних товарів і даних, це може зайняти кілька хвилин...',
+                'seed-sample-data-failed' => 'Не вдалося створити демонстраційні дані. Ви можете встановити їх пізніше за допомогою `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Дозволені валюти',

--- a/packages/Webkul/Installer/src/Resources/lang/vi_VN/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/vi_VN/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => 'Quản trị viên',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => 'Xác nhận mật khẩu',
-                'email-address'    => 'admin@example.com',
-                'email'            => 'Email',
-                'password'         => 'Mật khẩu',
-                'title'            => 'Tạo quản trị viên',
+                'admin'                   => 'Quản trị viên',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => 'Xác nhận mật khẩu',
+                'email-address'           => 'admin@example.com',
+                'email'                   => 'Email',
+                'password'                => 'Mật khẩu',
+                'title'                   => 'Tạo quản trị viên',
+                'seed-sample-data'        => 'Cài đặt sản phẩm mẫu và dữ liệu demo',
+                'seeding-sample-data'     => 'Đang tạo sản phẩm mẫu và dữ liệu demo, quá trình này có thể mất vài phút...',
+                'seed-sample-data-failed' => 'Không thể tạo dữ liệu mẫu. Bạn có thể cài đặt sau qua lệnh `php artisan unopim:install:demo-data`.',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => 'Đồng tiền được phép',

--- a/packages/Webkul/Installer/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/zh_CN/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => '行政',
-                'unopim'           => '乌诺皮姆',
-                'confirm-password' => '确认密码',
-                'email-address'    => 'admin@example.com',
-                'email'            => '电子邮件',
-                'password'         => '密码',
-                'title'            => '创建管理员',
+                'admin'                   => '行政',
+                'unopim'                  => '乌诺皮姆',
+                'confirm-password'        => '确认密码',
+                'email-address'           => 'admin@example.com',
+                'email'                   => '电子邮件',
+                'password'                => '密码',
+                'title'                   => '创建管理员',
+                'seed-sample-data'        => '安装示例产品和演示数据',
+                'seeding-sample-data'     => '正在生成示例产品和演示数据，这可能需要几分钟...',
+                'seed-sample-data-failed' => '无法生成示例数据。您可以稍后通过 `php artisan unopim:install:demo-data` 安装。',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => '允许的货币',

--- a/packages/Webkul/Installer/src/Resources/lang/zh_TW/app.php
+++ b/packages/Webkul/Installer/src/Resources/lang/zh_TW/app.php
@@ -101,13 +101,16 @@ return [
     'installer' => [
         'index' => [
             'create-administrator' => [
-                'admin'            => '管理員',
-                'unopim'           => 'UnoPim',
-                'confirm-password' => '確認密碼',
-                'email-address'    => 'admin@example.com',
-                'email'            => '電子郵件',
-                'password'         => '密碼',
-                'title'            => '建立管理員',
+                'admin'                   => '管理員',
+                'unopim'                  => 'UnoPim',
+                'confirm-password'        => '確認密碼',
+                'email-address'           => 'admin@example.com',
+                'email'                   => '電子郵件',
+                'password'                => '密碼',
+                'title'                   => '建立管理員',
+                'seed-sample-data'        => '安裝範例產品與示範資料',
+                'seeding-sample-data'     => '正在建立範例產品與示範資料，這可能需要幾分鐘...',
+                'seed-sample-data-failed' => '無法建立範例資料。您可以稍後透過 `php artisan unopim:install:demo-data` 安裝。',
             ],
             'environment-configuration' => [
                 'allowed-currencies'  => '允許的貨幣',

--- a/packages/Webkul/Installer/src/Resources/views/installer/index.blade.php
+++ b/packages/Webkul/Installer/src/Resources/views/installer/index.blade.php
@@ -530,6 +530,7 @@
                                         type="text"
                                         name="db_prefix"
                                         ::value="envData.db_prefix"
+                                        rules="max:4"
                                         :label="trans('installer::app.installer.index.environment-configuration.database-prefix')"
                                         :placeholder="trans('installer::app.installer.index.environment-configuration.database-prefix')"
                                     />
@@ -1107,6 +1108,33 @@
 
                                         <x-installer::form.control-group.error control-name="locale" />
                                     </x-installer::form.control-group>
+
+                                <!-- Seed sample data -->
+                                <x-installer::form.control-group class="w-full flex items-center gap-2.5 !mb-0 py-1.5 cursor-pointer select-none">
+                                    <x-installer::form.control-group.control
+                                        type="checkbox"
+                                        id="seed_sample_data"
+                                        name="seed_sample_data"
+                                        for="seed_sample_data"
+                                        value="1"
+                                        ::checked="seedSampleData"
+                                        @change="seedSampleData = $event.target.checked"
+                                    />
+
+                                    <x-installer::form.control-group.label
+                                        for="seed_sample_data"
+                                        class="!text-[14px] !font-semibold cursor-pointer"
+                                    >
+                                        @lang('installer::app.installer.index.create-administrator.seed-sample-data')
+                                    </x-installer::form.control-group.label>
+                                </x-installer::form.control-group>
+
+                                <p
+                                    class="text-[12px] text-gray-600 -mt-1"
+                                    v-if="seedSampleDataMessage"
+                                >
+                                    @{{ seedSampleDataMessage }}
+                                </p>
                             </div>
 
                             <div class="flex px-4 py-2.5 justify-end items-center">
@@ -1184,6 +1212,10 @@
                             currentStep: 'start',
 
                             envData: {},
+
+                            seedSampleData: false,
+
+                            seedSampleDataMessage: '',
 
                             locales: {
                                 allowed: [],
@@ -1383,10 +1415,30 @@
                         saveAdmin(params, setErrors) {
                             this.$axios.post("{{ route('installer.admin_config_setup') }}", params)
                                 .then((response) => {
-                                    this.currentStep = 'installationCompleted';
+                                    if (this.seedSampleData) {
+                                        this.runSampleDataSeeder();
+                                    } else {
+                                        this.currentStep = 'installationCompleted';
+                                    }
                                 })
                                 .catch(error => {
                                     setErrors(error.response.data.errors);
+                                });
+                        },
+
+                        runSampleDataSeeder() {
+                            this.seedSampleDataMessage = "@lang('installer::app.installer.index.create-administrator.seeding-sample-data')";
+
+                            this.$axios.post("{{ route('installer.seed_sample_data') }}")
+                                .then(() => {
+                                    this.seedSampleDataMessage = '';
+                                    this.currentStep = 'installationCompleted';
+                                })
+                                .catch(error => {
+                                    this.seedSampleDataMessage = (error.response && error.response.data && error.response.data.error)
+                                        ? error.response.data.error
+                                        : "@lang('installer::app.installer.index.create-administrator.seed-sample-data-failed')";
+                                    this.currentStep = 'installationCompleted';
                                 });
                         },
 

--- a/packages/Webkul/Installer/src/Routes/web.php
+++ b/packages/Webkul/Installer/src/Routes/web.php
@@ -16,6 +16,8 @@ Route::middleware(['web', 'installer_locale'])->group(function () {
             Route::post('run-seeder', 'runSeeder')->name('installer.run_seeder')->withoutMiddleware('web');
 
             Route::post('admin-config-setup', 'adminConfigSetup')->name('installer.admin_config_setup')->withoutMiddleware('web');
+
+            Route::post('seed-sample-data', 'seedSampleData')->name('installer.seed_sample_data')->withoutMiddleware('web');
         });
     });
 });

--- a/packages/Webkul/Installer/tests/Feature/InstallerControllerTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Support\Facades\URL;
+use Webkul\Installer\Helpers\DemoDataInstaller;
+
+beforeEach(function () {
+    // CSRF + CanInstall + auth middleware would otherwise reject these
+    // requests with 302/419/404. We test the controller logic directly;
+    // those middlewares have their own coverage.
+    $this->withoutMiddleware();
+
+    // The shared .env's APP_URL is a path-prefixed dev URL
+    // (http://host/issue-docker/unopim/public). That prefix leaks into
+    // the test request URI and the route matcher 404s on it. Force a
+    // clean APP_URL just for the test kernel.
+    config(['app.url' => 'http://localhost']);
+    URL::forceRootUrl('http://localhost');
+});
+
+describe('InstallerController::seedSampleData (issue #794)', function () {
+    it('returns success: true when the demo data installer reports success', function () {
+        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
+        {
+            public function seed(?Closure $reporter = null, bool $force = false): array
+            {
+                return ['success' => true];
+            }
+        });
+
+        $this->postJson('/install/api/seed-sample-data')
+            ->assertOk()
+            ->assertJson(['success' => true]);
+    });
+
+    it('returns 500 and forwards the seeder error message on failure', function () {
+        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
+        {
+            public function seed(?Closure $reporter = null, bool $force = false): array
+            {
+                return ['success' => false, 'error' => 'demo_extras.json missing'];
+            }
+        });
+
+        $this->postJson('/install/api/seed-sample-data')
+            ->assertStatus(500)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'demo_extras.json missing',
+            ]);
+    });
+});
+
+describe('InstallerController::envFileSetup DB_PREFIX validation (issue #794)', function () {
+    it('rejects a prefix containing spaces with the same message the CLI surfaces', function () {
+        $this->postJson('/install/api/env-file-setup', [
+            'db_prefix' => 'a a',
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'The database prefix can only contain letters, numbers, and underscores.');
+    });
+
+    it('rejects a prefix longer than 4 characters', function () {
+        $this->postJson('/install/api/env-file-setup', [
+            'db_prefix' => 'toolong',
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'The database prefix should not exceed 4 characters.');
+    });
+
+    it('rejects a prefix that contains non-alphanumeric/underscore characters', function () {
+        $this->postJson('/install/api/env-file-setup', [
+            'db_prefix' => 'bad!',
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'The database prefix can only contain letters, numbers, and underscores.');
+    });
+});

--- a/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
+++ b/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Webkul\Installer\Helpers\DemoDataInstaller;
+
+describe('unopim:install:demo-data (issue #794)', function () {
+    it('exits 0 and surfaces every step message when seeding succeeds', function () {
+        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
+        {
+            public function seed(?Closure $reporter = null, bool $force = false): array
+            {
+                ($reporter ?? static fn () => null)('Seeding demo extras...');
+                ($reporter ?? static fn () => null)('Seeding demo categories...');
+
+                return ['success' => true];
+            }
+        });
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsOutputToContain('Seeding demo extras...')
+            ->expectsOutputToContain('Seeding demo categories...')
+            ->expectsOutputToContain('Sample products seeded successfully.')
+            ->assertExitCode(0);
+    });
+
+    it('exits non-zero and prints the seeder error when seeding fails', function () {
+        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
+        {
+            public function seed(?Closure $reporter = null, bool $force = false): array
+            {
+                return ['success' => false, 'error' => 'JSON missing'];
+            }
+        });
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsOutputToContain('Failed to seed sample data: JSON missing')
+            ->assertExitCode(1);
+    });
+
+    it('exits 0 with the "already seeded" message and skips work when demo data is present', function () {
+        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
+        {
+            public function seed(?Closure $reporter = null, bool $force = false): array
+            {
+                return ['success' => true, 'skipped' => true];
+            }
+        });
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsOutputToContain('Demo data is already seeded')
+            ->assertExitCode(0);
+    });
+
+    it('forwards --force to the installer so a re-seed runs', function () {
+        $forceSeen = false;
+        app()->instance(DemoDataInstaller::class, new class($forceSeen) extends DemoDataInstaller
+        {
+            public function __construct(private bool &$forceSeen) {}
+
+            public function seed(?Closure $reporter = null, bool $force = false): array
+            {
+                $this->forceSeen = $force;
+
+                return ['success' => true];
+            }
+        });
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->assertExitCode(0);
+
+        expect($forceSeen)->toBeTrue();
+    });
+});

--- a/packages/Webkul/Installer/tests/Unit/DemoDataInstallerTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DemoDataInstallerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Webkul\Installer\Database\Seeders\CategoryDemoTableSeeder;
+use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
+use Webkul\Installer\Database\Seeders\ProductTableSeeder;
+use Webkul\Installer\Helpers\DemoDataInstaller;
+
+/**
+ * Returns a DemoDataInstaller whose idempotency probe is hard-coded.
+ * Avoids touching the real `categories` table from tests since these
+ * unit tests don't run migrations.
+ */
+function demoInstaller(bool $alreadySeeded): DemoDataInstaller
+{
+    return new class($alreadySeeded) extends DemoDataInstaller
+    {
+        public function __construct(private bool $alreadySeeded) {}
+
+        public function isAlreadySeeded(): bool
+        {
+            return $this->alreadySeeded;
+        }
+    };
+}
+
+describe('DemoDataInstaller::seed (issue #794)', function () {
+    it('runs every demo seeder in order, reports each step, and returns success', function () {
+        // Replace the three demo seeders with no-op spies so the test does not
+        // touch the JSON fixtures (slow) and we can verify call order.
+        $calls = [];
+        foreach ([
+            DemoExtrasTableSeeder::class,
+            CategoryDemoTableSeeder::class,
+            ProductTableSeeder::class,
+        ] as $class) {
+            app()->instance($class, new class($calls, $class)
+            {
+                public function __construct(private array &$calls, private string $name) {}
+
+                public function run(): void
+                {
+                    $this->calls[] = $this->name;
+                }
+            });
+        }
+
+        // Stub elasticsearch off and queue default to sync to avoid touching
+        // the real queue/ES while still exercising recalculateCompleteness.
+        config(['elasticsearch.enabled' => 'false']);
+        Artisan::shouldReceive('call')
+            ->with('unopim:completeness:recalculate', ['--all' => true])
+            ->once()
+            ->andReturn(0);
+
+        $messages = [];
+        $result = demoInstaller(alreadySeeded: false)->seed(function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        });
+
+        expect($result)->toBe(['success' => true])
+            ->and($calls)->toBe([
+                DemoExtrasTableSeeder::class,
+                CategoryDemoTableSeeder::class,
+                ProductTableSeeder::class,
+            ])
+            ->and($messages)->toContain('Seeding demo extras (channels, attributes, families, core config, ...)...')
+            ->and($messages)->toContain('Seeding demo categories...')
+            ->and($messages)->toContain('Seeding sample products...')
+            ->and($messages)->toContain('Recalculating product completeness...');
+    });
+
+    it('reports the seeder failure message instead of bubbling the exception', function () {
+        app()->instance(DemoExtrasTableSeeder::class, new class
+        {
+            public function run(): void
+            {
+                throw new RuntimeException('boom');
+            }
+        });
+
+        $result = demoInstaller(alreadySeeded: false)->seed();
+
+        expect($result['success'])->toBeFalse()
+            ->and($result['error'])->toBe('boom');
+    });
+
+    it('short-circuits with skipped=true when demo data is already present', function () {
+        $invoked = false;
+        foreach ([
+            DemoExtrasTableSeeder::class,
+            CategoryDemoTableSeeder::class,
+            ProductTableSeeder::class,
+        ] as $class) {
+            app()->instance($class, new class($invoked)
+            {
+                public function __construct(private bool &$invoked) {}
+
+                public function run(): void
+                {
+                    $this->invoked = true;
+                }
+            });
+        }
+
+        $messages = [];
+        $result = demoInstaller(alreadySeeded: true)->seed(function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        });
+
+        expect($result)->toBe(['success' => true, 'skipped' => true])
+            ->and($invoked)->toBeFalse()
+            ->and($messages)->toContain('Demo data is already seeded; skipping. Pass --force to re-seed.');
+    });
+
+    it('re-seeds even when demo data is already present if force=true', function () {
+        $calls = [];
+        foreach ([
+            DemoExtrasTableSeeder::class,
+            CategoryDemoTableSeeder::class,
+            ProductTableSeeder::class,
+        ] as $class) {
+            app()->instance($class, new class($calls, $class)
+            {
+                public function __construct(private array &$calls, private string $name) {}
+
+                public function run(): void
+                {
+                    $this->calls[] = $this->name;
+                }
+            });
+        }
+
+        config(['elasticsearch.enabled' => 'false']);
+        Artisan::shouldReceive('call')
+            ->with('unopim:completeness:recalculate', ['--all' => true])
+            ->once()
+            ->andReturn(0);
+
+        $result = demoInstaller(alreadySeeded: true)->seed(null, force: true);
+
+        expect($result)->toBe(['success' => true])
+            ->and($calls)->toBe([
+                DemoExtrasTableSeeder::class,
+                CategoryDemoTableSeeder::class,
+                ProductTableSeeder::class,
+            ]);
+    });
+
+    it('also reindexes elasticsearch when it is enabled', function () {
+        foreach ([
+            DemoExtrasTableSeeder::class,
+            CategoryDemoTableSeeder::class,
+            ProductTableSeeder::class,
+        ] as $class) {
+            app()->instance($class, new class
+            {
+                public function run(): void {}
+            });
+        }
+
+        config(['elasticsearch.enabled' => 'true']);
+
+        Artisan::shouldReceive('call')->with('unopim:category:index')->once()->andReturn(0);
+        Artisan::shouldReceive('call')->with('unopim:product:index')->once()->andReturn(0);
+        Artisan::shouldReceive('call')
+            ->with('unopim:completeness:recalculate', ['--all' => true])
+            ->once()
+            ->andReturn(0);
+
+        $result = demoInstaller(alreadySeeded: false)->seed();
+
+        expect($result['success'])->toBeTrue();
+    });
+});


### PR DESCRIPTION
## How To Test


Seeds demo categories, families, attributes, channels, and sample products in UI or Docker.

---

### UI Installer

Go to `/install` → on the **Create Administrator** step enable:

```text
Install sample products and demo data
```

After install, verify demo products and categories are available.

---

### Docker

```bash
docker compose exec unopim-fpm php artisan unopim:install:demo-data
```

Seeds demo data inside Docker setup.

---

### Idempotency Check

Running again:

```bash
php artisan unopim:install:demo-data
```

shows:

```text
Demo data is already seeded — nothing to do.
```

Use force re-seed:

```bash
php artisan unopim:install:demo-data --force
```
