### PR TITLE
fix(installer): public/ now redirects to install.php on fresh checkout

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -21,7 +21,8 @@ if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php'))
 */
 
 if (! file_exists(__DIR__.'/../vendor/autoload.php')) {
-    header('Location:install.php');
+    header('Location: install.php');
+    exit;
 }
 
 require __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- Fixes : visiting `…/unopim/public/` on a fresh clone (before `composer install`) returned HTTP 500 instead of redirecting to the UI installer.
- Root cause in `public/index.php`: `header('Location:install.php')` had no `exit;` after it, so PHP kept executing and fataled on `require __DIR__.'/../vendor/autoload.php'` (the file the redirect was meant to compensate for). The fatal flushed before the 302 header could reach the client.
- One-line fix: add `exit;` after the redirect, plus the canonical space in `Location: install.php`.

## Before
- Fresh checkout → browse to `/unopim/public/` → **500 Internal Server Error**.
- Workaround users were doing: manually open `/unopim/public/install.php`.

## After
- Fresh checkout → browse to `/unopim/public/` → **302 redirect to `install.php`** → UI installer runs composer + key:generate as designed.
