### PR TITLE
fix: strip HTML from datagrid cell title tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tests/e2e-pw/.state/
 tests/e2e-pw/playwright-report/
 tests/e2e-pw/test-results/
 tests/e2e-pw/test-results/
+test-results

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
@@ -156,7 +156,7 @@
                                     <p
                                         v-else
                                         class="truncate"
-                                        :title="record[column.index]"
+                                        :title="stripHtml(record[column.index])"
                                         v-html="record[column.index]"
                                     >
                                     </p>
@@ -226,7 +226,15 @@
             methods: {
                 handleRowClick(event, record) {
                     this.$parent.handleRowClick(event, record);
-                }
+                },
+
+                stripHtml(value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value).replace(/<[^>]*>/g, '').trim();
+                },
             }
         });
     </script>

--- a/tests/e2e-pw/tests/01-catalog/completenessTooltip.spec.js
+++ b/tests/e2e-pw/tests/01-catalog/completenessTooltip.spec.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('../../utils/fixtures');
+const { navigateTo } = require('../../utils/helpers');
+
+/**
+ * Regression: product grid "Complete" column rendered the closure HTML inside the
+ * cell correctly via v-html, but bound the same raw HTML to the native :title
+ * tooltip, so hovering showed markup like `<span class="...pill-medium">41%</span>`
+ * instead of just "41%". Fix sets :title via a stripHtml() helper.
+ */
+test.describe('Product grid Complete column tooltip', () => {
+  test('title attribute on closure-rendered cells is plain text, not raw HTML', async ({ adminPage }) => {
+    await navigateTo(adminPage, 'products');
+
+    const firstRow = adminPage.locator('div.row.grid').nth(1);
+    await firstRow.waitFor({ state: 'visible', timeout: 30_000 });
+
+    const completeCell = firstRow.locator('p.truncate', { hasText: /%|N\/A/ }).first();
+    await completeCell.waitFor({ state: 'visible', timeout: 15_000 });
+
+    const renderedHtml = await completeCell.innerHTML();
+    const titleAttr = await completeCell.getAttribute('title');
+
+    expect(renderedHtml).toMatch(/<span/);
+    expect(titleAttr).not.toBeNull();
+    expect(titleAttr).not.toMatch(/<[^>]+>/);
+    expect(titleAttr.trim()).toMatch(/^(\d+%|N\/A)$/);
+  });
+});


### PR DESCRIPTION

## Summary
- Product grid "Complete" column showed the raw closure HTML (e.g. `<span class="...pill-medium">41%</span>`) inside the native browser tooltip on hover, because `:title` was bound to the same value that `v-html` rendered.
- Added a small `stripHtml()` helper on the `v-datagrid-table` Vue component and use it to feed `:title`. The cell still renders the rich pill via `v-html`; only the tooltip text is sanitized.
- The fix is generic — applies to every datagrid column whose value is produced by a closure (status, type, completeness, etc.), not just the Complete column.

## Test plan
- [x] `vendor/bin/pest --testsuite="DataGrid Unit Test"` — 1 passed
- [x] `vendor/bin/pest packages/Webkul/Admin/tests/Feature/Catalog/ProductTest.php` — 103 passed
- [x] `vendor/bin/pest packages/Webkul/Core/tests/Unit/TranslationsCheckerTest.php` — 14 passed
- [x] `vendor/bin/pest --testsuite="Completeness Feature Test"` — 8 passed
- [x] New Playwright regression test `tests/e2e-pw/tests/01-catalog/completenessTooltip.spec.js` — passes after fix, fails without it (verified by reverting)
- [x] Manual: hover the "Complete" cell on `/admin/catalog/products` → tooltip shows `41%`, not raw `<span>` markup