### PR TITLE
fix(datagrid): exclude hidden filterable attributes from Manage Columns selected panel

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/manage-columns/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/manage-columns/index.blade.php
@@ -306,12 +306,14 @@
                 },
 
                 normalizeSelectedColumns() {
-                    this.selectedColumns = this.$parent.available.columns.map((el) => {
-                        return {
-                            code: el.index,
-                            label: el.label,
-                        };
-                    });
+                    this.selectedColumns = this.$parent.available.columns
+                        .filter((el) => el.visible !== false)
+                        .map((el) => {
+                            return {
+                                code: el.index,
+                                label: el.label,
+                            };
+                        });
                 },
 
                 getColumnsList() {

--- a/packages/Webkul/Admin/tests/Feature/ManageColumnsVisibleOnlyTest.php
+++ b/packages/Webkul/Admin/tests/Feature/ManageColumnsVisibleOnlyTest.php
@@ -1,0 +1,9 @@
+<?php
+
+$view = __DIR__.'/../../src/Resources/views/components/datagrid/manage-columns/index.blade.php';
+
+it('initializes the Selected Columns panel from visible grid columns only', function () use ($view) {
+    $contents = file_get_contents($view);
+
+    expect($contents)->toContain('.filter((el) => el.visible !== false)');
+});


### PR DESCRIPTION
## Summary

  - Manage Columns modal pre-populated its "Selected Columns" panel from the full column list, which includes filterable attributes injected as hidden (e.g.
  name, price). On Apply, those hidden entries were sent back as managedColumns and the backend promoted them to visible, so columns the user never selected
  reappeared in the product grid.
  - Filter the modal's seed list so the Selected panel mirrors what is actually rendered in the grid.
  - Add a regression test asserting the guard stays in the blade file.

  ## Root Cause

  ProductDataGrid::addFilterableAttributes() (introduced in #342) injects every filterable attribute into the response as hidden so they show up in the filter
   drawer but stay out of the table. The grid's visibleColumns computed correctly excludes them. The Manage Columns popup did not — its initializer mapped the
   full column list, so hidden entries leaked through Apply and got re-promoted to visible on the next request.

  ## Fix

  Filter the Manage Columns modal's Selected panel initializer to exclude columns marked hidden. The popup now mirrors the grid, so users only see and
  re-submit columns that are actually rendered.

  File touched: packages/Webkul/Admin/src/Resources/views/components/datagrid/manage-columns/index.blade.php

  ## Test Plan

  - Pint passes on changed files
  - New regression test packages/Webkul/Admin/tests/Feature/ManageColumnsVisibleOnlyTest.php passes
  - ProductFilterWithElasticSearchTest — 22/22 pass (covers managedColumns flow)
  - Full packages/Webkul/Admin/tests/Feature suite — 652 passed (1910 assertions)
  - php artisan unopim:translations:check — 224/224 locales at 100% (no new strings)
  - Manual: open Products grid → Manage Columns → keep only SKU → Apply → grid renders SKU only; reopen modal → Selected panel shows only SKU