### PR TITLE
 fix: cast product status to boolean in import indexBatch for ES8 compatibility

### DIFF
--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
@@ -2291,6 +2291,7 @@ class Importer extends AbstractImporter
              */
             $productDB['created_at'] = $this->formatDateForIndex($productDB['created_at']);
             $productDB['updated_at'] = $this->formatDateForIndex($productDB['updated_at']);
+            $productDB['status'] = (bool) ($productDB['status'] ?? true);
 
             $productsToUpdate['body'][] = [
                 'index' => [

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Importers/ProductIndexBatchBooleanStatusTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Importers/ProductIndexBatchBooleanStatusTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Webkul\Core\Facades\ElasticSearch;
+use Webkul\DataTransfer\Helpers\Importers\Product\Importer;
+use Webkul\DataTransfer\Models\JobTrack;
+use Webkul\DataTransfer\Models\JobTrackBatch;
+use Webkul\Product\Models\Product;
+
+beforeEach(function () {
+    config([
+        'elasticsearch.enabled'                     => true,
+        'elasticsearch.prefix'                      => 'testing',
+        'elasticsearch.connection'                  => 'default',
+        'elasticsearch.connections.default.hosts.0' => 'testhost:9200',
+    ]);
+
+    $elasticClientMock = Mockery::mock('Webkul\ElasticSearch\Client\Fake\FakeElasticClient');
+
+    ElasticSearch::shouldReceive('makeConnection')
+        ->andReturn($elasticClientMock)
+        ->zeroOrMoreTimes();
+});
+
+it('sends boolean true (not integer 1) when product status is enabled', function () {
+    config(['elasticsearch.enabled' => false]);
+
+    $product = Product::factory()->withInitialValues()->create(['status' => 1]);
+
+    $jobTrack = JobTrack::factory()->create();
+    $batch = JobTrackBatch::factory()->create([
+        'job_track_id' => $jobTrack->id,
+        'data'         => [['sku' => $product->sku]],
+    ]);
+
+    config(['elasticsearch.enabled' => true]);
+
+    ElasticSearch::shouldReceive('bulk')
+        ->once()
+        ->withArgs(function ($args) {
+            expect($args)->toHaveKey('body');
+
+            $productBody = $args['body'][1] ?? null;
+
+            expect($productBody)->not->toBeNull()
+                ->and($productBody['status'])->toBeBool()
+                ->and($productBody['status'])->toBeTrue();
+
+            return true;
+        })
+        ->andReturn(['errors' => false, 'items' => []]);
+
+    app(Importer::class)->indexBatch($batch);
+});
+
+it('sends boolean false (not integer 0) when product status is disabled', function () {
+    config(['elasticsearch.enabled' => false]);
+
+    $product = Product::factory()->withInitialValues()->create(['status' => 0]);
+
+    $jobTrack = JobTrack::factory()->create();
+    $batch = JobTrackBatch::factory()->create([
+        'job_track_id' => $jobTrack->id,
+        'data'         => [['sku' => $product->sku]],
+    ]);
+
+    config(['elasticsearch.enabled' => true]);
+
+    ElasticSearch::shouldReceive('bulk')
+        ->once()
+        ->withArgs(function ($args) {
+            $productBody = $args['body'][1] ?? null;
+
+            expect($productBody)->not->toBeNull()
+                ->and($productBody['status'])->toBeBool()
+                ->and($productBody['status'])->toBeFalse();
+
+            return true;
+        })
+        ->andReturn(['errors' => false, 'items' => []]);
+
+    app(Importer::class)->indexBatch($batch);
+});


### PR DESCRIPTION
## Summary

  After importing products via the admin UI in a Docker environment, imported products do not appear in the product datagrid until `php artisan
  unopim:product:index` is run manually.

  ## Root Cause

  `Importer::indexBatch()` (the per-batch ES indexing called by the import chain) was sending the product `status` field as an integer (`1`/`0`) straight from
   the database row. Elasticsearch 8 — which the Docker compose pulls (`elasticsearch:8.17.0`) — strictly rejects integers for boolean-mapped fields with
  `"Can't parse boolean value [1]"`, so the bulk write silently fails (errors only land in `elasticsearch.log`) and imported products never make it into the
  index. The datagrid reads from ES, so they don't show up.

  The manual `unopim:product:index` command works because it already casts `status` to bool (`ProductIndexer.php:121`). 

  ## Fix

  One-line change in `packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php` — cast `status` to bool before pushing the document into the
  bulk payload, matching the pattern already used in `ProductIndexer` and the Product observer:

  ```php
  $productDB['status'] = (bool) ($productDB['status'] ?? true);
