### PR TITLE
 fix(admin): hide product edit More button when no actions are available

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar_AE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar_AE/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'تاريخ الإنشاء',
                     'product-type' => 'نوع المنتج',
                 ],
+                'more'         => 'المزيد',
                 'more-actions' => 'إجراءات إضافية',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ca_ES/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca_ES/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Data de creació',
                     'product-type' => 'Tipus de producte',
                 ],
+                'more'         => 'Més',
                 'more-actions' => 'Més accions',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/da_DK/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/da_DK/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Oprettelsesdato',
                     'product-type' => 'Produkttype',
                 ],
+                'more'         => 'Flere',
                 'more-actions' => 'Flere handlinger',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Erstellt am',
                     'product-type' => 'Produkttyp',
                 ],
+                'more'         => 'Mehr',
                 'more-actions' => 'Mehr Aktionen',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en_AU/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_AU/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Created At',
                     'product-type' => 'Product Type',
                 ],
+                'more'         => 'More',
                 'more-actions' => 'More Actions',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en_GB/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_GB/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Date Created',
                     'product-type' => 'Product Type',
                 ],
+                'more'         => 'More',
                 'more-actions' => 'More Actions',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en_NZ/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_NZ/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Date Created',
                     'product-type' => 'Product Type',
                 ],
+                'more'         => 'More',
                 'more-actions' => 'More Actions',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
@@ -379,6 +379,7 @@ return [
                     'product-type' => 'Product Type',
                 ],
 
+                'more'         => 'More',
                 'more-actions' => 'More Actions',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/es_ES/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es_ES/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Fecha de creación',
                     'product-type' => 'Tipo de producto',
                 ],
+                'more'         => 'Más',
                 'more-actions' => 'Más acciones',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/es_VE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es_VE/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Fecha de creación',
                     'product-type' => 'Tipo de producto',
                 ],
+                'more'         => 'Más',
                 'more-actions' => 'Más acciones',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/fi_FI/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fi_FI/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Luotu',
                     'product-type' => 'Tuotetyyppi',
                 ],
+                'more'         => 'Lisää',
                 'more-actions' => 'Lisää toimintoja',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr_FR/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Créé le',
                     'product-type' => 'Type de produit',
                 ],
+                'more'         => 'Plus',
                 'more-actions' => 'Plus d\'actions',
             ],
             'bulk-edit' => [
@@ -364,7 +365,6 @@ return [
                     'url'                        => 'Veuillez entrer une URL valide.',
                     'regex'                      => 'La valeur ne correspond pas au modèle requis.',
                     'invalid-pattern'            => 'Modèle personnalisé invalide fourni.',
-
                     'numeric'                    => 'La valeur de l\'attribut numérique « :attribute » doit être un nombre valide.',
                     'select-attribute-or-family' => 'Veuillez sélectionner au moins un attribut ou une famille d’attributs.',
                     'failed'                     => 'La validation a échoué.',
@@ -385,47 +385,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Édition en masse réussie.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Aucun changement à enregistrer.',
-
-                'invalid-datetime'            => 'Veuillez saisir une date et une heure valides.',
-
-                'resize-column'               => 'Faites glisser pour redimensionner la colonne',
-                'success'                     => 'Opération réussie.',
-                'fetch-failed'                => 'Échec de la récupération.',
-                'action'                      => 'Édition en masse',
-                'description'                 => 'Edit multiple products at once. Changes are processed in the background.',
-                'gallery-preview'             => 'Aperçu de la galerie',
-                'img-preview'                 => 'Aperçu de l’image',
-                'no-image'                    => 'Pas d’image',
-                'img-fail'                    => 'Échec du téléchargement de l’image.',
-                'no-option'                   => 'Aucune option',
-                'keyboard-shortcuts'          => 'Raccourcis clavier',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Édition',
-                'shortcuts-selection'         => 'Sélection',
-                'shortcuts-clipboard'         => 'Presse-papiers et remplissage',
-                'shortcuts-move-cell'         => 'Se déplacer entre les cellules',
-                'shortcuts-move-down'         => 'Descendre / confirmer la modification',
-                'shortcuts-move-up'           => 'Monter',
-                'shortcuts-move-right-left'   => 'Aller à droite / gauche',
-                'shortcuts-home-end'          => 'Première / dernière colonne de la ligne',
-                'shortcuts-ctrl-home-end'     => 'Première / dernière cellule de la grille',
-                'shortcuts-extend-selection'  => 'Étendre la sélection',
-                'shortcuts-select-all'        => 'Sélectionner toutes les cellules',
-                'shortcuts-enter-edit'        => 'Passer en mode édition',
-                'shortcuts-confirm-move-down' => 'Confirmer + descendre',
-                'shortcuts-confirm-move-right'=> 'Confirmer + aller à droite',
-                'shortcuts-escape-revert'     => 'Rétablir la valeur + quitter l\'édition',
-                'shortcuts-clear-cell'        => 'Vider la cellule',
-                'shortcuts-copy'              => 'Copier',
-                'shortcuts-cut'               => 'Couper',
-                'shortcuts-paste'             => 'Coller',
-                'shortcuts-fill-down'         => 'Remplir vers le bas',
-                'shortcuts-fill-right'        => 'Remplir vers la droite',
-                'shortcuts-undo'              => 'Annuler',
-                'shortcuts-redo'              => 'Rétablir',
-                'shortcuts-help'              => 'Afficher/masquer les raccourcis clavier',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Aucun changement à enregistrer.',
+                'invalid-datetime'             => 'Veuillez saisir une date et une heure valides.',
+                'resize-column'                => 'Faites glisser pour redimensionner la colonne',
+                'success'                      => 'Opération réussie.',
+                'fetch-failed'                 => 'Échec de la récupération.',
+                'action'                       => 'Édition en masse',
+                'description'                  => 'Edit multiple products at once. Changes are processed in the background.',
+                'gallery-preview'              => 'Aperçu de la galerie',
+                'img-preview'                  => 'Aperçu de l’image',
+                'no-image'                     => 'Pas d’image',
+                'img-fail'                     => 'Échec du téléchargement de l’image.',
+                'no-option'                    => 'Aucune option',
+                'keyboard-shortcuts'           => 'Raccourcis clavier',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Édition',
+                'shortcuts-selection'          => 'Sélection',
+                'shortcuts-clipboard'          => 'Presse-papiers et remplissage',
+                'shortcuts-move-cell'          => 'Se déplacer entre les cellules',
+                'shortcuts-move-down'          => 'Descendre / confirmer la modification',
+                'shortcuts-move-up'            => 'Monter',
+                'shortcuts-move-right-left'    => 'Aller à droite / gauche',
+                'shortcuts-home-end'           => 'Première / dernière colonne de la ligne',
+                'shortcuts-ctrl-home-end'      => 'Première / dernière cellule de la grille',
+                'shortcuts-extend-selection'   => 'Étendre la sélection',
+                'shortcuts-select-all'         => 'Sélectionner toutes les cellules',
+                'shortcuts-enter-edit'         => 'Passer en mode édition',
+                'shortcuts-confirm-move-down'  => 'Confirmer + descendre',
+                'shortcuts-confirm-move-right' => 'Confirmer + aller à droite',
+                'shortcuts-escape-revert'      => 'Rétablir la valeur + quitter l\'édition',
+                'shortcuts-clear-cell'         => 'Vider la cellule',
+                'shortcuts-copy'               => 'Copier',
+                'shortcuts-cut'                => 'Couper',
+                'shortcuts-paste'              => 'Coller',
+                'shortcuts-fill-down'          => 'Remplir vers le bas',
+                'shortcuts-fill-right'         => 'Remplir vers la droite',
+                'shortcuts-undo'               => 'Annuler',
+                'shortcuts-redo'               => 'Rétablir',
+                'shortcuts-help'               => 'Afficher/masquer les raccourcis clavier',
             ],
             'create-success'          => 'Produit créé avec succès',
             'delete-failed'           => 'Erreur lors de la suppression du produit',
@@ -520,7 +518,6 @@ return [
                 'is-filterable'         => 'Disponible dans la navigation par filtre',
                 'ai-translate'          => 'Traduction IA',
                 'invalid-swatch-type'   => 'Le :attribute n\'est pas autorisé pour le type d\'attribut :type avec le type d\'échantillon :swatch_type.',
-
                 'single-object-only'    => 'Chaque requête de création doit contenir un seul objet d\'attribut.',
                 'option'                => [
                     'color'    => 'Couleur',
@@ -604,7 +601,6 @@ return [
             'delete-success'    => 'Attribut supprimé avec succès',
             'update-success'    => 'Attribut mis à jour avec succès',
             'user-define-error' => 'Impossible de supprimer un attribut système',
-
             'immutable-fields'  => 'Les champs suivants ne peuvent pas être modifiés : :fields.',
             'not-found'         => 'L\'attribut avec le code ":code" est introuvable',
         ],
@@ -887,7 +883,6 @@ return [
             'update-success'    => 'Le champ de catégorie a été mis à jour avec succès',
             'user-define-error' => 'Impossible de supprimer un champ de catégorie système',
             'not-found'         => 'Le champ de catégorie avec le code ":code" est introuvable',
-
             'immutable-fields'  => 'Les champs suivants ne peuvent pas être modifiés : :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +984,7 @@ return [
             'can-not-update-variant-options' => 'Impossible de mettre à jour les options configurables car cette famille dispose déjà de variations.',
         ],
         'history' => [
-            'view' => 'Voir les détails de la version',
-
+            'view'  => 'Voir les détails de la version',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1118,7 @@ return [
                         'paused'               => 'En pause',
                         'cancelled'            => 'Annulé',
                         'failed'               => 'Échoué',
-
-                        'view'       => 'Voir',
+                        'view'                 => 'Voir',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1776,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titre',
@@ -1831,11 +1821,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts système',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titre',

--- a/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'निर्माण तिथि',
                     'product-type' => 'उत्पाद प्रकार',
                 ],
+                'more'         => 'अधिक',
                 'more-actions' => 'अधिक कार्रवाई',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/hr_HR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hr_HR/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Datum izrade',
                     'product-type' => 'Vrsta proizvoda',
                 ],
+                'more'         => 'Više',
                 'more-actions' => 'Više radnji',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/id_ID/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/id_ID/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Tanggal Dibuat',
                     'product-type' => 'Tipe Produk',
                 ],
+                'more'         => 'Lainnya',
                 'more-actions' => 'Tindakan Lainnya',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Data di creazione',
                     'product-type' => 'Tipo di prodotto',
                 ],
+                'more'         => 'Altro',
                 'more-actions' => 'Altre azioni',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ja_JP/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja_JP/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => '作成日',
                     'product-type' => '製品タイプ',
                 ],
+                'more'         => 'その他',
                 'more-actions' => 'その他の操作',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ko_KR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ko_KR/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => '생성일',
                     'product-type' => '제품 유형',
                 ],
+                'more'         => '더보기',
                 'more-actions' => '추가 작업',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/mn_MN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/mn_MN/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Үүсгэсэн огноо',
                     'product-type' => 'Бүтээгдэхүүний төрөл',
                 ],
+                'more'         => 'Нэмэлт',
                 'more-actions' => 'Нэмэлт үйлдлүүд',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/nl_NL/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl_NL/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Aanmaakdatum',
                     'product-type' => 'Producttype',
                 ],
+                'more'         => 'Meer',
                 'more-actions' => 'Meer acties',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/no_NO/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/no_NO/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Opprettet',
                     'product-type' => 'Produkttype',
                 ],
+                'more'         => 'Flere',
                 'more-actions' => 'Flere handlinger',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pl_PL/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pl_PL/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Data utworzenia',
                     'product-type' => 'Typ produktu',
                 ],
+                'more'         => 'Więcej',
                 'more-actions' => 'Więcej akcji',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Data de Criação',
                     'product-type' => 'Tipo de Produto',
                 ],
+                'more'         => 'Mais',
                 'more-actions' => 'Mais ações',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pt_PT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_PT/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Data de Criação',
                     'product-type' => 'Tipo de Produto',
                 ],
+                'more'         => 'Mais',
                 'more-actions' => 'Mais ações',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ro_RO/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ro_RO/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Data Creării',
                     'product-type' => 'Tip Produs',
                 ],
+                'more'         => 'Mai multe',
                 'more-actions' => 'Mai multe acțiuni',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ru_RU/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ru_RU/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Дата создания',
                     'product-type' => 'Тип продукта',
                 ],
+                'more'         => 'Ещё',
                 'more-actions' => 'Дополнительные действия',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/sv_SE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/sv_SE/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Skapad datum',
                     'product-type' => 'Produkttyp',
                 ],
+                'more'         => 'Fler',
                 'more-actions' => 'Fler åtgärder',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/tl_PH/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tl_PH/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Petsa ng Pagkakalikha',
                     'product-type' => 'Uri ng Produkto',
                 ],
+                'more'         => 'Higit Pa',
                 'more-actions' => 'Higit Pang Aksyon',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/tr_TR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr_TR/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Oluşturulma Tarihi',
                     'product-type' => 'Ürün Türü',
                 ],
+                'more'         => 'Daha Fazla',
                 'more-actions' => 'Daha Fazla İşlem',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/uk_UA/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/uk_UA/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Дата створення',
                     'product-type' => 'Тип продукту',
                 ],
+                'more'         => 'Більше',
                 'more-actions' => 'Більше дій',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/vi_VN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi_VN/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => 'Ngày tạo',
                     'product-type' => 'Loại sản phẩm',
                 ],
+                'more'         => 'Thêm',
                 'more-actions' => 'Hành động khác',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => '创建日期',
                     'product-type' => '产品类型',
                 ],
+                'more'         => '更多',
                 'more-actions' => '更多操作',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/lang/zh_TW/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_TW/app.php
@@ -354,6 +354,7 @@ return [
                     'created-at'   => '創建日期',
                     'product-type' => '產品類型',
                 ],
+                'more'         => '更多',
                 'more-actions' => '更多操作',
             ],
             'bulk-edit' => [

--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/more-actions/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/more-actions/index.blade.php
@@ -19,7 +19,7 @@
                 @click="toggleDropdown"
                 title="@lang('admin::app.catalog.products.edit.more-actions')"
             >
-                More
+                @lang('admin::app.catalog.products.edit.more')
                 <i class="text-2xl icon-chevron-down"></i>
             </span>
 

--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/more-actions/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/more-actions/index.blade.php
@@ -1,9 +1,16 @@
+@php
+    $hasTranslateAction = core()->getConfigData('general.magic_ai.translation.enabled') && bouncer()->hasPermission('ai-agent');
+@endphp
+
 {!! view_render_event('unopim.admin.catalog.product.edit.more-actions.before', ['product' => $product]) !!}
 
-<v-custom-dropdown></v-custom-dropdown>
+@if ($hasTranslateAction)
+    <v-custom-dropdown></v-custom-dropdown>
+@endif
 
 {!! view_render_event('unopim.admin.catalog.product.edit.more-actions.after', ['product' => $product]) !!}
 
+@if ($hasTranslateAction)
 @pushOnce('scripts')
     <script type="text/x-template" id="v-custom-dropdown-template">
         <div class="relative inline-block text-left">
@@ -12,7 +19,7 @@
                 @click="toggleDropdown"
                 title="@lang('admin::app.catalog.products.edit.more-actions')"
             >
-                More 
+                More
                 <i class="text-2xl icon-chevron-down"></i>
             </span>
 
@@ -23,9 +30,7 @@
                 <ul class="text-gray-700 rounded">
                     {!! view_render_event('unopim.admin.catalog.product.edit.more-actions.list.before', ['product' => $product]) !!}
 
-                    @if (core()->getConfigData('general.magic_ai.translation.enabled') && bouncer()->hasPermission('ai-agent'))
-                        @include('admin::catalog.products.edit.more-actions.translate-action')
-                    @endif
+                    @include('admin::catalog.products.edit.more-actions.translate-action')
 
                     {!! view_render_event('unopim.admin.catalog.product.edit.more-actions.list.after', ['product' => $product]) !!}
                 </ul>
@@ -64,3 +69,4 @@
         });
     </script>
 @endPushOnce
+@endif

--- a/packages/Webkul/AiAgent/tests/Unit/MagicAIPermissionTest.php
+++ b/packages/Webkul/AiAgent/tests/Unit/MagicAIPermissionTest.php
@@ -26,6 +26,17 @@ describe('Magic AI permission guard (Issue #647)', function () {
         expect($source)->toContain("bouncer()->hasPermission('ai-agent')");
     });
 
+    it('More button dropdown itself is hidden when no actions are available', function () {
+        $source = file_get_contents(
+            base_path('packages/Webkul/Admin/src/Resources/views/catalog/products/edit/more-actions/index.blade.php')
+        );
+
+        // The <v-custom-dropdown> trigger must be wrapped in the same gate as its
+        // only menu item so the empty "More" button is not rendered when magic AI
+        // translation is disabled (issue: empty dropdown served no purpose).
+        expect($source)->toMatch('/@if\s*\(\s*\$hasTranslateAction\s*\)\s*\R\s*<v-custom-dropdown><\/v-custom-dropdown>\s*\R\s*@endif/');
+    });
+
     it('image generation enabled flag also checks ai-agent permission in file and images components', function () {
         $fileSource = file_get_contents(
             base_path('packages/Webkul/Admin/src/Resources/views/components/media/file.blade.php')

--- a/packages/Webkul/AiAgent/tests/Unit/MagicAIPermissionTest.php
+++ b/packages/Webkul/AiAgent/tests/Unit/MagicAIPermissionTest.php
@@ -31,9 +31,6 @@ describe('Magic AI permission guard (Issue #647)', function () {
             base_path('packages/Webkul/Admin/src/Resources/views/catalog/products/edit/more-actions/index.blade.php')
         );
 
-        // The <v-custom-dropdown> trigger must be wrapped in the same gate as its
-        // only menu item so the empty "More" button is not rendered when magic AI
-        // translation is disabled (issue: empty dropdown served no purpose).
         expect($source)->toMatch('/@if\s*\(\s*\$hasTranslateAction\s*\)\s*\R\s*<v-custom-dropdown><\/v-custom-dropdown>\s*\R\s*@endif/');
     });
 

--- a/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
+++ b/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
@@ -62,6 +62,54 @@ async function ensureMagicAITextEnabled(adminPage) {
 }
 
 /**
+ * Helper: Ensure Magic AI translation is enabled in the global config.
+ *
+ * The "More Actions" dropdown on the product edit page is gated by
+ * general.magic_ai.translation.enabled (its only menu item is Translate).
+ * Without this guarantee, the More button is intentionally hidden and the
+ * Section 7 translate tests can't find it.
+ *
+ * Uses the same direct-POST pattern as ensureMagicAITextEnabled to bypass
+ * the Vue toggle render race.
+ */
+async function ensureMagicAITranslationEnabled(adminPage) {
+  await adminPage.goto(MAGIC_AI_CONFIG_URL, { waitUntil: 'networkidle' });
+
+  const cbSelector = 'input[type="checkbox"][name="general[magic_ai][translation][enabled]"]';
+  await adminPage.locator(cbSelector).first().waitFor({ state: 'attached', timeout: 10000 });
+
+  const result = await adminPage.evaluate(async () => {
+    const cb = document.querySelector('input[type="checkbox"][name="general[magic_ai][translation][enabled]"]');
+    if (!cb) return { ok: false, reason: 'no-cb' };
+    const form = cb.closest('form');
+    if (!form) return { ok: false, reason: 'no-form' };
+
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const fd = new FormData(form);
+    const xsrf = (document.cookie.split('; ').find((c) => c.startsWith('XSRF-TOKEN=')) || '').split('=')[1] || '';
+    const action = form.getAttribute('action') || window.location.pathname;
+    const res = await fetch(action || window.location.pathname, {
+      method:      'POST',
+      credentials: 'same-origin',
+      headers: {
+        'X-XSRF-TOKEN': decodeURIComponent(xsrf),
+        Accept:         'text/html,*/*',
+      },
+      body:     fd,
+      redirect: 'follow',
+    });
+    return { ok: res.ok, status: res.status };
+  });
+
+  expect(result, `Magic AI translation config save failed: ${JSON.stringify(result)}`).toMatchObject({ ok: true });
+
+  await adminPage.goto(MAGIC_AI_CONFIG_URL, { waitUntil: 'networkidle' });
+  await expect(adminPage.locator(cbSelector).first()).toBeChecked({ timeout: 10000 });
+}
+
+/**
  * Helper: Open the datagrid on Prompt / System Prompt pages.
  * Clicking the "Create" button loads the datagrid AND opens a modal.
  * We close the modal immediately so we can interact with the grid.
@@ -810,6 +858,10 @@ test('7.3 - Open AI Assistance modal and verify fields', async ({ adminPage }) =
 });
 
 test('7.5 - Verify More Actions menu on product edit page', async ({ adminPage }) => {
+  // The More button is now gated on general.magic_ai.translation.enabled:
+  // without translation enabled the dropdown is empty and we hide it.
+  await ensureMagicAITranslationEnabled(adminPage);
+
   const uid = generateUid();
   const sku = `magicai-more-${uid}`;
 
@@ -844,8 +896,73 @@ test('7.5 - Verify More Actions menu on product edit page', async ({ adminPage }
   await expect(adminPage.locator('#app').getByText(/Product Deleted Successfully/i)).toBeVisible({ timeout: 20000 });
 });
 
+test('7.5b - More Actions button is hidden when AI translation is disabled', async ({ adminPage }) => {
+  // Regression guard: the More dropdown's only menu item is the AI Translate
+  // action. When translation is disabled the dropdown has nothing useful, so
+  // the button must not render at all.
+  await adminPage.goto(MAGIC_AI_CONFIG_URL, { waitUntil: 'networkidle' });
+  const cbSelector = 'input[type="checkbox"][name="general[magic_ai][translation][enabled]"]';
+  await adminPage.locator(cbSelector).first().waitFor({ state: 'attached', timeout: 10000 });
+
+  await adminPage.evaluate(async () => {
+    const cb = document.querySelector('input[type="checkbox"][name="general[magic_ai][translation][enabled]"]');
+    if (!cb) return;
+    const form = cb.closest('form');
+    if (!form) return;
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change', { bubbles: true }));
+    const fd = new FormData(form);
+    // Explicitly disable: the boolean toggle ships a hidden 0 + visible 1
+    // checkbox; remove the "1" so the POST body carries only the disabled state.
+    fd.set('general[magic_ai][translation][enabled]', '0');
+    const xsrf = (document.cookie.split('; ').find((c) => c.startsWith('XSRF-TOKEN=')) || '').split('=')[1] || '';
+    const action = form.getAttribute('action') || window.location.pathname;
+    await fetch(action || window.location.pathname, {
+      method:      'POST',
+      credentials: 'same-origin',
+      headers: {
+        'X-XSRF-TOKEN': decodeURIComponent(xsrf),
+        Accept:         'text/html,*/*',
+      },
+      body:     fd,
+      redirect: 'follow',
+    });
+  });
+
+  const uid = generateUid();
+  const sku = `magicai-nomore-${uid}`;
+
+  // Create product
+  await navigateTo(adminPage, 'products');
+  await adminPage.getByRole('button', { name: 'Create Product' }).click();
+  await expect(adminPage.locator('input[name="sku"]')).toBeVisible();
+  await adminPage.locator('input[name="type"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
+  await adminPage.getByRole('option', { name: 'Simple' }).first().click();
+  await adminPage.locator('input[name="attribute_family_id"]').locator('..').locator('.multiselect__placeholder, .multiselect__single').click();
+  await adminPage.getByRole('option', { name: 'Default' }).first().click();
+  await adminPage.locator('input[name="sku"]').fill(sku);
+  await adminPage.getByRole('button', { name: 'Save Product' }).click();
+  await adminPage.waitForURL(/\/admin\/catalog\/products\/edit\//, { timeout: 20000 });
+  await adminPage.waitForLoadState('networkidle');
+
+  // The More Actions trigger must not exist when translation is disabled.
+  await expect(adminPage.locator('[title="More Actions"]')).toHaveCount(0);
+
+  // Cleanup: delete the product, then restore translation enabled so the
+  // rest of the suite (7.6, 7.7) starts from a clean slate.
+  await navigateTo(adminPage, 'products');
+  await searchInDataGrid(adminPage, sku);
+  const row = adminPage.locator('div', { hasText: sku });
+  await row.locator('span[title="Delete"]').first().click();
+  await adminPage.getByRole('button', { name: 'Delete' }).click();
+  await expect(adminPage.locator('#app').getByText(/Product Deleted Successfully/i)).toBeVisible({ timeout: 20000 });
+
+  await ensureMagicAITranslationEnabled(adminPage);
+});
+
 test('7.6 - Verify Translate Step 1 fields', async ({ adminPage }) => {
   test.setTimeout(30000);
+  await ensureMagicAITranslationEnabled(adminPage);
 
   const uid = generateUid();
   const sku = `magicai-trans-${uid}`;
@@ -887,6 +1004,7 @@ test('7.6 - Verify Translate Step 1 fields', async ({ adminPage }) => {
 test('7.7 - Translate product content to Hindi and verify', async ({ adminPage }) => {
   test.skip(!OPENAI_API_KEY, 'OPENAI_API_KEY not set — translation requires configured platform');
   test.setTimeout(120000);
+  await ensureMagicAITranslationEnabled(adminPage);
 
   const uid = generateUid();
   const sku = `magicai-hindi-${uid}`;

--- a/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
+++ b/tests/e2e-pw/tests/02-configuration/magicAI.spec.js
@@ -8,19 +8,6 @@ const MAGIC_AI_PLATFORM_URL = '/admin/magic-ai/platform';
 const MAGIC_AI_PROMPT_URL = '/admin/magic-ai/prompt';
 const MAGIC_AI_SYSTEM_PROMPT_URL = '/admin/system-prompt';
 
-/**
- * Helper: Ensure Magic AI text-generation is enabled in the global config.
- *
- * The Magic AI WYSIWYG button is gated by general.magic_ai.settings.enabled
- * (see tinymce/index.blade.php). Section 7 tests depend on the button being
- * visible — without this guarantee they time out.
- *
- * Why we POST directly instead of using the UI form: Vue's :checked binding
- * on the sr-only boolean toggle is applied async after module ESM load, so
- * any click-then-save sequence races the binding and can either invert the
- * desired state or submit a form without the field at all. Posting the full
- * settings payload with explicit enabled=1 sidesteps the race entirely.
- */
 async function ensureMagicAITextEnabled(adminPage) {
   await adminPage.goto(MAGIC_AI_CONFIG_URL, { waitUntil: 'networkidle' });
 
@@ -858,8 +845,6 @@ test('7.3 - Open AI Assistance modal and verify fields', async ({ adminPage }) =
 });
 
 test('7.5 - Verify More Actions menu on product edit page', async ({ adminPage }) => {
-  // The More button is now gated on general.magic_ai.translation.enabled:
-  // without translation enabled the dropdown is empty and we hide it.
   await ensureMagicAITranslationEnabled(adminPage);
 
   const uid = generateUid();
@@ -897,9 +882,6 @@ test('7.5 - Verify More Actions menu on product edit page', async ({ adminPage }
 });
 
 test('7.5b - More Actions button is hidden when AI translation is disabled', async ({ adminPage }) => {
-  // Regression guard: the More dropdown's only menu item is the AI Translate
-  // action. When translation is disabled the dropdown has nothing useful, so
-  // the button must not render at all.
   await adminPage.goto(MAGIC_AI_CONFIG_URL, { waitUntil: 'networkidle' });
   const cbSelector = 'input[type="checkbox"][name="general[magic_ai][translation][enabled]"]';
   await adminPage.locator(cbSelector).first().waitFor({ state: 'attached', timeout: 10000 });
@@ -912,8 +894,6 @@ test('7.5b - More Actions button is hidden when AI translation is disabled', asy
     cb.checked = false;
     cb.dispatchEvent(new Event('change', { bubbles: true }));
     const fd = new FormData(form);
-    // Explicitly disable: the boolean toggle ships a hidden 0 + visible 1
-    // checkbox; remove the "1" so the POST body carries only the disabled state.
     fd.set('general[magic_ai][translation][enabled]', '0');
     const xsrf = (document.cookie.split('; ').find((c) => c.startsWith('XSRF-TOKEN=')) || '').split('=')[1] || '';
     const action = form.getAttribute('action') || window.location.pathname;
@@ -945,11 +925,8 @@ test('7.5b - More Actions button is hidden when AI translation is disabled', asy
   await adminPage.waitForURL(/\/admin\/catalog\/products\/edit\//, { timeout: 20000 });
   await adminPage.waitForLoadState('networkidle');
 
-  // The More Actions trigger must not exist when translation is disabled.
   await expect(adminPage.locator('[title="More Actions"]')).toHaveCount(0);
 
-  // Cleanup: delete the product, then restore translation enabled so the
-  // rest of the suite (7.6, 7.7) starts from a clean slate.
   await navigateTo(adminPage, 'products');
   await searchInDataGrid(adminPage, sku);
   const row = adminPage.locator('div', { hasText: sku });
@@ -985,12 +962,19 @@ test('7.6 - Verify Translate Step 1 fields', async ({ adminPage }) => {
   await expect(moreBtn).toBeVisible({ timeout: 20000 });
   await moreBtn.click();
 
-  const translateOption = adminPage.locator('span[title="Translate"]');
-  if (await translateOption.isVisible().catch(() => false)) {
-    await translateOption.click();
-    await expect(adminPage.locator('#app').getByText('Step 1: Select Source Channel, Language and Attributes')).toBeVisible();
-    await expect(adminPage.getByRole('button', { name: 'Next' })).toBeVisible();
-  }
+  // Translation is force-enabled via ensureMagicAITranslationEnabled above,
+  // so the Translate option must be present — wait for it instead of skipping
+  // silently if it isn't (the previous if-guard hid real failures).
+  const translateOption = adminPage.locator('span[title="Translate"]').first();
+  await expect(translateOption).toBeVisible({ timeout: 10000 });
+  await translateOption.click();
+
+  // Redesigned modal renders step-indicator circles (1, 2) with "Select Source"
+  // / "Select Target" labels and a "Source content" card — verify those plus
+  // the Step 1 "Next" button.
+  await expect(adminPage.locator('#app').getByRole('heading', { name: /Source content/i })).toBeVisible({ timeout: 15000 });
+  await expect(adminPage.locator('#app').getByText('Select Source', { exact: true })).toBeVisible();
+  await expect(adminPage.getByRole('button', { name: 'Next' })).toBeVisible();
 
   // Cleanup: delete the product
   await navigateTo(adminPage, 'products');


### PR DESCRIPTION
PR Description

  ## Summary

  - The "More" dropdown on the product edit page used to render an empty shell whenever Magic AI translation was disabled or the user lacked the ai-agent
  permission — its only menu item (Translate) was already gated, but the trigger button itself was not.
  - This change gates the <v-custom-dropdown> trigger (and its template/script block) behind the same condition as its sole menu item, so the button
  disappears entirely when there is nothing inside.

  ## Why

  - Clicking "More" and seeing an empty popover is a confusing dead-end for users without translation access.
  - Keeps the toolbar visually clean and consistent with how other permission-gated controls behave in the admin panel.

  Behaviour

  - Magic AI translation enabled + ai-agent permission → "More" button renders with the Translate action (unchanged).
  - Magic AI translation disabled or permission missing → "More" button is not rendered at all.

  Test plan

  - Run Pest: php artisan test packages/Webkul/AiAgent/tests/Unit/MagicAIPermissionTest.php
  - Run Playwright section 7: npx playwright test tests/e2e-pw/tests/02-configuration/magicAI.spec.js
  - Manual: with general.magic_ai.translation.enabled = false, open any product edit page and confirm the "More" button is absent.
  - Manual: enable the toggle, reload, and confirm "More → Translate" renders and works.
  - Manual: as a non-ai-agent user with translation enabled, confirm "More" is still hidden.
