### PR TITLE
fix(installer): preserve user locales/currencies during demo seed 

### DIFF
--- a/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
@@ -65,11 +65,6 @@ class DemoExtrasTableSeeder extends Seeder
         $driver = DB::getDriverName();
         $isMysql = in_array($driver, ['mysql', 'mariadb'], true);
 
-        // Capture the locale / currency / channel-wiring the user picked
-        // during the base installer. The demo dump replays a hardcoded
-        // snapshot (de_DE / en_US / fr_FR + EUR / USD wired to channels
-        // default / ecommerce / Sales) and would otherwise silently
-        // overwrite the user's selections — see restoreUserConfig().
         $userConfig = $this->snapshotUserConfig();
 
         try {
@@ -84,13 +79,6 @@ class DemoExtrasTableSeeder extends Seeder
                     continue;
                 }
 
-                // The Magic AI config entries in the demo dump point at hardcoded
-                // platform/model/channel/locale values that don't reflect the
-                // target install (encrypted api_key with a different APP_KEY,
-                // model names the user hasn't configured, translation channels
-                // the user hasn't set up). Strip these so Magic AI starts in the
-                // same empty-placeholder state a fresh install has — the user
-                // can opt into their own values via Configuration → Magic AI.
                 if ($table === 'core_config') {
                     $rows = array_values(array_filter(
                         $rows,
@@ -98,20 +86,10 @@ class DemoExtrasTableSeeder extends Seeder
                     ));
                 }
 
-                // The seeded platform row has an api_key encrypted with a
-                // different APP_KEY and is thus useless on any install. Skip it.
                 if ($table === 'magic_ai_platforms') {
                     $rows = [];
                 }
 
-                // The demo dump captures the admin@example.com / admin123 row
-                // that was created on the source server. Replaying it here would
-                // wipe out the admin record the user just configured via the
-                // installer (see Installer::createAdminCredentials and
-                // InstallerController::adminConfigSetup) and replace it with the
-                // hardcoded demo credentials, locking the user out with their
-                // chosen password. AdminsTableSeeder + the admin-config step
-                // already own admin provisioning, so leave the table untouched.
                 if ($table === 'admins') {
                     continue;
                 }
@@ -122,9 +100,6 @@ class DemoExtrasTableSeeder extends Seeder
                     continue;
                 }
 
-                // DB::table()->insert() supports chunked inserts; chunk to
-                // avoid MySQL max_allowed_packet limits on large payloads
-                // (audits has 137 rows with big JSON columns).
                 foreach (array_chunk($rows, 200) as $chunk) {
                     DB::table($table)->insert($chunk);
                 }

--- a/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
@@ -65,6 +65,13 @@ class DemoExtrasTableSeeder extends Seeder
         $driver = DB::getDriverName();
         $isMysql = in_array($driver, ['mysql', 'mariadb'], true);
 
+        // Capture the locale / currency / channel-wiring the user picked
+        // during the base installer. The demo dump replays a hardcoded
+        // snapshot (de_DE / en_US / fr_FR + EUR / USD wired to channels
+        // default / ecommerce / Sales) and would otherwise silently
+        // overwrite the user's selections — see restoreUserConfig().
+        $userConfig = $this->snapshotUserConfig();
+
         try {
             if ($isMysql) {
                 DB::statement('SET FOREIGN_KEY_CHECKS = 0');
@@ -131,12 +138,127 @@ class DemoExtrasTableSeeder extends Seeder
 
             DatabaseSequenceHelper::fixSequences($appliedTables);
 
+            $this->restoreUserConfig($userConfig);
+
             $this->command?->info('Demo extras seeded successfully ('.count($appliedTables).' tables).');
         } catch (Throwable $e) {
             if ($isMysql) {
                 DB::statement('SET FOREIGN_KEY_CHECKS = 1');
             }
             $this->command?->error('Failed to seed demo extras: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * Snapshot the locale / currency / channel-wiring the user configured
+     * during the base installer so it can be re-applied after the demo
+     * dump replaces these tables wholesale. Channels are keyed by code
+     * because the demo dump reassigns their ids.
+     *
+     * @return array{
+     *     locale_codes: array<int, string>,
+     *     currency_codes: array<int, string>,
+     *     channel_wiring: array<string, array{locale_codes: array<int, string>, currency_codes: array<int, string>, translations: array<int, array{locale: string, name: string}>}>
+     * }
+     */
+    protected function snapshotUserConfig(): array
+    {
+        $enabledLocaleCodes = DB::table('locales')->where('status', 1)->pluck('code')->all();
+        $enabledCurrencyCodes = DB::table('currencies')->where('status', 1)->pluck('code')->all();
+
+        $channelWiring = [];
+
+        foreach (DB::table('channels')->get(['id', 'code']) as $channel) {
+            $channelWiring[$channel->code] = [
+                'locale_codes' => DB::table('channel_locales')
+                    ->join('locales', 'locales.id', '=', 'channel_locales.locale_id')
+                    ->where('channel_locales.channel_id', $channel->id)
+                    ->pluck('locales.code')
+                    ->all(),
+                'currency_codes' => DB::table('channel_currencies')
+                    ->join('currencies', 'currencies.id', '=', 'channel_currencies.currency_id')
+                    ->where('channel_currencies.channel_id', $channel->id)
+                    ->pluck('currencies.code')
+                    ->all(),
+                'translations' => DB::table('channel_translations')
+                    ->where('channel_id', $channel->id)
+                    ->get(['locale', 'name'])
+                    ->map(static fn ($t) => ['locale' => $t->locale, 'name' => $t->name])
+                    ->all(),
+            ];
+        }
+
+        return [
+            'locale_codes'   => $enabledLocaleCodes,
+            'currency_codes' => $enabledCurrencyCodes,
+            'channel_wiring' => $channelWiring,
+        ];
+    }
+
+    /**
+     * Re-apply the user's locale / currency / channel selections on top of
+     * the demo dump. The dump's own enabled locales (en_US, de_DE, fr_FR)
+     * and currencies (USD, EUR) stay enabled too — they are required by
+     * the demo product translations — but the user's picks are added
+     * back so installing with sample products no longer wipes them.
+     *
+     * @param  array{
+     *     locale_codes: array<int, string>,
+     *     currency_codes: array<int, string>,
+     *     channel_wiring: array<string, array{locale_codes: array<int, string>, currency_codes: array<int, string>, translations: array<int, array{locale: string, name: string}>}>
+     * }  $state
+     */
+    protected function restoreUserConfig(array $state): void
+    {
+        if (! empty($state['locale_codes'])) {
+            DB::table('locales')
+                ->whereIn('code', $state['locale_codes'])
+                ->update(['status' => 1]);
+        }
+
+        if (! empty($state['currency_codes'])) {
+            DB::table('currencies')
+                ->whereIn('code', $state['currency_codes'])
+                ->update(['status' => 1]);
+        }
+
+        foreach ($state['channel_wiring'] as $code => $wiring) {
+            $channelId = DB::table('channels')->where('code', $code)->value('id');
+
+            if (! $channelId) {
+                continue;
+            }
+
+            $localeIds = DB::table('locales')
+                ->whereIn('code', $wiring['locale_codes'])
+                ->pluck('id')
+                ->all();
+
+            foreach ($localeIds as $localeId) {
+                DB::table('channel_locales')->updateOrInsert(
+                    ['channel_id' => $channelId, 'locale_id' => $localeId],
+                    []
+                );
+            }
+
+            $currencyIds = DB::table('currencies')
+                ->whereIn('code', $wiring['currency_codes'])
+                ->pluck('id')
+                ->all();
+
+            foreach ($currencyIds as $currencyId) {
+                DB::table('channel_currencies')->updateOrInsert(
+                    ['channel_id' => $channelId, 'currency_id' => $currencyId],
+                    []
+                );
+            }
+
+            foreach ($wiring['translations'] as $translation) {
+                DB::table('channel_translations')->updateOrInsert(
+                    ['channel_id' => $channelId, 'locale' => $translation['locale']],
+                    ['name' => $translation['name']]
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `unopim: install` followed by "Do you want sample products? → yes" silently wiped the user's locale/currency selections and replaced them with the demo dump's hardcoded `de_DE`/`en_US`/`fr_FR` + `EUR`/`USD` wired to channels `default`/`ecommerce`/`Sales`.
- Root cause: `DemoExtrasTableSeeder` deletes + re-inserts `locales`, `currencies`, `channels`, `channel_locales`, `channel_currencies`, `channel_translations` from `demo_extras.json` wholesale. The seeder already guarded `admins` and `magic_ai_*` against this; the locale/currency/channel tables were missed.
- Fix: snapshot the user's enabled locale codes, currency codes, and per-channel wiring before the dump runs, then re-apply them after. Demo's own enabled rows stay enabled (demo product translations need `en_US`, prices reference `EUR`/`USD`); user picks are merged on top.

