### PR TITLE
Fix/installer trim whitespace db inputs

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -279,19 +279,31 @@ class Installer extends Command
             'DB_HOST'       => text(
                 label: 'Please enter the database host',
                 default: env('DB_HOST') ?? '127.0.0.1',
-                required: true
+                required: true,
+                validate: fn (string $value) => preg_match('/\s/', trim($value))
+                    ? 'The database host cannot contain whitespace.'
+                    : null,
+                transform: trim(...),
             ),
 
             'DB_PORT'       => text(
                 label: 'Please enter the database port',
                 default: env('DB_PORT') ?? '3306',
-                required: true
+                required: true,
+                validate: fn (string $value) => ctype_digit(trim($value))
+                    ? null
+                    : 'The database port must be numeric.',
+                transform: trim(...),
             ),
 
             'DB_DATABASE' => text(
                 label: 'Please enter the database name',
                 default: env('DB_DATABASE') ?? '',
-                required: true
+                required: true,
+                validate: fn (string $value) => preg_match('/\s/', trim($value))
+                    ? 'The database name cannot contain whitespace.'
+                    : null,
+                transform: trim(...),
             ),
 
             'DB_PREFIX' => text(
@@ -314,7 +326,11 @@ class Installer extends Command
             'DB_USERNAME' => text(
                 label: 'Please enter your database username',
                 default: env('DB_USERNAME') ?? '',
-                required: true
+                required: true,
+                validate: fn (string $value) => preg_match('/\s/', trim($value))
+                    ? 'The database username cannot contain whitespace.'
+                    : null,
+                transform: trim(...),
             ),
 
             'DB_PASSWORD' => password(
@@ -323,7 +339,9 @@ class Installer extends Command
             ),
         ];
 
-        $databaseDetails['DB_PREFIX'] = trim((string) ($databaseDetails['DB_PREFIX'] ?? ''));
+        foreach (['DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_PREFIX', 'DB_USERNAME'] as $trimKey) {
+            $databaseDetails[$trimKey] = trim((string) ($databaseDetails[$trimKey] ?? ''));
+        }
 
         if (
             ! $databaseDetails['DB_DATABASE']
@@ -370,19 +388,22 @@ class Installer extends Command
         if ($connectionType === 'cloud') {
             $cloudId = text(
                 label: 'Please enter your Elasticsearch Cloud ID',
-                default: env('ELASTICSEARCH_CLOUD_ID') ?? ''
+                default: env('ELASTICSEARCH_CLOUD_ID') ?? '',
+                transform: trim(...),
             );
             $this->envUpdate('ELASTICSEARCH_CLOUD_ID', $cloudId);
         } else {
             $host = text(
                 label: 'Please enter the Elasticsearch host',
-                default: env('ELASTICSEARCH_HOST') ?? '127.0.0.1:9200'
+                default: env('ELASTICSEARCH_HOST') ?? '127.0.0.1:9200',
+                transform: trim(...),
             );
             $this->envUpdate('ELASTICSEARCH_HOST', $host);
 
             $user = text(
                 label: 'Please enter the Elasticsearch user',
-                default: env('ELASTICSEARCH_USER') ?? ''
+                default: env('ELASTICSEARCH_USER') ?? '',
+                transform: trim(...),
             );
             $this->envUpdate('ELASTICSEARCH_USER', $user);
 
@@ -394,7 +415,8 @@ class Installer extends Command
             if ($connectionType === 'api') {
                 $apiKey = text(
                     label: 'Please enter the Elasticsearch API key',
-                    default: env('ELASTICSEARCH_API_KEY') ?? ''
+                    default: env('ELASTICSEARCH_API_KEY') ?? '',
+                    transform: trim(...),
                 );
                 $this->envUpdate('ELASTICSEARCH_API_KEY', $apiKey);
             }
@@ -402,7 +424,8 @@ class Installer extends Command
 
         $indexPrefix = text(
             label: 'Please enter your Elasticsearch Index Prefix',
-            default: env('ELASTICSEARCH_INDEX_PREFIX') ?? ''
+            default: env('ELASTICSEARCH_INDEX_PREFIX') ?? '',
+            transform: trim(...),
         );
 
         $this->envUpdate('ELASTICSEARCH_INDEX_PREFIX', $indexPrefix);
@@ -418,17 +441,18 @@ class Installer extends Command
         $adminName = text(
             label: 'Set the Name for Administrator',
             default  : 'Example',
-            required: true
+            required: true,
+            transform: trim(...),
         );
 
         $adminEmail = text(
             label: 'Provide Email of Administrator',
             default  : 'admin@example.com',
             validate: fn (string $value) => match (true) {
-                ! filter_var($value, FILTER_VALIDATE_EMAIL) => 'The email address you entered is not valid please try again.',
-                ! filter_var($value, FILTER_VALIDATE_EMAIL) => 'The provided email is invalid, kindly enter a valid email address.',
-                default                                     => null
-            }
+                ! filter_var(trim($value), FILTER_VALIDATE_EMAIL) => 'The email address you entered is not valid please try again.',
+                default                                           => null
+            },
+            transform: trim(...),
         );
 
         $adminPassword = password(
@@ -579,7 +603,8 @@ class Installer extends Command
         $input = text(
             label: $question,
             default: $defaultValue,
-            required: true
+            required: true,
+            transform: trim(...),
         );
 
         $this->envUpdate($key, $input ?: $defaultValue);

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -344,9 +344,9 @@ class Installer extends Command
         }
 
         if (
-            ! $databaseDetails['DB_DATABASE']
-            || ! $databaseDetails['DB_USERNAME']
-            || ! $databaseDetails['DB_PASSWORD']
+            $databaseDetails['DB_DATABASE'] === ''
+            || $databaseDetails['DB_USERNAME'] === ''
+            || $databaseDetails['DB_PASSWORD'] === ''
         ) {
             return $this->error('Please enter the database credentials.');
         }
@@ -607,7 +607,7 @@ class Installer extends Command
             transform: trim(...),
         );
 
-        $this->envUpdate($key, $input ?: $defaultValue);
+        $this->envUpdate($key, $input === '' ? $defaultValue : $input);
     }
 
     /**

--- a/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use Webkul\Installer\Console\Commands\Installer;
+
+function bindInstallerCapturingDbEnvUpdate(array &$captured): Closure
+{
+    return function () use (&$captured) {
+        return new class($captured) extends Installer
+        {
+            private array $captured;
+
+            public function __construct(array &$captured)
+            {
+                parent::__construct();
+                $this->captured = &$captured;
+            }
+
+            public function call($command, array $arguments = [], $output = null)
+            {
+                return 0;
+            }
+
+            protected function envUpdate(string $key, string $value): void
+            {
+                $this->captured[$key] = $value;
+            }
+
+            public function handle()
+            {
+                $this->askForDatabaseDetails();
+
+                return 0;
+            }
+        };
+    };
+}
+
+it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks DNS resolution (issue #863)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1     ')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_HOST'])->toBe('127.0.0.1');
+});
+
+it('rejects DB_HOST containing internal whitespace (issue #863)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0 .1')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_HOST');
+});
+
+it('trims surrounding whitespace on DB_PORT and rejects non-numeric port (issue #863)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '  3306  ')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_PORT'])->toBe('3306');
+});
+
+it('trims surrounding whitespace on DB_DATABASE so the schema lookup uses the bare name (issue #863)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim    ')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_DATABASE'])->toBe('unopim');
+});
+
+it('trims surrounding whitespace on DB_USERNAME so PDO auth uses the bare name (issue #863)', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root  ')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_USERNAME'])->toBe('root');
+});

--- a/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
@@ -35,7 +35,7 @@ function bindInstallerCapturingDbEnvUpdate(array &$captured): Closure
     };
 }
 
-it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks DNS resolution (issue #863)', function () {
+it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks DNS resolution ', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 
@@ -52,7 +52,7 @@ it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks 
     expect($captured['DB_HOST'])->toBe('127.0.0.1');
 });
 
-it('rejects DB_HOST containing internal whitespace (issue #863)', function () {
+it('rejects DB_HOST containing internal whitespace ', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 
@@ -64,7 +64,7 @@ it('rejects DB_HOST containing internal whitespace (issue #863)', function () {
     expect($captured)->not->toHaveKey('DB_HOST');
 });
 
-it('trims surrounding whitespace on DB_PORT and rejects non-numeric port (issue #863)', function () {
+it('trims surrounding whitespace on DB_PORT and rejects non-numeric port ', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 
@@ -81,7 +81,7 @@ it('trims surrounding whitespace on DB_PORT and rejects non-numeric port (issue 
     expect($captured['DB_PORT'])->toBe('3306');
 });
 
-it('trims surrounding whitespace on DB_DATABASE so the schema lookup uses the bare name (issue #863)', function () {
+it('trims surrounding whitespace on DB_DATABASE so the schema lookup uses the bare name ', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 
@@ -98,7 +98,7 @@ it('trims surrounding whitespace on DB_DATABASE so the schema lookup uses the ba
     expect($captured['DB_DATABASE'])->toBe('unopim');
 });
 
-it('trims surrounding whitespace on DB_USERNAME so PDO auth uses the bare name (issue #863)', function () {
+it('trims surrounding whitespace on DB_USERNAME so PDO auth uses the bare name ', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 

--- a/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
@@ -35,7 +35,7 @@ function bindInstallerCapturingDbEnvUpdate(array &$captured): Closure
     };
 }
 
-it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks DNS resolution ', function () {
+it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks DNS resolution', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 
@@ -64,7 +64,7 @@ it('rejects DB_HOST containing internal whitespace ', function () {
     expect($captured)->not->toHaveKey('DB_HOST');
 });
 
-it('trims surrounding whitespace on DB_PORT and rejects non-numeric port ', function () {
+it('trims surrounding whitespace on DB_PORT', function () {
     $captured = [];
     $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
 
@@ -79,6 +79,19 @@ it('trims surrounding whitespace on DB_PORT and rejects non-numeric port ', func
         ->assertExitCode(0);
 
     expect($captured['DB_PORT'])->toBe('3306');
+});
+
+it('rejects a non-numeric DB_PORT so the connection cannot be written with garbage', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '33a06')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_PORT');
 });
 
 it('trims surrounding whitespace on DB_DATABASE so the schema lookup uses the bare name ', function () {


### PR DESCRIPTION
## Summary
- `php artisan unopim:install` accepted whitespace in DB inputs and wrote `DB_HOST="127.0.0.1     "` to `.env`, causing `getaddrinfo for "127.0.0.1" failed` during migrations.
- Only `DB_PREFIX` had `transform: trim(...)`; every other text input passed the raw value straight through to `envUpdate()`, which quote-wraps anything containing whitespace.
- Fix trims and validates `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME` at the prompt level and again after the prompt array is built (defense-in-depth, mirrors the existing `DB_PREFIX` pattern). Same trim treatment extended to `APP_NAME`, `APP_URL`, every Elasticsearch text input, and the admin name/email inputs. Passwords intentionally left untrimmed.
- Added validators that reject internal whitespace on host/database/username and non-numeric ports so the installer fails fast with a clear message instead of silently writing a broken `.env`.

## Test plan
- [x] `vendor/bin/pest packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php` — 5 new tests, all passing (DB_HOST trailing whitespace, DB_HOST internal whitespace rejection, DB_PORT/DB_DATABASE/DB_USERNAME trim)
- [x] `vendor/bin/pest --testsuite="Installer Feature Test"` — 32 passed (134 assertions), no regressions in existing `DatabasePrefixTrimTest`, `CommandTest`, `InstallerControllerTest`, etc.
- [x] Manual repro: entering `127.0.0.1␠␠␠` at the host prompt now lands as `DB_HOST=127.0.0.1` (unquoted) in `.env`; entering `127.0.0 .1` is rejected with "The database host cannot contain whitespace."


