### PR TITLE
Fix: drop FK before column in magic_ai_prompts tone rollback

### DIFF
--- a/packages/Webkul/MagicAI/src/Database/Migrations/2025_09_12_060921_add_tone_to_magic_ai_prompts_table.php
+++ b/packages/Webkul/MagicAI/src/Database/Migrations/2025_09_12_060921_add_tone_to_magic_ai_prompts_table.php
@@ -26,6 +26,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('magic_ai_prompts', function (Blueprint $table) {
+            $table->dropForeign('magic_ai_prompts_tone_foreign');
             $table->dropColumn('tone');
         });
     }


### PR DESCRIPTION
The down() of 2025_09_12_060921_add_tone_to_magic_ai_prompts_table dropped the tone column directly, but MySQL blocks it because magic_ai_prompts_tone_foreign still references it. Added dropForeign() before dropColumn() so rollback works.
