### PR TITLE
fix(webhook): logs grid search placeholder reflects SKU/user 

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar_AE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar_AE/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'يرجى إدخال عنوان URL صالح.',
                     'regex'                      => 'القيمة لا تطابق النمط المطلوب.',
                     'invalid-pattern'            => 'تم تقديم نمط مخصص غير صالح.',
-
                     'numeric'                    => 'يجب أن تكون القيمة المدخلة في السمة الرقمية ":attribute" رقماً صالحاً.',
                     'select-attribute-or-family' => 'يرجى اختيار سمة واحدة على الأقل أو عائلة سمات.',
                     'failed'                     => 'فشلت عملية التحقق.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'تم التحرير الجماعي بنجاح.',
                 ],
-                'id'                          => 'المعرف',
-                'no-changes'                  => 'لا توجد تغييرات للحفظ.',
-
-                'invalid-datetime'            => 'يرجى إدخال تاريخ ووقت صالح.',
-
-                'resize-column'               => 'اسحب لتغيير عرض العمود',
-                'success'                     => 'تم تنفيذ العملية بنجاح.',
-                'fetch-failed'                => 'فشل في الجلب.',
-                'action'                      => 'تحرير جماعي',
-                'description'                 => 'تحرير منتجات متعددة دفعة واحدة. تتم معالجة التغييرات في الخلفية.',
-                'gallery-preview'             => 'معاينة المعرض',
-                'img-preview'                 => 'معاينة الصورة',
-                'no-image'                    => 'لا توجد صورة',
-                'img-fail'                    => 'فشل تحميل الصورة.',
-                'no-option'                   => 'لا توجد خيارات',
-                'keyboard-shortcuts'          => 'اختصارات لوحة المفاتيح',
-                'shortcuts-navigation'        => 'التنقل',
-                'shortcuts-editing'           => 'التحرير',
-                'shortcuts-selection'         => 'التحديد',
-                'shortcuts-clipboard'         => 'الحافظة والتعبئة',
-                'shortcuts-move-cell'         => 'التنقل بين الخلايا',
-                'shortcuts-move-down'         => 'التنقل للأسفل / تأكيد التعديل',
-                'shortcuts-move-up'           => 'التنقل للأعلى',
-                'shortcuts-move-right-left'   => 'التنقل يميناً / يساراً',
-                'shortcuts-home-end'          => 'أول / آخر عمود في الصف',
-                'shortcuts-ctrl-home-end'     => 'أول / آخر خلية في الشبكة',
-                'shortcuts-extend-selection'  => 'توسيع التحديد',
-                'shortcuts-select-all'        => 'تحديد كل الخلايا',
-                'shortcuts-enter-edit'        => 'الدخول إلى وضع التحرير',
-                'shortcuts-confirm-move-down' => 'تأكيد + التنقل للأسفل',
-                'shortcuts-confirm-move-right'=> 'تأكيد + التنقل يميناً',
-                'shortcuts-escape-revert'     => 'استعادة القيمة + الخروج من التحرير',
-                'shortcuts-clear-cell'        => 'مسح الخلية',
-                'shortcuts-copy'              => 'نسخ',
-                'shortcuts-cut'               => 'قص',
-                'shortcuts-paste'             => 'لصق',
-                'shortcuts-fill-down'         => 'تعبئة للأسفل',
-                'shortcuts-fill-right'        => 'تعبئة لليمين',
-                'shortcuts-undo'              => 'تراجع',
-                'shortcuts-redo'              => 'إعادة',
-                'shortcuts-help'              => 'تبديل اختصارات لوحة المفاتيح',
+                'id'                           => 'المعرف',
+                'no-changes'                   => 'لا توجد تغييرات للحفظ.',
+                'invalid-datetime'             => 'يرجى إدخال تاريخ ووقت صالح.',
+                'resize-column'                => 'اسحب لتغيير عرض العمود',
+                'success'                      => 'تم تنفيذ العملية بنجاح.',
+                'fetch-failed'                 => 'فشل في الجلب.',
+                'action'                       => 'تحرير جماعي',
+                'description'                  => 'تحرير منتجات متعددة دفعة واحدة. تتم معالجة التغييرات في الخلفية.',
+                'gallery-preview'              => 'معاينة المعرض',
+                'img-preview'                  => 'معاينة الصورة',
+                'no-image'                     => 'لا توجد صورة',
+                'img-fail'                     => 'فشل تحميل الصورة.',
+                'no-option'                    => 'لا توجد خيارات',
+                'keyboard-shortcuts'           => 'اختصارات لوحة المفاتيح',
+                'shortcuts-navigation'         => 'التنقل',
+                'shortcuts-editing'            => 'التحرير',
+                'shortcuts-selection'          => 'التحديد',
+                'shortcuts-clipboard'          => 'الحافظة والتعبئة',
+                'shortcuts-move-cell'          => 'التنقل بين الخلايا',
+                'shortcuts-move-down'          => 'التنقل للأسفل / تأكيد التعديل',
+                'shortcuts-move-up'            => 'التنقل للأعلى',
+                'shortcuts-move-right-left'    => 'التنقل يميناً / يساراً',
+                'shortcuts-home-end'           => 'أول / آخر عمود في الصف',
+                'shortcuts-ctrl-home-end'      => 'أول / آخر خلية في الشبكة',
+                'shortcuts-extend-selection'   => 'توسيع التحديد',
+                'shortcuts-select-all'         => 'تحديد كل الخلايا',
+                'shortcuts-enter-edit'         => 'الدخول إلى وضع التحرير',
+                'shortcuts-confirm-move-down'  => 'تأكيد + التنقل للأسفل',
+                'shortcuts-confirm-move-right' => 'تأكيد + التنقل يميناً',
+                'shortcuts-escape-revert'      => 'استعادة القيمة + الخروج من التحرير',
+                'shortcuts-clear-cell'         => 'مسح الخلية',
+                'shortcuts-copy'               => 'نسخ',
+                'shortcuts-cut'                => 'قص',
+                'shortcuts-paste'              => 'لصق',
+                'shortcuts-fill-down'          => 'تعبئة للأسفل',
+                'shortcuts-fill-right'         => 'تعبئة لليمين',
+                'shortcuts-undo'               => 'تراجع',
+                'shortcuts-redo'               => 'إعادة',
+                'shortcuts-help'               => 'تبديل اختصارات لوحة المفاتيح',
             ],
             'create-success'          => 'تم إنشاء المنتج بنجاح',
             'delete-failed'           => 'فشل حذف المنتج',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'قابل للتصفية',
                 'ai-translate'          => 'ترجمة الذكاء الاصطناعي',
                 'invalid-swatch-type'   => 'ال:attribute غير مسموح به لنوع السمة :type مع نوع العينة :swatch_type.',
-
                 'single-object-only'    => 'يجب إرسال كائن سمة واحد فقط لكل طلب إنشاء.',
                 'option'                => [
                     'color'    => 'تغيير الالوان',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'تم حذف السمة بنجاح',
             'update-success'    => 'سمة تحديث بنجاح',
             'user-define-error' => 'لا يمكن حذف سمة النظام',
-
             'immutable-fields'  => 'لا يمكن تعديل الحقول التالية: :fields.',
             'not-found'         => 'لم يتم العثور على السمة برمز ":code"',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'تحديث حقل الفئة بنجاح',
             'user-define-error' => 'لا يمكن حذف حقل فئة النظام',
             'not-found'         => 'لم يتم العثور على عائلة السمات برمز ":code"',
-
             'immutable-fields'  => 'لا يمكن تعديل الحقول التالية: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'لا يمكن تحديث الخيارات القابلة للتكوين لأن هذه العائلة لديها بالفعل منتجات متغيرة.',
         ],
         'history' => [
-            'view' => 'عرض تفاصيل الإصدار',
-
+            'view'  => 'عرض تفاصيل الإصدار',
             'index' => [
                 'datagrid' => [
                     'version'   => 'إصدار',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'متوقف مؤقتاً',
                         'cancelled'            => 'ملغي',
                         'failed'               => 'فشل',
-
-                        'view'       => 'عرض',
+                        'view'                 => 'عرض',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'حالة',
                 'title'            => 'تحرير العضو',
             ],
-            'activate-warning'           => 'لم يتم تنشيط حسابك بعد ، يرجى الاتصال بالمسؤول.',
-            'cannot-change'              => 'لا يمكن تغيير المستخدم',
-            'cannot-escalate-role'       => 'ليس لديك إذن لتعيين دور بصلاحيات كاملة.',
-            'create-success'             => 'تم إنشاء المستخدم بنجاح.',
-            'delete-failed'              => 'فشل حذف المستخدم.',
-            'delete-success'             => 'تم حذف المستخدم بنجاح.',
-            'delete-warning'             => 'هل أنت متأكد من أنك تريد تنفيذ هذا الإجراء؟',
-            'incorrect-password'         => 'كلمة سر خاطئة',
-            'last-delete-error'          => 'فشل آخر حذف المستخدم',
-            'login-error'                => 'يرجى التحقق من بيانات الاعتماد الخاصة بك والمحاولة مرة أخرى.',
-            'update-success'             => 'تم تحديث المستخدم بنجاح.',
-            'current-user-delete-error'  => 'لا يمكن حذف المستخدم الذي قام بتسجيل الدخول',
+            'activate-warning'          => 'لم يتم تنشيط حسابك بعد ، يرجى الاتصال بالمسؤول.',
+            'cannot-change'             => 'لا يمكن تغيير المستخدم',
+            'cannot-escalate-role'      => 'ليس لديك إذن لتعيين دور بصلاحيات كاملة.',
+            'create-success'            => 'تم إنشاء المستخدم بنجاح.',
+            'delete-failed'             => 'فشل حذف المستخدم.',
+            'delete-success'            => 'تم حذف المستخدم بنجاح.',
+            'delete-warning'            => 'هل أنت متأكد من أنك تريد تنفيذ هذا الإجراء؟',
+            'incorrect-password'        => 'كلمة سر خاطئة',
+            'last-delete-error'         => 'فشل آخر حذف المستخدم',
+            'login-error'               => 'يرجى التحقق من بيانات الاعتماد الخاصة بك والمحاولة مرة أخرى.',
+            'update-success'            => 'تم تحديث المستخدم بنجاح.',
+            'current-user-delete-error' => 'لا يمكن حذف المستخدم الذي قام بتسجيل الدخول',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'المحفزات',
-
             ],
-
             'datagrid' => [
                 'id'               => 'المعرف',
                 'title'            => 'العنوان',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'محفزات النظام',
-
             ],
-
             'datagrid' => [
                 'id'          => 'المعرف',
                 'title'       => 'العنوان',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'منقي',
                 ],
                 'search_by' => [
-                    'code'       => 'البحث حسب الرمز',
-                    'code_or_id' => 'ابحث حسب الرمز أو الهوية',
+                    'code'        => 'البحث حسب الرمز',
+                    'code_or_id'  => 'ابحث حسب الرمز أو الهوية',
+                    'sku_or_user' => 'البحث حسب SKU أو المستخدم',
                 ],
                 'search' => [
                     'title' => 'يبحث',

--- a/packages/Webkul/Admin/src/Resources/lang/ca_ES/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca_ES/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Si us plau, introdueix una URL vàlida.',
                     'regex'                      => 'El valor no coincideix amb el patró requerit.',
                     'invalid-pattern'            => 'S\'ha proporcionat un patró personalitzat no vàlid.',
-
                     'numeric'                    => 'El valor de l\'atribut numèric ":attribute" ha de ser un número vàlid.',
                     'select-attribute-or-family' => 'Si us plau, seleccioneu almenys un atribut o una família d’atributs.',
                     'failed'                     => 'La validació ha fallat.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Edició massiva realitzada amb èxit.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'No hi ha canvis per desar.',
-
-                'invalid-datetime'            => 'Introdueix una data i hora vàlides.',
-
-                'resize-column'               => 'Arrossega per redimensionar la columna',
-                'success'                     => 'Operació completada amb èxit.',
-                'fetch-failed'                => 'Error en obtenir les dades.',
-                'action'                      => 'Edició en massa',
-                'description'                 => 'Editeu diversos productes alhora. Els canvis es processen en segon pla.',
-                'gallery-preview'             => 'Previsualització de la galeria',
-                'img-preview'                 => 'Previsualització de la imatge',
-                'no-image'                    => 'Sense imatge',
-                'img-fail'                    => 'Error en la pujada de la imatge.',
-                'no-option'                   => 'Sense opcions',
-                'keyboard-shortcuts'          => 'Dreceres de teclat',
-                'shortcuts-navigation'        => 'Navegació',
-                'shortcuts-editing'           => 'Edició',
-                'shortcuts-selection'         => 'Selecció',
-                'shortcuts-clipboard'         => 'Porta-retalls i omplir',
-                'shortcuts-move-cell'         => 'Moure entre cel·les',
-                'shortcuts-move-down'         => 'Baixar / confirmar edició',
-                'shortcuts-move-up'           => 'Pujar',
-                'shortcuts-move-right-left'   => 'Moure a la dreta / esquerra',
-                'shortcuts-home-end'          => 'Primera / última columna de la fila',
-                'shortcuts-ctrl-home-end'     => 'Primera / última cel·la de la graella',
-                'shortcuts-extend-selection'  => 'Ampliar la selecció',
-                'shortcuts-select-all'        => 'Seleccionar totes les cel·les',
-                'shortcuts-enter-edit'        => 'Entrar en mode edició',
-                'shortcuts-confirm-move-down' => 'Confirmar + baixar',
-                'shortcuts-confirm-move-right'=> 'Confirmar + moure a la dreta',
-                'shortcuts-escape-revert'     => 'Revertir valor + sortir de l\'edició',
-                'shortcuts-clear-cell'        => 'Buidar cel·la',
-                'shortcuts-copy'              => 'Copiar',
-                'shortcuts-cut'               => 'Retallar',
-                'shortcuts-paste'             => 'Enganxar',
-                'shortcuts-fill-down'         => 'Omplir cap avall',
-                'shortcuts-fill-right'        => 'Omplir cap a la dreta',
-                'shortcuts-undo'              => 'Desfer',
-                'shortcuts-redo'              => 'Refer',
-                'shortcuts-help'              => 'Mostrar/amagar dreceres de teclat',
+                'id'                           => 'ID',
+                'no-changes'                   => 'No hi ha canvis per desar.',
+                'invalid-datetime'             => 'Introdueix una data i hora vàlides.',
+                'resize-column'                => 'Arrossega per redimensionar la columna',
+                'success'                      => 'Operació completada amb èxit.',
+                'fetch-failed'                 => 'Error en obtenir les dades.',
+                'action'                       => 'Edició en massa',
+                'description'                  => 'Editeu diversos productes alhora. Els canvis es processen en segon pla.',
+                'gallery-preview'              => 'Previsualització de la galeria',
+                'img-preview'                  => 'Previsualització de la imatge',
+                'no-image'                     => 'Sense imatge',
+                'img-fail'                     => 'Error en la pujada de la imatge.',
+                'no-option'                    => 'Sense opcions',
+                'keyboard-shortcuts'           => 'Dreceres de teclat',
+                'shortcuts-navigation'         => 'Navegació',
+                'shortcuts-editing'            => 'Edició',
+                'shortcuts-selection'          => 'Selecció',
+                'shortcuts-clipboard'          => 'Porta-retalls i omplir',
+                'shortcuts-move-cell'          => 'Moure entre cel·les',
+                'shortcuts-move-down'          => 'Baixar / confirmar edició',
+                'shortcuts-move-up'            => 'Pujar',
+                'shortcuts-move-right-left'    => 'Moure a la dreta / esquerra',
+                'shortcuts-home-end'           => 'Primera / última columna de la fila',
+                'shortcuts-ctrl-home-end'      => 'Primera / última cel·la de la graella',
+                'shortcuts-extend-selection'   => 'Ampliar la selecció',
+                'shortcuts-select-all'         => 'Seleccionar totes les cel·les',
+                'shortcuts-enter-edit'         => 'Entrar en mode edició',
+                'shortcuts-confirm-move-down'  => 'Confirmar + baixar',
+                'shortcuts-confirm-move-right' => 'Confirmar + moure a la dreta',
+                'shortcuts-escape-revert'      => 'Revertir valor + sortir de l\'edició',
+                'shortcuts-clear-cell'         => 'Buidar cel·la',
+                'shortcuts-copy'               => 'Copiar',
+                'shortcuts-cut'                => 'Retallar',
+                'shortcuts-paste'              => 'Enganxar',
+                'shortcuts-fill-down'          => 'Omplir cap avall',
+                'shortcuts-fill-right'         => 'Omplir cap a la dreta',
+                'shortcuts-undo'               => 'Desfer',
+                'shortcuts-redo'               => 'Refer',
+                'shortcuts-help'               => 'Mostrar/amagar dreceres de teclat',
             ],
             'create-success'          => 'Producte creat amb èxit',
             'delete-failed'           => 'Eliminació del producte fallida',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'És filtrable',
                 'ai-translate'          => 'Traducció IA',
                 'invalid-swatch-type'   => 'L\':attribute no està permès per al tipus d\'atribut :type amb el tipus de mostra :swatch_type.',
-
                 'single-object-only'    => 'Cada sol·licitud de creació ha d\'enviar només un objecte d\'atribut.',
                 'option'                => [
                     'color'    => 'Muestra de color',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atribut eliminat amb èxit',
             'update-success'    => 'Atribut actualitzat amb èxit',
             'user-define-error' => 'No es pot eliminar un atribut del sistema',
-
             'immutable-fields'  => 'No es poden modificar els camps següents: :fields.',
             'not-found'         => 'No s\'ha trobat l\'atribut amb codi ":code"',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Camp de Categoria Actualitzat Correctament',
             'user-define-error' => 'No es pot eliminar un Camp de Categoria del sistema',
             'not-found'         => 'No s\'ha trobat el Camp de Categoria amb el codi ":code"',
-
             'immutable-fields'  => 'No es poden modificar els camps següents: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'No es poden actualitzar les opcions configurables ja que aquesta família ja té productes variants.',
         ],
         'history' => [
-            'view' => 'Veure els detalls de la versió',
-
+            'view'  => 'Veure els detalls de la versió',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versió',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'En pausa',
                         'cancelled'            => 'Cancel·lat',
                         'failed'               => 'Fallat',
-
-                        'view'       => 'Veure',
+                        'view'                 => 'Veure',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Estat',
                 'title'            => 'Editar Usuari',
             ],
-            'activate-warning'           => 'El teu compte encara no està activat, contacta amb l\'administrador.',
-            'cannot-change'              => 'L\'usuari no pot ser modificat',
-            'cannot-escalate-role'       => 'No teniu permís per assignar un rol amb accés complet.',
-            'create-success'             => 'Usuari creat correctament.',
-            'delete-failed'              => 'Error en eliminar l\'usuari.',
-            'delete-success'             => 'Usuari eliminat correctament.',
-            'delete-warning'             => 'Estàs segur de voler realitzar aquesta acció?',
-            'incorrect-password'         => 'Contrasenya incorrecta',
-            'last-delete-error'          => 'Última eliminació d\'usuari fallida',
-            'login-error'                => 'Comprova les teves credencials i torna a provar.',
-            'update-success'             => 'Usuari actualitzat correctament.',
-            'current-user-delete-error'  => 'L\'usuari connectat no es pot eliminar.',
+            'activate-warning'          => 'El teu compte encara no està activat, contacta amb l\'administrador.',
+            'cannot-change'             => 'L\'usuari no pot ser modificat',
+            'cannot-escalate-role'      => 'No teniu permís per assignar un rol amb accés complet.',
+            'create-success'            => 'Usuari creat correctament.',
+            'delete-failed'             => 'Error en eliminar l\'usuari.',
+            'delete-success'            => 'Usuari eliminat correctament.',
+            'delete-warning'            => 'Estàs segur de voler realitzar aquesta acció?',
+            'incorrect-password'        => 'Contrasenya incorrecta',
+            'last-delete-error'         => 'Última eliminació d\'usuari fallida',
+            'login-error'               => 'Comprova les teves credencials i torna a provar.',
+            'update-success'            => 'Usuari actualitzat correctament.',
+            'current-user-delete-error' => 'L\'usuari connectat no es pot eliminar.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Títol',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts del sistema',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Títol',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtrar',
                 ],
                 'search_by' => [
-                    'code'       => 'Buscar por código',
-                    'code_or_id' => 'Buscar por código o id',
+                    'code'        => 'Buscar por código',
+                    'code_or_id'  => 'Buscar por código o id',
+                    'sku_or_user' => 'Buscar por SKU o usuario',
                 ],
                 'search' => [
                     'title' => 'Buscar',

--- a/packages/Webkul/Admin/src/Resources/lang/da_DK/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/da_DK/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Indtast venligst en gyldig URL.',
                     'regex'                      => 'Værdien matcher ikke det krævede mønster.',
                     'invalid-pattern'            => 'Ugyldigt brugerdefineret mønster angivet.',
-
                     'numeric'                    => 'Værdien for den numeriske attribut ":attribute" skal være et gyldigt tal.',
                     'select-attribute-or-family' => 'Vælg mindst ét attribut eller en attributfamilie.',
                     'failed'                     => 'Validering mislykkedes.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Masse-redigering lykkedes.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Ingen ændringer at gemme.',
-
-                'invalid-datetime'            => 'Indtast en gyldig dato og klokkeslæt.',
-
-                'resize-column'               => 'Træk for at ændre kolonnebredden',
-                'success'                     => 'Handling gennemført med succes.',
-                'fetch-failed'                => 'Hentning mislykkedes.',
-                'action'                      => 'Masseændring',
-                'description'                 => 'Rediger flere produkter på én gang. Ændringerne behandles i baggrunden.',
-                'gallery-preview'             => 'Galleri forhåndsvisning',
-                'img-preview'                 => 'Billedforhåndsvisning',
-                'no-image'                    => 'Intet billede',
-                'img-fail'                    => 'Billedupload mislykkedes.',
-                'no-option'                   => 'Ingen muligheder',
-                'keyboard-shortcuts'          => 'Tastaturgenveje',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Redigering',
-                'shortcuts-selection'         => 'Valg',
-                'shortcuts-clipboard'         => 'Udklipsholder og udfyldning',
-                'shortcuts-move-cell'         => 'Flyt mellem celler',
-                'shortcuts-move-down'         => 'Flyt ned / bekræft redigering',
-                'shortcuts-move-up'           => 'Flyt op',
-                'shortcuts-move-right-left'   => 'Flyt til højre / venstre',
-                'shortcuts-home-end'          => 'Første / sidste kolonne i rækken',
-                'shortcuts-ctrl-home-end'     => 'Første / sidste celle i gitteret',
-                'shortcuts-extend-selection'  => 'Udvid valg',
-                'shortcuts-select-all'        => 'Vælg alle celler',
-                'shortcuts-enter-edit'        => 'Gå til redigeringstilstand',
-                'shortcuts-confirm-move-down' => 'Bekræft + flyt ned',
-                'shortcuts-confirm-move-right'=> 'Bekræft + flyt til højre',
-                'shortcuts-escape-revert'     => 'Gendan værdi + forlad redigering',
-                'shortcuts-clear-cell'        => 'Ryd celle',
-                'shortcuts-copy'              => 'Kopier',
-                'shortcuts-cut'               => 'Klip',
-                'shortcuts-paste'             => 'Indsæt',
-                'shortcuts-fill-down'         => 'Udfyld nedad',
-                'shortcuts-fill-right'        => 'Udfyld til højre',
-                'shortcuts-undo'              => 'Fortryd',
-                'shortcuts-redo'              => 'Gentag',
-                'shortcuts-help'              => 'Vis/skjul tastaturgenveje',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Ingen ændringer at gemme.',
+                'invalid-datetime'             => 'Indtast en gyldig dato og klokkeslæt.',
+                'resize-column'                => 'Træk for at ændre kolonnebredden',
+                'success'                      => 'Handling gennemført med succes.',
+                'fetch-failed'                 => 'Hentning mislykkedes.',
+                'action'                       => 'Masseændring',
+                'description'                  => 'Rediger flere produkter på én gang. Ændringerne behandles i baggrunden.',
+                'gallery-preview'              => 'Galleri forhåndsvisning',
+                'img-preview'                  => 'Billedforhåndsvisning',
+                'no-image'                     => 'Intet billede',
+                'img-fail'                     => 'Billedupload mislykkedes.',
+                'no-option'                    => 'Ingen muligheder',
+                'keyboard-shortcuts'           => 'Tastaturgenveje',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Redigering',
+                'shortcuts-selection'          => 'Valg',
+                'shortcuts-clipboard'          => 'Udklipsholder og udfyldning',
+                'shortcuts-move-cell'          => 'Flyt mellem celler',
+                'shortcuts-move-down'          => 'Flyt ned / bekræft redigering',
+                'shortcuts-move-up'            => 'Flyt op',
+                'shortcuts-move-right-left'    => 'Flyt til højre / venstre',
+                'shortcuts-home-end'           => 'Første / sidste kolonne i rækken',
+                'shortcuts-ctrl-home-end'      => 'Første / sidste celle i gitteret',
+                'shortcuts-extend-selection'   => 'Udvid valg',
+                'shortcuts-select-all'         => 'Vælg alle celler',
+                'shortcuts-enter-edit'         => 'Gå til redigeringstilstand',
+                'shortcuts-confirm-move-down'  => 'Bekræft + flyt ned',
+                'shortcuts-confirm-move-right' => 'Bekræft + flyt til højre',
+                'shortcuts-escape-revert'      => 'Gendan værdi + forlad redigering',
+                'shortcuts-clear-cell'         => 'Ryd celle',
+                'shortcuts-copy'               => 'Kopier',
+                'shortcuts-cut'                => 'Klip',
+                'shortcuts-paste'              => 'Indsæt',
+                'shortcuts-fill-down'          => 'Udfyld nedad',
+                'shortcuts-fill-right'         => 'Udfyld til højre',
+                'shortcuts-undo'               => 'Fortryd',
+                'shortcuts-redo'               => 'Gentag',
+                'shortcuts-help'               => 'Vis/skjul tastaturgenveje',
             ],
             'create-success'          => 'Produkt oprettet med succes',
             'delete-failed'           => 'Produkt sletning mislykkedes',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Er filtrerbar',
                 'ai-translate'          => 'AI Oversæt',
                 'invalid-swatch-type'   => 'Attributten :attribute er ikke tilladt for attributtype :type med swatchtype :swatch_type.',
-
                 'single-object-only'    => 'Hver oprettelsesanmodning må kun indeholde ét attributobjekt.',
                 'option'                => [
                     'color'    => 'Farveprøve',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribut slettet succesfuldt',
             'update-success'    => 'Attribut opdateret succesfuldt',
             'user-define-error' => 'Kan ikke slette systemattribut',
-
             'immutable-fields'  => 'Følgende felter kan ikke ændres: :fields.',
             'not-found'         => 'Attribut med kode ":code" blev ikke fundet',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Kategori Felt Opdateret Med Succes',
             'user-define-error' => 'Kan ikke slette system Kategori Felt',
             'not-found'         => 'Kategori Felt med kode ":code" blev ikke fundet',
-
             'immutable-fields'  => 'Følgende felter kan ikke ændres: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Kan ikke opdatere konfigurerbare muligheder, da denne familie allerede har variantprodukter.',
         ],
         'history' => [
-            'view' => 'Vis versionsdetaljer',
-
+            'view'  => 'Vis versionsdetaljer',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Sat på pause',
                         'cancelled'            => 'Annulleret',
                         'failed'               => 'Mislykket',
-
-                        'view'       => 'Vis',
+                        'view'                 => 'Vis',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Status',
                 'title'            => 'Rediger Bruger',
             ],
-            'activate-warning'           => 'Din konto er endnu ikke aktiveret, kontakt administrator.',
-            'cannot-change'              => 'Bruger kan ikke ændres',
-            'cannot-escalate-role'       => 'Du har ikke tilladelse til at tildele en rolle med fuld adgang.',
-            'create-success'             => 'Bruger oprettet succesfuldt.',
-            'delete-failed'              => 'Bruger sletning mislykkedes.',
-            'delete-success'             => 'Bruger slettet succesfuldt.',
-            'delete-warning'             => 'Er du sikker på, at du vil udføre denne handling?',
-            'incorrect-password'         => 'Forkert adgangskode',
-            'last-delete-error'          => 'Sidste sletning af bruger mislykkedes',
-            'login-error'                => 'Tjek dine legitimationsoplysninger og prøv igen.',
-            'update-success'             => 'Bruger opdateret succesfuldt.',
-            'current-user-delete-error'  => 'Den loggede bruger kan ikke slettes.',
+            'activate-warning'          => 'Din konto er endnu ikke aktiveret, kontakt administrator.',
+            'cannot-change'             => 'Bruger kan ikke ændres',
+            'cannot-escalate-role'      => 'Du har ikke tilladelse til at tildele en rolle med fuld adgang.',
+            'create-success'            => 'Bruger oprettet succesfuldt.',
+            'delete-failed'             => 'Bruger sletning mislykkedes.',
+            'delete-success'            => 'Bruger slettet succesfuldt.',
+            'delete-warning'            => 'Er du sikker på, at du vil udføre denne handling?',
+            'incorrect-password'        => 'Forkert adgangskode',
+            'last-delete-error'         => 'Sidste sletning af bruger mislykkedes',
+            'login-error'               => 'Tjek dine legitimationsoplysninger og prøv igen.',
+            'update-success'            => 'Bruger opdateret succesfuldt.',
+            'current-user-delete-error' => 'Den loggede bruger kan ikke slettes.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titel',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Systemprompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titel',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtrer',
                 ],
                 'search_by' => [
-                    'code'       => 'Søg efter kode',
-                    'code_or_id' => 'Søg efter kode eller id',
+                    'code'        => 'Søg efter kode',
+                    'code_or_id'  => 'Søg efter kode eller id',
+                    'sku_or_user' => 'Søg efter SKU eller bruger',
                 ],
                 'search' => [
                     'title' => 'Søg',

--- a/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de_DE/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Bitte geben Sie eine gültige URL ein.',
                     'regex'                      => 'Der Wert entspricht nicht dem erforderlichen Muster.',
                     'invalid-pattern'            => 'Ungültiges benutzerdefiniertes Muster angegeben.',
-
                     'numeric'                    => 'Der Wert für das numerische Attribut „:attribute“ muss eine gültige Zahl sein.',
                     'select-attribute-or-family' => 'Bitte wählen Sie mindestens ein Attribut oder eine Attributfamilie aus.',
                     'failed'                     => 'Validierung fehlgeschlagen.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Massenbearbeitung erfolgreich.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Keine Änderungen zum Speichern.',
-
-                'invalid-datetime'            => 'Bitte ein gültiges Datum mit Uhrzeit eingeben.',
-
-                'resize-column'               => 'Ziehen, um die Spaltenbreite zu ändern',
-                'success'                     => 'Vorgang erfolgreich abgeschlossen.',
-                'fetch-failed'                => 'Abruf fehlgeschlagen.',
-                'action'                      => 'Massenbearbeitung',
-                'description'                 => 'Mehrere Produkte gleichzeitig bearbeiten. Änderungen werden im Hintergrund verarbeitet.',
-                'gallery-preview'             => 'Galerievorschau',
-                'img-preview'                 => 'Bildvorschau',
-                'no-image'                    => 'Kein Bild',
-                'img-fail'                    => 'Bildupload fehlgeschlagen.',
-                'no-option'                   => 'Keine Optionen',
-                'keyboard-shortcuts'          => 'Tastaturkürzel',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Bearbeitung',
-                'shortcuts-selection'         => 'Auswahl',
-                'shortcuts-clipboard'         => 'Zwischenablage & Ausfüllen',
-                'shortcuts-move-cell'         => 'Zwischen Zellen wechseln',
-                'shortcuts-move-down'         => 'Nach unten / Bearbeitung bestätigen',
-                'shortcuts-move-up'           => 'Nach oben',
-                'shortcuts-move-right-left'   => 'Nach rechts / links',
-                'shortcuts-home-end'          => 'Erste / letzte Spalte in der Zeile',
-                'shortcuts-ctrl-home-end'     => 'Erste / letzte Zelle im Raster',
-                'shortcuts-extend-selection'  => 'Auswahl erweitern',
-                'shortcuts-select-all'        => 'Alle Zellen auswählen',
-                'shortcuts-enter-edit'        => 'Bearbeitungsmodus aktivieren',
-                'shortcuts-confirm-move-down' => 'Bestätigen + nach unten',
-                'shortcuts-confirm-move-right'=> 'Bestätigen + nach rechts',
-                'shortcuts-escape-revert'     => 'Wert zurücksetzen + Bearbeitung beenden',
-                'shortcuts-clear-cell'        => 'Zelle leeren',
-                'shortcuts-copy'              => 'Kopieren',
-                'shortcuts-cut'               => 'Ausschneiden',
-                'shortcuts-paste'             => 'Einfügen',
-                'shortcuts-fill-down'         => 'Nach unten ausfüllen',
-                'shortcuts-fill-right'        => 'Nach rechts ausfüllen',
-                'shortcuts-undo'              => 'Rückgängig',
-                'shortcuts-redo'              => 'Wiederholen',
-                'shortcuts-help'              => 'Tastaturkürzel ein-/ausblenden',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Keine Änderungen zum Speichern.',
+                'invalid-datetime'             => 'Bitte ein gültiges Datum mit Uhrzeit eingeben.',
+                'resize-column'                => 'Ziehen, um die Spaltenbreite zu ändern',
+                'success'                      => 'Vorgang erfolgreich abgeschlossen.',
+                'fetch-failed'                 => 'Abruf fehlgeschlagen.',
+                'action'                       => 'Massenbearbeitung',
+                'description'                  => 'Mehrere Produkte gleichzeitig bearbeiten. Änderungen werden im Hintergrund verarbeitet.',
+                'gallery-preview'              => 'Galerievorschau',
+                'img-preview'                  => 'Bildvorschau',
+                'no-image'                     => 'Kein Bild',
+                'img-fail'                     => 'Bildupload fehlgeschlagen.',
+                'no-option'                    => 'Keine Optionen',
+                'keyboard-shortcuts'           => 'Tastaturkürzel',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Bearbeitung',
+                'shortcuts-selection'          => 'Auswahl',
+                'shortcuts-clipboard'          => 'Zwischenablage & Ausfüllen',
+                'shortcuts-move-cell'          => 'Zwischen Zellen wechseln',
+                'shortcuts-move-down'          => 'Nach unten / Bearbeitung bestätigen',
+                'shortcuts-move-up'            => 'Nach oben',
+                'shortcuts-move-right-left'    => 'Nach rechts / links',
+                'shortcuts-home-end'           => 'Erste / letzte Spalte in der Zeile',
+                'shortcuts-ctrl-home-end'      => 'Erste / letzte Zelle im Raster',
+                'shortcuts-extend-selection'   => 'Auswahl erweitern',
+                'shortcuts-select-all'         => 'Alle Zellen auswählen',
+                'shortcuts-enter-edit'         => 'Bearbeitungsmodus aktivieren',
+                'shortcuts-confirm-move-down'  => 'Bestätigen + nach unten',
+                'shortcuts-confirm-move-right' => 'Bestätigen + nach rechts',
+                'shortcuts-escape-revert'      => 'Wert zurücksetzen + Bearbeitung beenden',
+                'shortcuts-clear-cell'         => 'Zelle leeren',
+                'shortcuts-copy'               => 'Kopieren',
+                'shortcuts-cut'                => 'Ausschneiden',
+                'shortcuts-paste'              => 'Einfügen',
+                'shortcuts-fill-down'          => 'Nach unten ausfüllen',
+                'shortcuts-fill-right'         => 'Nach rechts ausfüllen',
+                'shortcuts-undo'               => 'Rückgängig',
+                'shortcuts-redo'               => 'Wiederholen',
+                'shortcuts-help'               => 'Tastaturkürzel ein-/ausblenden',
             ],
             'create-success'          => 'Produkt erfolgreich erstellt',
             'delete-failed'           => 'Produkt gelöscht Fehlgeschlagen',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Ist filterbar',
                 'ai-translate'          => 'KI Übersetzen',
                 'invalid-swatch-type'   => 'Der :attribute ist für den Attributtyp :type mit dem Farbmuster :swatch_type nicht erlaubt.',
-
                 'single-object-only'    => 'Pro Erstellungsanfrage darf nur ein Attributobjekt gesendet werden.',
                 'option'                => [
                     'color'    => 'Farbfeld',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribut erfolgreich gelöscht',
             'update-success'    => 'Attribut erfolgreich aktualisiert',
             'user-define-error' => 'Systemattribut kann nicht gelöscht werden',
-
             'immutable-fields'  => 'Die folgenden Felder können nicht geändert werden: :fields.',
             'not-found'         => 'Attribut mit Code „:code“ konnte nicht gefunden werden',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Kategoriefeld erfolgreich aktualisiert',
             'user-define-error' => 'Systemkategoriefeld kann nicht gelöscht werden',
             'not-found'         => 'Kategoriefeld mit Code „:code“ konnte nicht gefunden werden',
-
             'immutable-fields'  => 'Die folgenden Felder können nicht geändert werden: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Konfigurierbare Optionen können nicht aktualisiert werden, da diese Familie bereits Variantenprodukte hat.',
         ],
         'history' => [
-            'view' => 'Versionsdetails anzeigen',
-
+            'view'  => 'Versionsdetails anzeigen',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Pausiert',
                         'cancelled'            => 'Abgebrochen',
                         'failed'               => 'Fehlgeschlagen',
-
-                        'view'       => 'Ansehen',
+                        'view'                 => 'Ansehen',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Status',
                 'title'            => 'Benutzer bearbeiten',
             ],
-            'activate-warning'           => 'Ihr Konto muss noch aktiviert werden. Bitte wenden Sie sich an Administrator.',
-            'cannot-change'              => 'Der Benutzer kann nicht geändert werden',
-            'cannot-escalate-role'       => 'Sie haben keine Berechtigung, eine Rolle mit Vollzugriff zuzuweisen.',
-            'create-success'             => 'Benutzer erfolgreich erstellt.',
-            'delete-failed'              => 'Benutzer gelöscht fehlgeschlagen.',
-            'delete-success'             => 'Benutzer erfolgreich gelöscht.',
-            'delete-warning'             => 'Sind Sie sicher, Sie möchten diese Aktion ausführen?',
-            'incorrect-password'         => 'Falsches Passwort',
-            'last-delete-error'          => 'Der letzte Benutzer löschen fehlgeschlagen',
-            'login-error'                => 'Bitte überprüfen Sie Ihre Anmeldeinformationen und versuchen Sie es erneut.',
-            'update-success'             => 'Benutzer erfolgreich aktualisiert.',
-            'current-user-delete-error'  => 'Der angemeldete Benutzer kann nicht gelöscht werden.',
+            'activate-warning'          => 'Ihr Konto muss noch aktiviert werden. Bitte wenden Sie sich an Administrator.',
+            'cannot-change'             => 'Der Benutzer kann nicht geändert werden',
+            'cannot-escalate-role'      => 'Sie haben keine Berechtigung, eine Rolle mit Vollzugriff zuzuweisen.',
+            'create-success'            => 'Benutzer erfolgreich erstellt.',
+            'delete-failed'             => 'Benutzer gelöscht fehlgeschlagen.',
+            'delete-success'            => 'Benutzer erfolgreich gelöscht.',
+            'delete-warning'            => 'Sind Sie sicher, Sie möchten diese Aktion ausführen?',
+            'incorrect-password'        => 'Falsches Passwort',
+            'last-delete-error'         => 'Der letzte Benutzer löschen fehlgeschlagen',
+            'login-error'               => 'Bitte überprüfen Sie Ihre Anmeldeinformationen und versuchen Sie es erneut.',
+            'update-success'            => 'Benutzer erfolgreich aktualisiert.',
+            'current-user-delete-error' => 'Der angemeldete Benutzer kann nicht gelöscht werden.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titel',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'System-Prompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titel',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Suche nach Code',
-                    'code_or_id' => 'Suche nach Code oder ID',
+                    'code'        => 'Suche nach Code',
+                    'code_or_id'  => 'Suche nach Code oder ID',
+                    'sku_or_user' => 'Suche nach SKU oder Benutzer',
                 ],
                 'search' => [
                     'title' => 'Suchen',

--- a/packages/Webkul/Admin/src/Resources/lang/en_AU/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_AU/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Please enter a valid URL.',
                     'regex'                      => 'Value does not match the required pattern.',
                     'invalid-pattern'            => 'Invalid custom pattern provided.',
-
                     'numeric'                    => 'Value for the numeric attribute ":attribute" must be a valid number.',
                     'select-attribute-or-family' => 'Please select at least one attribute or an attribute family.',
                     'failed'                     => 'Validation failed.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Bulk edit successful.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'No changes to save.',
-
-                'invalid-datetime'            => 'Please enter a valid date and time.',
-
-                'resize-column'               => 'Drag to resize column',
-                'success'                     => 'Job executed successfully.',
-                'fetch-failed'                => 'Failed to fetch.',
-                'action'                      => 'Bulk Edit',
-                'description'                 => 'Edit multiple products at once. Changes are processed in the background.',
-                'gallery-preview'             => 'Gallery Preview',
-                'img-preview'                 => 'Image Preview',
-                'no-image'                    => 'No Image',
-                'img-fail'                    => 'Image upload failed',
-                'no-option'                   => 'No Options',
-                'keyboard-shortcuts'          => 'Keyboard Shortcuts',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Editing',
-                'shortcuts-selection'         => 'Selection',
-                'shortcuts-clipboard'         => 'Clipboard & Fill',
-                'shortcuts-move-cell'         => 'Move between cells',
-                'shortcuts-move-down'         => 'Move down / confirm edit',
-                'shortcuts-move-up'           => 'Move up',
-                'shortcuts-move-right-left'   => 'Move right / left',
-                'shortcuts-home-end'          => 'First / last column in row',
-                'shortcuts-ctrl-home-end'     => 'First / last cell in grid',
-                'shortcuts-extend-selection'  => 'Extend selection',
-                'shortcuts-select-all'        => 'Select all cells',
-                'shortcuts-enter-edit'        => 'Enter edit mode',
-                'shortcuts-confirm-move-down' => 'Confirm + move down',
-                'shortcuts-confirm-move-right'=> 'Confirm + move right',
-                'shortcuts-escape-revert'     => 'Revert value + exit edit',
-                'shortcuts-clear-cell'        => 'Clear cell',
-                'shortcuts-copy'              => 'Copy',
-                'shortcuts-cut'               => 'Cut',
-                'shortcuts-paste'             => 'Paste',
-                'shortcuts-fill-down'         => 'Fill down',
-                'shortcuts-fill-right'        => 'Fill right',
-                'shortcuts-undo'              => 'Undo',
-                'shortcuts-redo'              => 'Redo',
-                'shortcuts-help'              => 'Toggle keyboard shortcuts',
+                'id'                           => 'ID',
+                'no-changes'                   => 'No changes to save.',
+                'invalid-datetime'             => 'Please enter a valid date and time.',
+                'resize-column'                => 'Drag to resize column',
+                'success'                      => 'Job executed successfully.',
+                'fetch-failed'                 => 'Failed to fetch.',
+                'action'                       => 'Bulk Edit',
+                'description'                  => 'Edit multiple products at once. Changes are processed in the background.',
+                'gallery-preview'              => 'Gallery Preview',
+                'img-preview'                  => 'Image Preview',
+                'no-image'                     => 'No Image',
+                'img-fail'                     => 'Image upload failed',
+                'no-option'                    => 'No Options',
+                'keyboard-shortcuts'           => 'Keyboard Shortcuts',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Editing',
+                'shortcuts-selection'          => 'Selection',
+                'shortcuts-clipboard'          => 'Clipboard & Fill',
+                'shortcuts-move-cell'          => 'Move between cells',
+                'shortcuts-move-down'          => 'Move down / confirm edit',
+                'shortcuts-move-up'            => 'Move up',
+                'shortcuts-move-right-left'    => 'Move right / left',
+                'shortcuts-home-end'           => 'First / last column in row',
+                'shortcuts-ctrl-home-end'      => 'First / last cell in grid',
+                'shortcuts-extend-selection'   => 'Extend selection',
+                'shortcuts-select-all'         => 'Select all cells',
+                'shortcuts-enter-edit'         => 'Enter edit mode',
+                'shortcuts-confirm-move-down'  => 'Confirm + move down',
+                'shortcuts-confirm-move-right' => 'Confirm + move right',
+                'shortcuts-escape-revert'      => 'Revert value + exit edit',
+                'shortcuts-clear-cell'         => 'Clear cell',
+                'shortcuts-copy'               => 'Copy',
+                'shortcuts-cut'                => 'Cut',
+                'shortcuts-paste'              => 'Paste',
+                'shortcuts-fill-down'          => 'Fill down',
+                'shortcuts-fill-right'         => 'Fill right',
+                'shortcuts-undo'               => 'Undo',
+                'shortcuts-redo'               => 'Redo',
+                'shortcuts-help'               => 'Toggle keyboard shortcuts',
             ],
             'create-success'          => 'Product created successfully',
             'delete-failed'           => 'Product deletion failed',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Is filterable',
                 'ai-translate'          => 'AI Translate',
                 'invalid-swatch-type'   => 'The :attribute is not allowed for attribute type :type with swatch type :swatch_type.',
-
                 'single-object-only'    => 'Each create request must send a single attribute object.',
                 'option'                => [
                     'color'    => 'Colour Swatch',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribute Deleted Successfully',
             'update-success'    => 'Attribute Updated Successfully',
             'user-define-error' => 'Cannot delete system Attribute',
-
             'immutable-fields'  => 'The following fields cannot be modified: :fields.',
             'not-found'         => 'Attribute with code ":code" could not be found',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Category Field Updated Successfully',
             'user-define-error' => 'Cannot delete system Category Field',
             'not-found'         => 'Category Field with code ":code" not found',
-
             'immutable-fields'  => 'The following fields cannot be modified: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Cannot update configurable options as this family already has variant products.',
         ],
         'history' => [
-            'view' => 'View Version Details',
-
+            'view'  => 'View Version Details',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Paused',
                         'cancelled'            => 'Cancelled',
                         'failed'               => 'Failed',
-
-                        'view'       => 'View',
+                        'view'                 => 'View',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Status',
                 'title'            => 'Edit User',
             ],
-            'activate-warning'           => 'Your account is yet to be activated, please contact the administrator.',
-            'cannot-change'              => 'User cannot be changed',
-            'cannot-escalate-role'       => 'You do not have permission to assign an all-access role.',
-            'create-success'             => 'User created successfully.',
-            'delete-failed'              => 'User delete failed.',
-            'delete-success'             => 'User deleted successfully.',
-            'delete-warning'             => 'Are you sure you want to perform this action?',
-            'incorrect-password'         => 'Incorrect password',
-            'last-delete-error'          => 'Last User delete failed',
-            'login-error'                => 'Please check your credentials and try again.',
-            'update-success'             => 'User updated successfully.',
-            'current-user-delete-error'  => 'The logged-in user cannot be deleted.',
+            'activate-warning'          => 'Your account is yet to be activated, please contact the administrator.',
+            'cannot-change'             => 'User cannot be changed',
+            'cannot-escalate-role'      => 'You do not have permission to assign an all-access role.',
+            'create-success'            => 'User created successfully.',
+            'delete-failed'             => 'User delete failed.',
+            'delete-success'            => 'User deleted successfully.',
+            'delete-warning'            => 'Are you sure you want to perform this action?',
+            'incorrect-password'        => 'Incorrect password',
+            'last-delete-error'         => 'Last User delete failed',
+            'login-error'               => 'Please check your credentials and try again.',
+            'update-success'            => 'User updated successfully.',
+            'current-user-delete-error' => 'The logged-in user cannot be deleted.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Title',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'System Prompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Title',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Search by code',
-                    'code_or_id' => 'Search by code or ID',
+                    'code'        => 'Search by code',
+                    'code_or_id'  => 'Search by code or ID',
+                    'sku_or_user' => 'Search by SKU or user',
                 ],
                 'search' => [
                     'title' => 'Search',

--- a/packages/Webkul/Admin/src/Resources/lang/en_GB/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_GB/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Please enter a valid URL.',
                     'regex'                      => 'Value does not match the required pattern.',
                     'invalid-pattern'            => 'Invalid custom pattern provided.',
-
                     'numeric'                    => 'Value for the numeric attribute ":attribute" must be a valid number.',
                     'select-attribute-or-family' => 'Please select at least one attribute or an attribute family.',
                     'failed'                     => 'Validation failed.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Bulk edit successful.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'No changes to save.',
-
-                'invalid-datetime'            => 'Please enter a valid date and time.',
-
-                'resize-column'               => 'Drag to resize column',
-                'success'                     => 'Job executed successfully.',
-                'fetch-failed'                => 'Failed to fetch.',
-                'action'                      => 'Bulk Edit',
-                'description'                 => 'Edit multiple products at once. Changes are processed in the background.',
-                'gallery-preview'             => 'Gallery Preview',
-                'img-preview'                 => 'Image Preview',
-                'no-image'                    => 'No Image',
-                'img-fail'                    => 'Image upload failed',
-                'no-option'                   => 'No Options',
-                'keyboard-shortcuts'          => 'Keyboard Shortcuts',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Editing',
-                'shortcuts-selection'         => 'Selection',
-                'shortcuts-clipboard'         => 'Clipboard & Fill',
-                'shortcuts-move-cell'         => 'Move between cells',
-                'shortcuts-move-down'         => 'Move down / confirm edit',
-                'shortcuts-move-up'           => 'Move up',
-                'shortcuts-move-right-left'   => 'Move right / left',
-                'shortcuts-home-end'          => 'First / last column in row',
-                'shortcuts-ctrl-home-end'     => 'First / last cell in grid',
-                'shortcuts-extend-selection'  => 'Extend selection',
-                'shortcuts-select-all'        => 'Select all cells',
-                'shortcuts-enter-edit'        => 'Enter edit mode',
-                'shortcuts-confirm-move-down' => 'Confirm + move down',
-                'shortcuts-confirm-move-right'=> 'Confirm + move right',
-                'shortcuts-escape-revert'     => 'Revert value + exit edit',
-                'shortcuts-clear-cell'        => 'Clear cell',
-                'shortcuts-copy'              => 'Copy',
-                'shortcuts-cut'               => 'Cut',
-                'shortcuts-paste'             => 'Paste',
-                'shortcuts-fill-down'         => 'Fill down',
-                'shortcuts-fill-right'        => 'Fill right',
-                'shortcuts-undo'              => 'Undo',
-                'shortcuts-redo'              => 'Redo',
-                'shortcuts-help'              => 'Toggle keyboard shortcuts',
+                'id'                           => 'ID',
+                'no-changes'                   => 'No changes to save.',
+                'invalid-datetime'             => 'Please enter a valid date and time.',
+                'resize-column'                => 'Drag to resize column',
+                'success'                      => 'Job executed successfully.',
+                'fetch-failed'                 => 'Failed to fetch.',
+                'action'                       => 'Bulk Edit',
+                'description'                  => 'Edit multiple products at once. Changes are processed in the background.',
+                'gallery-preview'              => 'Gallery Preview',
+                'img-preview'                  => 'Image Preview',
+                'no-image'                     => 'No Image',
+                'img-fail'                     => 'Image upload failed',
+                'no-option'                    => 'No Options',
+                'keyboard-shortcuts'           => 'Keyboard Shortcuts',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Editing',
+                'shortcuts-selection'          => 'Selection',
+                'shortcuts-clipboard'          => 'Clipboard & Fill',
+                'shortcuts-move-cell'          => 'Move between cells',
+                'shortcuts-move-down'          => 'Move down / confirm edit',
+                'shortcuts-move-up'            => 'Move up',
+                'shortcuts-move-right-left'    => 'Move right / left',
+                'shortcuts-home-end'           => 'First / last column in row',
+                'shortcuts-ctrl-home-end'      => 'First / last cell in grid',
+                'shortcuts-extend-selection'   => 'Extend selection',
+                'shortcuts-select-all'         => 'Select all cells',
+                'shortcuts-enter-edit'         => 'Enter edit mode',
+                'shortcuts-confirm-move-down'  => 'Confirm + move down',
+                'shortcuts-confirm-move-right' => 'Confirm + move right',
+                'shortcuts-escape-revert'      => 'Revert value + exit edit',
+                'shortcuts-clear-cell'         => 'Clear cell',
+                'shortcuts-copy'               => 'Copy',
+                'shortcuts-cut'                => 'Cut',
+                'shortcuts-paste'              => 'Paste',
+                'shortcuts-fill-down'          => 'Fill down',
+                'shortcuts-fill-right'         => 'Fill right',
+                'shortcuts-undo'               => 'Undo',
+                'shortcuts-redo'               => 'Redo',
+                'shortcuts-help'               => 'Toggle keyboard shortcuts',
             ],
             'create-success'          => 'Product created successfully',
             'delete-failed'           => 'Product deletion failed',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Is filterable',
                 'ai-translate'          => 'AI Translate',
                 'invalid-swatch-type'   => 'The :attribute is not allowed for attribute type :type with swatch type :swatch_type.',
-
                 'single-object-only'    => 'Each create request must send a single attribute object.',
                 'option'                => [
                     'color'    => 'Colour Swatch',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribute Deleted Successfully',
             'update-success'    => 'Attribute Updated Successfully',
             'user-define-error' => 'Cannot delete system Attribute',
-
             'immutable-fields'  => 'The following fields cannot be modified: :fields.',
             'not-found'         => 'Attribute with code ":code" could not be found',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Category Field Updated Successfully',
             'user-define-error' => 'Cannot delete system Category Field',
             'not-found'         => 'Category Field with code ":code" not found',
-
             'immutable-fields'  => 'The following fields cannot be modified: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Cannot update configurable options as this family already has variant products.',
         ],
         'history' => [
-            'view' => 'View Version Details',
-
+            'view'  => 'View Version Details',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Paused',
                         'cancelled'            => 'Cancelled',
                         'failed'               => 'Failed',
-
-                        'view'       => 'View',
+                        'view'                 => 'View',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Status',
                 'title'            => 'Edit User',
             ],
-            'activate-warning'           => 'Your account has yet to be activated, please contact the administrator.',
-            'cannot-change'              => 'User cannot be changed',
-            'cannot-escalate-role'       => 'You do not have permission to assign an all-access role.',
-            'create-success'             => 'User created successfully.',
-            'delete-failed'              => 'User delete failed.',
-            'delete-success'             => 'User deleted successfully.',
-            'delete-warning'             => 'Are you sure you want to perform this action?',
-            'incorrect-password'         => 'Incorrect password',
-            'last-delete-error'          => 'Last User delete failed',
-            'login-error'                => 'Please check your credentials and try again.',
-            'update-success'             => 'User updated successfully.',
-            'current-user-delete-error'  => 'The logged-in user cannot be deleted.',
+            'activate-warning'          => 'Your account has yet to be activated, please contact the administrator.',
+            'cannot-change'             => 'User cannot be changed',
+            'cannot-escalate-role'      => 'You do not have permission to assign an all-access role.',
+            'create-success'            => 'User created successfully.',
+            'delete-failed'             => 'User delete failed.',
+            'delete-success'            => 'User deleted successfully.',
+            'delete-warning'            => 'Are you sure you want to perform this action?',
+            'incorrect-password'        => 'Incorrect password',
+            'last-delete-error'         => 'Last User delete failed',
+            'login-error'               => 'Please check your credentials and try again.',
+            'update-success'            => 'User updated successfully.',
+            'current-user-delete-error' => 'The logged-in user cannot be deleted.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Title',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'System Prompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Title',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Search by code',
-                    'code_or_id' => 'Search by code or id',
+                    'code'        => 'Search by code',
+                    'code_or_id'  => 'Search by code or id',
+                    'sku_or_user' => 'Search by SKU or user',
                 ],
                 'search' => [
                     'title' => 'Search',

--- a/packages/Webkul/Admin/src/Resources/lang/en_NZ/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_NZ/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Please enter a valid URL.',
                     'regex'                      => 'Value does not match the required pattern.',
                     'invalid-pattern'            => 'Invalid custom pattern provided.',
-
                     'numeric'                    => 'Value for the numeric attribute ":attribute" must be a valid number.',
                     'select-attribute-or-family' => 'Please select at least one attribute or an attribute family.',
                     'failed'                     => 'Validation failed.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Bulk edit successful.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'No changes to save.',
-
-                'invalid-datetime'            => 'Please enter a valid date and time.',
-
-                'resize-column'               => 'Drag to resize column',
-                'success'                     => 'Job executed successfully.',
-                'fetch-failed'                => 'Failed to fetch.',
-                'action'                      => 'Bulk Edit',
-                'description'                 => 'Edit multiple products at once. Changes are processed in the background.',
-                'gallery-preview'             => 'Gallery Preview',
-                'img-preview'                 => 'Image Preview',
-                'no-image'                    => 'No Image',
-                'img-fail'                    => 'Image upload failed',
-                'no-option'                   => 'No Options',
-                'keyboard-shortcuts'          => 'Keyboard Shortcuts',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Editing',
-                'shortcuts-selection'         => 'Selection',
-                'shortcuts-clipboard'         => 'Clipboard & Fill',
-                'shortcuts-move-cell'         => 'Move between cells',
-                'shortcuts-move-down'         => 'Move down / confirm edit',
-                'shortcuts-move-up'           => 'Move up',
-                'shortcuts-move-right-left'   => 'Move right / left',
-                'shortcuts-home-end'          => 'First / last column in row',
-                'shortcuts-ctrl-home-end'     => 'First / last cell in grid',
-                'shortcuts-extend-selection'  => 'Extend selection',
-                'shortcuts-select-all'        => 'Select all cells',
-                'shortcuts-enter-edit'        => 'Enter edit mode',
-                'shortcuts-confirm-move-down' => 'Confirm + move down',
-                'shortcuts-confirm-move-right'=> 'Confirm + move right',
-                'shortcuts-escape-revert'     => 'Revert value + exit edit',
-                'shortcuts-clear-cell'        => 'Clear cell',
-                'shortcuts-copy'              => 'Copy',
-                'shortcuts-cut'               => 'Cut',
-                'shortcuts-paste'             => 'Paste',
-                'shortcuts-fill-down'         => 'Fill down',
-                'shortcuts-fill-right'        => 'Fill right',
-                'shortcuts-undo'              => 'Undo',
-                'shortcuts-redo'              => 'Redo',
-                'shortcuts-help'              => 'Toggle keyboard shortcuts',
+                'id'                           => 'ID',
+                'no-changes'                   => 'No changes to save.',
+                'invalid-datetime'             => 'Please enter a valid date and time.',
+                'resize-column'                => 'Drag to resize column',
+                'success'                      => 'Job executed successfully.',
+                'fetch-failed'                 => 'Failed to fetch.',
+                'action'                       => 'Bulk Edit',
+                'description'                  => 'Edit multiple products at once. Changes are processed in the background.',
+                'gallery-preview'              => 'Gallery Preview',
+                'img-preview'                  => 'Image Preview',
+                'no-image'                     => 'No Image',
+                'img-fail'                     => 'Image upload failed',
+                'no-option'                    => 'No Options',
+                'keyboard-shortcuts'           => 'Keyboard Shortcuts',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Editing',
+                'shortcuts-selection'          => 'Selection',
+                'shortcuts-clipboard'          => 'Clipboard & Fill',
+                'shortcuts-move-cell'          => 'Move between cells',
+                'shortcuts-move-down'          => 'Move down / confirm edit',
+                'shortcuts-move-up'            => 'Move up',
+                'shortcuts-move-right-left'    => 'Move right / left',
+                'shortcuts-home-end'           => 'First / last column in row',
+                'shortcuts-ctrl-home-end'      => 'First / last cell in grid',
+                'shortcuts-extend-selection'   => 'Extend selection',
+                'shortcuts-select-all'         => 'Select all cells',
+                'shortcuts-enter-edit'         => 'Enter edit mode',
+                'shortcuts-confirm-move-down'  => 'Confirm + move down',
+                'shortcuts-confirm-move-right' => 'Confirm + move right',
+                'shortcuts-escape-revert'      => 'Revert value + exit edit',
+                'shortcuts-clear-cell'         => 'Clear cell',
+                'shortcuts-copy'               => 'Copy',
+                'shortcuts-cut'                => 'Cut',
+                'shortcuts-paste'              => 'Paste',
+                'shortcuts-fill-down'          => 'Fill down',
+                'shortcuts-fill-right'         => 'Fill right',
+                'shortcuts-undo'               => 'Undo',
+                'shortcuts-redo'               => 'Redo',
+                'shortcuts-help'               => 'Toggle keyboard shortcuts',
             ],
             'create-success'          => 'Product created successfully',
             'delete-failed'           => 'Product deletion failed',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Is filterable',
                 'ai-translate'          => 'AI Translate',
                 'invalid-swatch-type'   => 'The :attribute is not allowed for attribute type :type with swatch type :swatch_type.',
-
                 'single-object-only'    => 'Each create request must send a single attribute object.',
                 'option'                => [
                     'color'    => 'Colour Swatch',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribute Deleted Successfully',
             'update-success'    => 'Attribute Updated Successfully',
             'user-define-error' => 'Cannot delete system Attribute',
-
             'immutable-fields'  => 'The following fields cannot be modified: :fields.',
             'not-found'         => 'Attribute with code ":code" could not be found',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Category Field Updated Successfully',
             'user-define-error' => 'Cannot delete system Category Field',
             'not-found'         => 'Category Field with code ":code" not found',
-
             'immutable-fields'  => 'The following fields cannot be modified: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Cannot update configurable options as this family already has variant products.',
         ],
         'history' => [
-            'view' => 'View Version Details',
-
+            'view'  => 'View Version Details',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Paused',
                         'cancelled'            => 'Cancelled',
                         'failed'               => 'Failed',
-
-                        'view'       => 'View',
+                        'view'                 => 'View',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Status',
                 'title'            => 'Edit User',
             ],
-            'activate-warning'           => 'Your account is yet to be activated, please contact the administrator.',
-            'cannot-change'              => 'User cannot be changed',
-            'cannot-escalate-role'       => 'You do not have permission to assign an all-access role.',
-            'create-success'             => 'User created successfully.',
-            'delete-failed'              => 'User delete failed.',
-            'delete-success'             => 'User deleted successfully.',
-            'delete-warning'             => 'Are you sure you want to perform this action?',
-            'incorrect-password'         => 'Incorrect password',
-            'last-delete-error'          => 'Last User delete failed',
-            'login-error'                => 'Please check your credentials and try again.',
-            'update-success'             => 'User updated successfully.',
-            'current-user-delete-error'  => 'The logged-in user cannot be deleted.',
+            'activate-warning'          => 'Your account is yet to be activated, please contact the administrator.',
+            'cannot-change'             => 'User cannot be changed',
+            'cannot-escalate-role'      => 'You do not have permission to assign an all-access role.',
+            'create-success'            => 'User created successfully.',
+            'delete-failed'             => 'User delete failed.',
+            'delete-success'            => 'User deleted successfully.',
+            'delete-warning'            => 'Are you sure you want to perform this action?',
+            'incorrect-password'        => 'Incorrect password',
+            'last-delete-error'         => 'Last User delete failed',
+            'login-error'               => 'Please check your credentials and try again.',
+            'update-success'            => 'User updated successfully.',
+            'current-user-delete-error' => 'The logged-in user cannot be deleted.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Title',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'System Prompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Title',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Search by code',
-                    'code_or_id' => 'Search by code or id',
+                    'code'        => 'Search by code',
+                    'code_or_id'  => 'Search by code or id',
+                    'sku_or_user' => 'Search by SKU or user',
                 ],
                 'search' => [
                     'title' => 'Search',

--- a/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
@@ -2148,8 +2148,9 @@ return [
                 ],
 
                 'search_by' => [
-                    'code'       => 'Search by code',
-                    'code_or_id' => 'Search by code or id',
+                    'code'        => 'Search by code',
+                    'code_or_id'  => 'Search by code or id',
+                    'sku_or_user' => 'Search by SKU or user',
                 ],
 
                 'search' => [

--- a/packages/Webkul/Admin/src/Resources/lang/es_ES/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es_ES/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Por favor, introduce una URL válida.',
                     'regex'                      => 'El valor no coincide con el patrón requerido.',
                     'invalid-pattern'            => 'Patrón personalizado no válido.',
-
                     'numeric'                    => 'El valor del atributo numérico ":attribute" debe ser un número válido.',
                     'select-attribute-or-family' => 'Por favor, seleccione al menos un atributo o una familia de atributos.',
                     'failed'                     => 'La validación ha fallado.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Edición masiva exitosa.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'No hay cambios para guardar.',
-
-                'invalid-datetime'            => 'Introduce una fecha y hora válidas.',
-
-                'resize-column'               => 'Arrastra para redimensionar la columna',
-                'success'                     => 'Operación completada con éxito.',
-                'fetch-failed'                => 'Error al obtener los datos.',
-                'action'                      => 'Edición masiva',
-                'description'                 => 'Editar varios productos a la vez. Los cambios se procesan en segundo plano.',
-                'gallery-preview'             => 'Vista previa de galería',
-                'img-preview'                 => 'Vista previa de imagen',
-                'no-image'                    => 'Sin imagen',
-                'img-fail'                    => 'Fallo al subir la imagen.',
-                'no-option'                   => 'Sin opciones',
-                'keyboard-shortcuts'          => 'Atajos de teclado',
-                'shortcuts-navigation'        => 'Navegación',
-                'shortcuts-editing'           => 'Edición',
-                'shortcuts-selection'         => 'Selección',
-                'shortcuts-clipboard'         => 'Portapapeles y relleno',
-                'shortcuts-move-cell'         => 'Moverse entre celdas',
-                'shortcuts-move-down'         => 'Bajar / confirmar edición',
-                'shortcuts-move-up'           => 'Subir',
-                'shortcuts-move-right-left'   => 'Mover a la derecha / izquierda',
-                'shortcuts-home-end'          => 'Primera / última columna de la fila',
-                'shortcuts-ctrl-home-end'     => 'Primera / última celda de la cuadrícula',
-                'shortcuts-extend-selection'  => 'Ampliar selección',
-                'shortcuts-select-all'        => 'Seleccionar todas las celdas',
-                'shortcuts-enter-edit'        => 'Entrar en modo edición',
-                'shortcuts-confirm-move-down' => 'Confirmar + bajar',
-                'shortcuts-confirm-move-right'=> 'Confirmar + mover a la derecha',
-                'shortcuts-escape-revert'     => 'Revertir valor + salir de la edición',
-                'shortcuts-clear-cell'        => 'Borrar celda',
-                'shortcuts-copy'              => 'Copiar',
-                'shortcuts-cut'               => 'Cortar',
-                'shortcuts-paste'             => 'Pegar',
-                'shortcuts-fill-down'         => 'Rellenar hacia abajo',
-                'shortcuts-fill-right'        => 'Rellenar hacia la derecha',
-                'shortcuts-undo'              => 'Deshacer',
-                'shortcuts-redo'              => 'Rehacer',
-                'shortcuts-help'              => 'Mostrar/ocultar atajos de teclado',
+                'id'                           => 'ID',
+                'no-changes'                   => 'No hay cambios para guardar.',
+                'invalid-datetime'             => 'Introduce una fecha y hora válidas.',
+                'resize-column'                => 'Arrastra para redimensionar la columna',
+                'success'                      => 'Operación completada con éxito.',
+                'fetch-failed'                 => 'Error al obtener los datos.',
+                'action'                       => 'Edición masiva',
+                'description'                  => 'Editar varios productos a la vez. Los cambios se procesan en segundo plano.',
+                'gallery-preview'              => 'Vista previa de galería',
+                'img-preview'                  => 'Vista previa de imagen',
+                'no-image'                     => 'Sin imagen',
+                'img-fail'                     => 'Fallo al subir la imagen.',
+                'no-option'                    => 'Sin opciones',
+                'keyboard-shortcuts'           => 'Atajos de teclado',
+                'shortcuts-navigation'         => 'Navegación',
+                'shortcuts-editing'            => 'Edición',
+                'shortcuts-selection'          => 'Selección',
+                'shortcuts-clipboard'          => 'Portapapeles y relleno',
+                'shortcuts-move-cell'          => 'Moverse entre celdas',
+                'shortcuts-move-down'          => 'Bajar / confirmar edición',
+                'shortcuts-move-up'            => 'Subir',
+                'shortcuts-move-right-left'    => 'Mover a la derecha / izquierda',
+                'shortcuts-home-end'           => 'Primera / última columna de la fila',
+                'shortcuts-ctrl-home-end'      => 'Primera / última celda de la cuadrícula',
+                'shortcuts-extend-selection'   => 'Ampliar selección',
+                'shortcuts-select-all'         => 'Seleccionar todas las celdas',
+                'shortcuts-enter-edit'         => 'Entrar en modo edición',
+                'shortcuts-confirm-move-down'  => 'Confirmar + bajar',
+                'shortcuts-confirm-move-right' => 'Confirmar + mover a la derecha',
+                'shortcuts-escape-revert'      => 'Revertir valor + salir de la edición',
+                'shortcuts-clear-cell'         => 'Borrar celda',
+                'shortcuts-copy'               => 'Copiar',
+                'shortcuts-cut'                => 'Cortar',
+                'shortcuts-paste'              => 'Pegar',
+                'shortcuts-fill-down'          => 'Rellenar hacia abajo',
+                'shortcuts-fill-right'         => 'Rellenar hacia la derecha',
+                'shortcuts-undo'               => 'Deshacer',
+                'shortcuts-redo'               => 'Rehacer',
+                'shortcuts-help'               => 'Mostrar/ocultar atajos de teclado',
             ],
             'create-success'          => 'Producto creado con éxito',
             'delete-failed'           => 'Producto eliminado Falló',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Es filtrable',
                 'ai-translate'          => 'Traducción IA',
                 'invalid-swatch-type'   => 'El :attribute no está permitido para el tipo de atributo :type con el tipo de muestra :swatch_type.',
-
                 'single-object-only'    => 'Cada solicitud de creación debe enviar un único objeto de atributo.',
                 'option'                => [
                     'color'    => 'Muestra de color',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atributo eliminado con éxito',
             'update-success'    => 'Atributo actualizado correctamente',
             'user-define-error' => 'No puede eliminar el atributo del sistema',
-
             'immutable-fields'  => 'Los siguientes campos no se pueden modificar: :fields.',
             'not-found'         => 'Atributo con el código ":code" no se puede encontrar',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Campo de categoría actualizado correctamente',
             'user-define-error' => 'No puede eliminar el campo de categoría del sistema',
             'not-found'         => 'Campo de categoría con código ":code" no se pudo encontrar',
-
             'immutable-fields'  => 'Los siguientes campos no se pueden modificar: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'No se puede actualizar opciones configurables ya que esta familia ya tiene productos variantes.',
         ],
         'history' => [
-            'view' => 'Ver detalles de la versión',
-
+            'view'  => 'Ver detalles de la versión',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versión',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Pausado',
                         'cancelled'            => 'Cancelado',
                         'failed'               => 'Fallido',
-
-                        'view'       => 'Ver',
+                        'view'                 => 'Ver',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Estado',
                 'title'            => 'editar usuario',
             ],
-            'activate-warning'           => 'Su cuenta aún no se ha activado, comuníquese con el administrador.',
-            'cannot-change'              => 'El usuario no se puede cambiar',
-            'cannot-escalate-role'       => 'No tiene permiso para asignar un rol con acceso completo.',
-            'create-success'             => 'Usuario creado con éxito.',
-            'delete-failed'              => 'Error al eliminar el usuario.',
-            'delete-success'             => 'Usuario eliminado con éxito.',
-            'delete-warning'             => '¿Estás seguro, quieres realizar esta acción?',
-            'incorrect-password'         => 'Contraseña incorrecta',
-            'last-delete-error'          => 'Last User Eliminar falló',
-            'login-error'                => 'Consulte sus credenciales y vuelva a intentarlo.',
-            'update-success'             => 'Usuario actualizado con éxito.',
-            'current-user-delete-error'  => 'El usuario que inició sesión no se puede eliminar',
+            'activate-warning'          => 'Su cuenta aún no se ha activado, comuníquese con el administrador.',
+            'cannot-change'             => 'El usuario no se puede cambiar',
+            'cannot-escalate-role'      => 'No tiene permiso para asignar un rol con acceso completo.',
+            'create-success'            => 'Usuario creado con éxito.',
+            'delete-failed'             => 'Error al eliminar el usuario.',
+            'delete-success'            => 'Usuario eliminado con éxito.',
+            'delete-warning'            => '¿Estás seguro, quieres realizar esta acción?',
+            'incorrect-password'        => 'Contraseña incorrecta',
+            'last-delete-error'         => 'Last User Eliminar falló',
+            'login-error'               => 'Consulte sus credenciales y vuelva a intentarlo.',
+            'update-success'            => 'Usuario actualizado con éxito.',
+            'current-user-delete-error' => 'El usuario que inició sesión no se puede eliminar',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Título',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts del sistema',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Título',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtrar',
                 ],
                 'search_by' => [
-                    'code'       => 'Buscar por código',
-                    'code_or_id' => 'Buscar por código o identificación',
+                    'code'        => 'Buscar por código',
+                    'code_or_id'  => 'Buscar por código o identificación',
+                    'sku_or_user' => 'Buscar por SKU o usuario',
                 ],
                 'search' => [
                     'title' => 'Buscar',

--- a/packages/Webkul/Admin/src/Resources/lang/es_VE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es_VE/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Por favor, ingrese una URL válida.',
                     'regex'                      => 'El valor no cumple con el patrón requerido.',
                     'invalid-pattern'            => 'Patrón personalizado inválido.',
-
                     'numeric'                    => 'El valor del atributo numérico ":attribute" debe ser un número válido.',
                     'select-attribute-or-family' => 'Por favor seleccione al menos un atributo o una familia de atributos.',
                     'failed'                     => 'La validación falló.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Edición masiva completada exitosamente.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'No hay cambios para guardar.',
-
-                'invalid-datetime'            => 'Introduce una fecha y hora válidas.',
-
-                'resize-column'               => 'Arrastra para redimensionar la columna',
-                'success'                     => 'Operación realizada con éxito.',
-                'fetch-failed'                => 'Error al obtener los datos.',
-                'action'                      => 'Edición masiva',
-                'description'                 => 'Editar varios productos a la vez. Los cambios se procesan en segundo plano.',
-                'gallery-preview'             => 'Vista previa de galería',
-                'img-preview'                 => 'Vista previa de imagen',
-                'no-image'                    => 'Sin imagen',
-                'img-fail'                    => 'Fallo al subir la imagen.',
-                'no-option'                   => 'Sin opciones',
-                'keyboard-shortcuts'          => 'Atajos de teclado',
-                'shortcuts-navigation'        => 'Navegación',
-                'shortcuts-editing'           => 'Edición',
-                'shortcuts-selection'         => 'Selección',
-                'shortcuts-clipboard'         => 'Portapapeles y relleno',
-                'shortcuts-move-cell'         => 'Moverse entre celdas',
-                'shortcuts-move-down'         => 'Bajar / confirmar edición',
-                'shortcuts-move-up'           => 'Subir',
-                'shortcuts-move-right-left'   => 'Mover a la derecha / izquierda',
-                'shortcuts-home-end'          => 'Primera / última columna de la fila',
-                'shortcuts-ctrl-home-end'     => 'Primera / última celda de la cuadrícula',
-                'shortcuts-extend-selection'  => 'Ampliar selección',
-                'shortcuts-select-all'        => 'Seleccionar todas las celdas',
-                'shortcuts-enter-edit'        => 'Entrar en modo edición',
-                'shortcuts-confirm-move-down' => 'Confirmar + bajar',
-                'shortcuts-confirm-move-right'=> 'Confirmar + mover a la derecha',
-                'shortcuts-escape-revert'     => 'Revertir valor + salir de la edición',
-                'shortcuts-clear-cell'        => 'Borrar celda',
-                'shortcuts-copy'              => 'Copiar',
-                'shortcuts-cut'               => 'Cortar',
-                'shortcuts-paste'             => 'Pegar',
-                'shortcuts-fill-down'         => 'Rellenar hacia abajo',
-                'shortcuts-fill-right'        => 'Rellenar hacia la derecha',
-                'shortcuts-undo'              => 'Deshacer',
-                'shortcuts-redo'              => 'Rehacer',
-                'shortcuts-help'              => 'Mostrar/ocultar atajos de teclado',
+                'id'                           => 'ID',
+                'no-changes'                   => 'No hay cambios para guardar.',
+                'invalid-datetime'             => 'Introduce una fecha y hora válidas.',
+                'resize-column'                => 'Arrastra para redimensionar la columna',
+                'success'                      => 'Operación realizada con éxito.',
+                'fetch-failed'                 => 'Error al obtener los datos.',
+                'action'                       => 'Edición masiva',
+                'description'                  => 'Editar varios productos a la vez. Los cambios se procesan en segundo plano.',
+                'gallery-preview'              => 'Vista previa de galería',
+                'img-preview'                  => 'Vista previa de imagen',
+                'no-image'                     => 'Sin imagen',
+                'img-fail'                     => 'Fallo al subir la imagen.',
+                'no-option'                    => 'Sin opciones',
+                'keyboard-shortcuts'           => 'Atajos de teclado',
+                'shortcuts-navigation'         => 'Navegación',
+                'shortcuts-editing'            => 'Edición',
+                'shortcuts-selection'          => 'Selección',
+                'shortcuts-clipboard'          => 'Portapapeles y relleno',
+                'shortcuts-move-cell'          => 'Moverse entre celdas',
+                'shortcuts-move-down'          => 'Bajar / confirmar edición',
+                'shortcuts-move-up'            => 'Subir',
+                'shortcuts-move-right-left'    => 'Mover a la derecha / izquierda',
+                'shortcuts-home-end'           => 'Primera / última columna de la fila',
+                'shortcuts-ctrl-home-end'      => 'Primera / última celda de la cuadrícula',
+                'shortcuts-extend-selection'   => 'Ampliar selección',
+                'shortcuts-select-all'         => 'Seleccionar todas las celdas',
+                'shortcuts-enter-edit'         => 'Entrar en modo edición',
+                'shortcuts-confirm-move-down'  => 'Confirmar + bajar',
+                'shortcuts-confirm-move-right' => 'Confirmar + mover a la derecha',
+                'shortcuts-escape-revert'      => 'Revertir valor + salir de la edición',
+                'shortcuts-clear-cell'         => 'Borrar celda',
+                'shortcuts-copy'               => 'Copiar',
+                'shortcuts-cut'                => 'Cortar',
+                'shortcuts-paste'              => 'Pegar',
+                'shortcuts-fill-down'          => 'Rellenar hacia abajo',
+                'shortcuts-fill-right'         => 'Rellenar hacia la derecha',
+                'shortcuts-undo'               => 'Deshacer',
+                'shortcuts-redo'               => 'Rehacer',
+                'shortcuts-help'               => 'Mostrar/ocultar atajos de teclado',
             ],
             'create-success'          => 'Producto creado con éxito',
             'delete-failed'           => 'Hubo un error al eliminar el producto',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Es filtrable',
                 'ai-translate'          => 'Traducción IA',
                 'invalid-swatch-type'   => 'El :attribute no está permitido para el tipo de atributo :type con el tipo de muestra :swatch_type.',
-
                 'single-object-only'    => 'Cada solicitud de creación debe enviar un único objeto de atributo.',
                 'option'                => [
                     'color'    => 'Muestra de color',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atributo eliminado con éxito',
             'update-success'    => 'Atributo actualizado con éxito',
             'user-define-error' => 'No se puede eliminar un atributo del sistema',
-
             'immutable-fields'  => 'Los siguientes campos no se pueden modificar: :fields.',
             'not-found'         => 'No se encontró el atributo con código ":code"',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Campo de Categoría Actualizado Exitosamente',
             'user-define-error' => 'No se puede eliminar un Campo de Categoría del sistema',
             'not-found'         => 'No se encuentra el Campo de Categoría con el código ":code"',
-
             'immutable-fields'  => 'Los siguientes campos no se pueden modificar: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'No se pueden actualizar las opciones de configuración porque esta familia ya tiene variantes de productos.',
         ],
         'history' => [
-            'view' => 'Ver detalles de la versión',
-
+            'view'  => 'Ver detalles de la versión',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versión',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'En pausa',
                         'cancelled'            => 'Cancelado',
                         'failed'               => 'Fallido',
-
-                        'view'       => 'Ver',
+                        'view'                 => 'Ver',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Estado',
                 'title'            => 'Editar Usuario',
             ],
-            'activate-warning'           => 'Tu cuenta aún no está activada, por favor contacta al administrador.',
-            'cannot-change'              => 'No se puede cambiar el usuario',
-            'cannot-escalate-role'       => 'No tiene permiso para asignar un rol con acceso completo.',
-            'create-success'             => 'Usuario creado exitosamente.',
-            'delete-failed'              => 'Error al eliminar el usuario.',
-            'delete-success'             => 'Usuario eliminado exitosamente.',
-            'delete-warning'             => '¿Estás seguro de que deseas realizar esta acción?',
-            'incorrect-password'         => 'Contraseña incorrecta',
-            'last-delete-error'          => 'Error al eliminar el último usuario',
-            'login-error'                => 'Por favor verifica tus credenciales e intenta de nuevo.',
-            'update-success'             => 'Usuario actualizado exitosamente.',
-            'current-user-delete-error'  => 'No se puede eliminar al usuario actual.',
+            'activate-warning'          => 'Tu cuenta aún no está activada, por favor contacta al administrador.',
+            'cannot-change'             => 'No se puede cambiar el usuario',
+            'cannot-escalate-role'      => 'No tiene permiso para asignar un rol con acceso completo.',
+            'create-success'            => 'Usuario creado exitosamente.',
+            'delete-failed'             => 'Error al eliminar el usuario.',
+            'delete-success'            => 'Usuario eliminado exitosamente.',
+            'delete-warning'            => '¿Estás seguro de que deseas realizar esta acción?',
+            'incorrect-password'        => 'Contraseña incorrecta',
+            'last-delete-error'         => 'Error al eliminar el último usuario',
+            'login-error'               => 'Por favor verifica tus credenciales e intenta de nuevo.',
+            'update-success'            => 'Usuario actualizado exitosamente.',
+            'current-user-delete-error' => 'No se puede eliminar al usuario actual.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Título',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts del sistema',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Título',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtrar',
                 ],
                 'search_by' => [
-                    'code'       => 'Buscar por código',
-                    'code_or_id' => 'Buscar por código o ID',
+                    'code'        => 'Buscar por código',
+                    'code_or_id'  => 'Buscar por código o ID',
+                    'sku_or_user' => 'Buscar por SKU o usuario',
                 ],
                 'search' => [
                     'title' => 'Buscar',

--- a/packages/Webkul/Admin/src/Resources/lang/fi_FI/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fi_FI/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Anna kelvollinen URL.',
                     'regex'                      => 'Arvo ei vastaa vaadittua kaavaa.',
                     'invalid-pattern'            => 'Virheellinen mukautettu kaava annettu.',
-
                     'numeric'                    => 'Numeerisen määritteen ":attribute" arvon on oltava kelvollinen luku.',
                     'select-attribute-or-family' => 'Valitse vähintään yksi attribuutti tai attribuuttiperhe.',
                     'failed'                     => 'Validointi epäonnistui.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Massamuokkaus onnistui.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Ei muutoksia tallennettavaksi.',
-
-                'invalid-datetime'            => 'Anna kelvollinen päivämäärä ja kellonaika.',
-
-                'resize-column'               => 'Vedä muuttaaksesi sarakkeen leveyttä',
-                'success'                     => 'Toiminto suoritettu onnistuneesti.',
-                'fetch-failed'                => 'Tietojen haku epäonnistui.',
-                'action'                      => 'Massamuokkaus',
-                'description'                 => 'Muokkaa useita tuotteita kerralla. Muutokset käsitellään taustalla.',
-                'gallery-preview'             => 'Gallerian esikatselu',
-                'img-preview'                 => 'Kuvan esikatselu',
-                'no-image'                    => 'Ei kuvaa',
-                'img-fail'                    => 'Kuvan lataus epäonnistui.',
-                'no-option'                   => 'Ei vaihtoehtoja',
-                'keyboard-shortcuts'          => 'Pikanäppäimet',
-                'shortcuts-navigation'        => 'Navigointi',
-                'shortcuts-editing'           => 'Muokkaus',
-                'shortcuts-selection'         => 'Valinta',
-                'shortcuts-clipboard'         => 'Leikepöytä ja täyttö',
-                'shortcuts-move-cell'         => 'Siirry solujen välillä',
-                'shortcuts-move-down'         => 'Siirry alas / vahvista muokkaus',
-                'shortcuts-move-up'           => 'Siirry ylös',
-                'shortcuts-move-right-left'   => 'Siirry oikealle / vasemmalle',
-                'shortcuts-home-end'          => 'Ensimmäinen / viimeinen sarake rivillä',
-                'shortcuts-ctrl-home-end'     => 'Ensimmäinen / viimeinen solu ruudukossa',
-                'shortcuts-extend-selection'  => 'Laajenna valintaa',
-                'shortcuts-select-all'        => 'Valitse kaikki solut',
-                'shortcuts-enter-edit'        => 'Siirry muokkaustilaan',
-                'shortcuts-confirm-move-down' => 'Vahvista + siirry alas',
-                'shortcuts-confirm-move-right'=> 'Vahvista + siirry oikealle',
-                'shortcuts-escape-revert'     => 'Palauta arvo + poistu muokkauksesta',
-                'shortcuts-clear-cell'        => 'Tyhjennä solu',
-                'shortcuts-copy'              => 'Kopioi',
-                'shortcuts-cut'               => 'Leikkaa',
-                'shortcuts-paste'             => 'Liitä',
-                'shortcuts-fill-down'         => 'Täytä alas',
-                'shortcuts-fill-right'        => 'Täytä oikealle',
-                'shortcuts-undo'              => 'Kumoa',
-                'shortcuts-redo'              => 'Tee uudelleen',
-                'shortcuts-help'              => 'Näytä/piilota pikanäppäimet',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Ei muutoksia tallennettavaksi.',
+                'invalid-datetime'             => 'Anna kelvollinen päivämäärä ja kellonaika.',
+                'resize-column'                => 'Vedä muuttaaksesi sarakkeen leveyttä',
+                'success'                      => 'Toiminto suoritettu onnistuneesti.',
+                'fetch-failed'                 => 'Tietojen haku epäonnistui.',
+                'action'                       => 'Massamuokkaus',
+                'description'                  => 'Muokkaa useita tuotteita kerralla. Muutokset käsitellään taustalla.',
+                'gallery-preview'              => 'Gallerian esikatselu',
+                'img-preview'                  => 'Kuvan esikatselu',
+                'no-image'                     => 'Ei kuvaa',
+                'img-fail'                     => 'Kuvan lataus epäonnistui.',
+                'no-option'                    => 'Ei vaihtoehtoja',
+                'keyboard-shortcuts'           => 'Pikanäppäimet',
+                'shortcuts-navigation'         => 'Navigointi',
+                'shortcuts-editing'            => 'Muokkaus',
+                'shortcuts-selection'          => 'Valinta',
+                'shortcuts-clipboard'          => 'Leikepöytä ja täyttö',
+                'shortcuts-move-cell'          => 'Siirry solujen välillä',
+                'shortcuts-move-down'          => 'Siirry alas / vahvista muokkaus',
+                'shortcuts-move-up'            => 'Siirry ylös',
+                'shortcuts-move-right-left'    => 'Siirry oikealle / vasemmalle',
+                'shortcuts-home-end'           => 'Ensimmäinen / viimeinen sarake rivillä',
+                'shortcuts-ctrl-home-end'      => 'Ensimmäinen / viimeinen solu ruudukossa',
+                'shortcuts-extend-selection'   => 'Laajenna valintaa',
+                'shortcuts-select-all'         => 'Valitse kaikki solut',
+                'shortcuts-enter-edit'         => 'Siirry muokkaustilaan',
+                'shortcuts-confirm-move-down'  => 'Vahvista + siirry alas',
+                'shortcuts-confirm-move-right' => 'Vahvista + siirry oikealle',
+                'shortcuts-escape-revert'      => 'Palauta arvo + poistu muokkauksesta',
+                'shortcuts-clear-cell'         => 'Tyhjennä solu',
+                'shortcuts-copy'               => 'Kopioi',
+                'shortcuts-cut'                => 'Leikkaa',
+                'shortcuts-paste'              => 'Liitä',
+                'shortcuts-fill-down'          => 'Täytä alas',
+                'shortcuts-fill-right'         => 'Täytä oikealle',
+                'shortcuts-undo'               => 'Kumoa',
+                'shortcuts-redo'               => 'Tee uudelleen',
+                'shortcuts-help'               => 'Näytä/piilota pikanäppäimet',
             ],
             'create-success'          => 'Tuote luotiin onnistuneesti',
             'delete-failed'           => 'Tuotteen poistaminen epäonnistui',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'On suodatettavissa',
                 'ai-translate'          => 'AI Käännös',
                 'invalid-swatch-type'   => ':attribute ei ole sallittu attribuuttityypille :type, jossa on swatch-tyyppi :swatch_type.',
-
                 'single-object-only'    => 'Jokaisen luontipyynnön tulee sisältää vain yksi attribuuttiolio.',
                 'option'                => [
                     'color'    => 'Väri',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Ominaisuus poistettu onnistuneesti',
             'update-success'    => 'Ominaisuus päivitetty onnistuneesti',
             'user-define-error' => 'Ei voi poistaa järjestelmän ominaisuutta',
-
             'immutable-fields'  => 'Seuraavia kenttiä ei voi muokata: :fields.',
             'not-found'         => 'Ominaisuutta koodilla ":code" ei löytynyt',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Kategoriakenttä päivitettiin onnistuneesti',
             'user-define-error' => 'Ei voida poistaa järjestelmän kategoria kenttää',
             'not-found'         => 'Kategoria kenttää koodilla ":code" ei löydy',
-
             'immutable-fields'  => 'Seuraavia kenttiä ei voi muokata: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Ei voida päivittää määritettäväviä vaihtoehtoja, koska tällä perheellä on jo varianttituotteita.',
         ],
         'history' => [
-            'view' => 'Näytä version tiedot',
-
+            'view'  => 'Näytä version tiedot',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versio',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Keskeytetty',
                         'cancelled'            => 'Peruutettu',
                         'failed'               => 'Epäonnistui',
-
-                        'view'       => 'Näytä',
+                        'view'                 => 'Näytä',
                     ],
                 ],
                 'import' => [
@@ -1602,18 +1594,18 @@ return [
                 'status'           => 'Tila',
                 'title'            => 'Muokkaa Käyttäjää',
             ],
-            'activate-warning'           => 'Tilisi ei ole vielä aktivoitu, ota yhteys järjestelmänvalvojaan.',
-            'cannot-change'              => 'Käyttäjää ei voi muuttaa',
-            'cannot-escalate-role'       => 'Sinulla ei ole oikeutta määrittää täyden pääsyn roolia.',
-            'create-success'             => 'Käyttäjä luotu onnistuneesti.',
-            'delete-failed'              => 'Käyttäjän poistaminen epäonnistui.',
-            'delete-success'             => 'Käyttäjä poistettu onnistuneesti.',
-            'delete-warning'             => 'Oletko varma, että haluat suorittaa tämän toiminnon?',
-            'incorrect-password'         => 'Virheellinen salasana',
-            'last-delete-error'          => 'Viimeinen käyttäjän poisto epäonnistui',
-            'login-error'                => 'Tarkista tunnuksesi ja yritä uudelleen.',
-            'update-success'             => 'Käyttäjä päivitettiin onnistuneesti.',
-            'current-user-delete-error'  => 'Kirjautunutta käyttäjää ei voi poistaa.',
+            'activate-warning'          => 'Tilisi ei ole vielä aktivoitu, ota yhteys järjestelmänvalvojaan.',
+            'cannot-change'             => 'Käyttäjää ei voi muuttaa',
+            'cannot-escalate-role'      => 'Sinulla ei ole oikeutta määrittää täyden pääsyn roolia.',
+            'create-success'            => 'Käyttäjä luotu onnistuneesti.',
+            'delete-failed'             => 'Käyttäjän poistaminen epäonnistui.',
+            'delete-success'            => 'Käyttäjä poistettu onnistuneesti.',
+            'delete-warning'            => 'Oletko varma, että haluat suorittaa tämän toiminnon?',
+            'incorrect-password'        => 'Virheellinen salasana',
+            'last-delete-error'         => 'Viimeinen käyttäjän poisto epäonnistui',
+            'login-error'               => 'Tarkista tunnuksesi ja yritä uudelleen.',
+            'update-success'            => 'Käyttäjä päivitettiin onnistuneesti.',
+            'current-user-delete-error' => 'Kirjautunutta käyttäjää ei voi poistaa.',
         ],
         'roles' => [
             'index' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Kehotteet',
-
             ],
-
             'datagrid' => [
                 'id'               => 'Tunnus',
                 'title'            => 'Otsikko',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Järjestelmäkehotteet',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Otsikko',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Suodata',
                 ],
                 'search_by' => [
-                    'code'       => 'Etsi koodilla',
-                    'code_or_id' => 'Etsi koodilla tai id:llä',
+                    'code'        => 'Etsi koodilla',
+                    'code_or_id'  => 'Etsi koodilla tai id:llä',
+                    'sku_or_user' => 'Etsi SKU:lla tai käyttäjällä',
                 ],
                 'search' => [
                     'title' => 'Etsi',

--- a/packages/Webkul/Admin/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr_FR/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Veuillez entrer une URL valide.',
                     'regex'                      => 'La valeur ne correspond pas au modèle requis.',
                     'invalid-pattern'            => 'Modèle personnalisé invalide fourni.',
-
                     'numeric'                    => 'La valeur de l\'attribut numérique « :attribute » doit être un nombre valide.',
                     'select-attribute-or-family' => 'Veuillez sélectionner au moins un attribut ou une famille d’attributs.',
                     'failed'                     => 'La validation a échoué.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Édition en masse réussie.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Aucun changement à enregistrer.',
-
-                'invalid-datetime'            => 'Veuillez saisir une date et une heure valides.',
-
-                'resize-column'               => 'Faites glisser pour redimensionner la colonne',
-                'success'                     => 'Opération réussie.',
-                'fetch-failed'                => 'Échec de la récupération.',
-                'action'                      => 'Édition en masse',
-                'description'                 => 'Edit multiple products at once. Changes are processed in the background.',
-                'gallery-preview'             => 'Aperçu de la galerie',
-                'img-preview'                 => 'Aperçu de l’image',
-                'no-image'                    => 'Pas d’image',
-                'img-fail'                    => 'Échec du téléchargement de l’image.',
-                'no-option'                   => 'Aucune option',
-                'keyboard-shortcuts'          => 'Raccourcis clavier',
-                'shortcuts-navigation'        => 'Navigation',
-                'shortcuts-editing'           => 'Édition',
-                'shortcuts-selection'         => 'Sélection',
-                'shortcuts-clipboard'         => 'Presse-papiers et remplissage',
-                'shortcuts-move-cell'         => 'Se déplacer entre les cellules',
-                'shortcuts-move-down'         => 'Descendre / confirmer la modification',
-                'shortcuts-move-up'           => 'Monter',
-                'shortcuts-move-right-left'   => 'Aller à droite / gauche',
-                'shortcuts-home-end'          => 'Première / dernière colonne de la ligne',
-                'shortcuts-ctrl-home-end'     => 'Première / dernière cellule de la grille',
-                'shortcuts-extend-selection'  => 'Étendre la sélection',
-                'shortcuts-select-all'        => 'Sélectionner toutes les cellules',
-                'shortcuts-enter-edit'        => 'Passer en mode édition',
-                'shortcuts-confirm-move-down' => 'Confirmer + descendre',
-                'shortcuts-confirm-move-right'=> 'Confirmer + aller à droite',
-                'shortcuts-escape-revert'     => 'Rétablir la valeur + quitter l\'édition',
-                'shortcuts-clear-cell'        => 'Vider la cellule',
-                'shortcuts-copy'              => 'Copier',
-                'shortcuts-cut'               => 'Couper',
-                'shortcuts-paste'             => 'Coller',
-                'shortcuts-fill-down'         => 'Remplir vers le bas',
-                'shortcuts-fill-right'        => 'Remplir vers la droite',
-                'shortcuts-undo'              => 'Annuler',
-                'shortcuts-redo'              => 'Rétablir',
-                'shortcuts-help'              => 'Afficher/masquer les raccourcis clavier',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Aucun changement à enregistrer.',
+                'invalid-datetime'             => 'Veuillez saisir une date et une heure valides.',
+                'resize-column'                => 'Faites glisser pour redimensionner la colonne',
+                'success'                      => 'Opération réussie.',
+                'fetch-failed'                 => 'Échec de la récupération.',
+                'action'                       => 'Édition en masse',
+                'description'                  => 'Edit multiple products at once. Changes are processed in the background.',
+                'gallery-preview'              => 'Aperçu de la galerie',
+                'img-preview'                  => 'Aperçu de l’image',
+                'no-image'                     => 'Pas d’image',
+                'img-fail'                     => 'Échec du téléchargement de l’image.',
+                'no-option'                    => 'Aucune option',
+                'keyboard-shortcuts'           => 'Raccourcis clavier',
+                'shortcuts-navigation'         => 'Navigation',
+                'shortcuts-editing'            => 'Édition',
+                'shortcuts-selection'          => 'Sélection',
+                'shortcuts-clipboard'          => 'Presse-papiers et remplissage',
+                'shortcuts-move-cell'          => 'Se déplacer entre les cellules',
+                'shortcuts-move-down'          => 'Descendre / confirmer la modification',
+                'shortcuts-move-up'            => 'Monter',
+                'shortcuts-move-right-left'    => 'Aller à droite / gauche',
+                'shortcuts-home-end'           => 'Première / dernière colonne de la ligne',
+                'shortcuts-ctrl-home-end'      => 'Première / dernière cellule de la grille',
+                'shortcuts-extend-selection'   => 'Étendre la sélection',
+                'shortcuts-select-all'         => 'Sélectionner toutes les cellules',
+                'shortcuts-enter-edit'         => 'Passer en mode édition',
+                'shortcuts-confirm-move-down'  => 'Confirmer + descendre',
+                'shortcuts-confirm-move-right' => 'Confirmer + aller à droite',
+                'shortcuts-escape-revert'      => 'Rétablir la valeur + quitter l\'édition',
+                'shortcuts-clear-cell'         => 'Vider la cellule',
+                'shortcuts-copy'               => 'Copier',
+                'shortcuts-cut'                => 'Couper',
+                'shortcuts-paste'              => 'Coller',
+                'shortcuts-fill-down'          => 'Remplir vers le bas',
+                'shortcuts-fill-right'         => 'Remplir vers la droite',
+                'shortcuts-undo'               => 'Annuler',
+                'shortcuts-redo'               => 'Rétablir',
+                'shortcuts-help'               => 'Afficher/masquer les raccourcis clavier',
             ],
             'create-success'          => 'Produit créé avec succès',
             'delete-failed'           => 'Erreur lors de la suppression du produit',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Disponible dans la navigation par filtre',
                 'ai-translate'          => 'Traduction IA',
                 'invalid-swatch-type'   => 'Le :attribute n\'est pas autorisé pour le type d\'attribut :type avec le type d\'échantillon :swatch_type.',
-
                 'single-object-only'    => 'Chaque requête de création doit contenir un seul objet d\'attribut.',
                 'option'                => [
                     'color'    => 'Couleur',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribut supprimé avec succès',
             'update-success'    => 'Attribut mis à jour avec succès',
             'user-define-error' => 'Impossible de supprimer un attribut système',
-
             'immutable-fields'  => 'Les champs suivants ne peuvent pas être modifiés : :fields.',
             'not-found'         => 'L\'attribut avec le code ":code" est introuvable',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Le champ de catégorie a été mis à jour avec succès',
             'user-define-error' => 'Impossible de supprimer un champ de catégorie système',
             'not-found'         => 'Le champ de catégorie avec le code ":code" est introuvable',
-
             'immutable-fields'  => 'Les champs suivants ne peuvent pas être modifiés : :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Impossible de mettre à jour les options configurables car cette famille dispose déjà de variations.',
         ],
         'history' => [
-            'view' => 'Voir les détails de la version',
-
+            'view'  => 'Voir les détails de la version',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'En pause',
                         'cancelled'            => 'Annulé',
                         'failed'               => 'Échoué',
-
-                        'view'       => 'Voir',
+                        'view'                 => 'Voir',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titre',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts système',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titre',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtre',
                 ],
                 'search_by' => [
-                    'code'       => 'Recherche par code',
-                    'code_or_id' => 'Recherche par code ou identifiant',
+                    'code'        => 'Recherche par code',
+                    'code_or_id'  => 'Recherche par code ou identifiant',
+                    'sku_or_user' => 'Recherche par SKU ou utilisateur',
                 ],
                 'search' => [
                     'title' => 'Recherche',

--- a/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'कृपया एक मान्य URL दर्ज करें।',
                     'regex'                      => 'मान आवश्यक पैटर्न से मेल नहीं खाता।',
                     'invalid-pattern'            => 'अवैध कस्टम पैटर्न प्रदान किया गया।',
-
                     'numeric'                    => 'संख्यात्मक विशेषता ":attribute" का मान एक मान्य संख्या होना चाहिए।',
                     'select-attribute-or-family' => 'कृपया कम से कम एक विशेषता या विशेषता परिवार का चयन करें।',
                     'failed'                     => 'सत्यापन विफल हुआ।',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'बल्क संपादन सफल रहा।',
                 ],
-                'id'                          => 'आईडी',
-                'no-changes'                  => 'सहेजने के लिए कोई परिवर्तन नहीं है।',
-
-                'invalid-datetime'            => 'कृपया मान्य दिनांक और समय दर्ज करें।',
-
-                'resize-column'               => 'कॉलम का आकार बदलने के लिए खींचें',
-                'success'                     => 'ऑपरेशन सफलतापूर्वक पूरा हुआ।',
-                'fetch-failed'                => 'डेटा प्राप्त करने में विफल।',
-                'action'                      => 'बल्क संपादन',
-                'description'                 => 'एक साथ कई उत्पादों को संपादित करें। परिवर्तन पृष्ठभूमि में संसाधित किए जाते हैं।',
-                'gallery-preview'             => 'गैलरी पूर्वावलोकन',
-                'img-preview'                 => 'छवि पूर्वावलोकन',
-                'no-image'                    => 'कोई छवि नहीं',
-                'img-fail'                    => 'छवि अपलोड विफल रहा।',
-                'no-option'                   => 'कोई विकल्प नहीं',
-                'keyboard-shortcuts'          => 'कीबोर्ड शॉर्टकट',
-                'shortcuts-navigation'        => 'नेविगेशन',
-                'shortcuts-editing'           => 'संपादन',
-                'shortcuts-selection'         => 'चयन',
-                'shortcuts-clipboard'         => 'क्लिपबोर्ड और भरना',
-                'shortcuts-move-cell'         => 'सेल के बीच जाएँ',
-                'shortcuts-move-down'         => 'नीचे जाएँ / संपादन की पुष्टि करें',
-                'shortcuts-move-up'           => 'ऊपर जाएँ',
-                'shortcuts-move-right-left'   => 'दाएँ / बाएँ जाएँ',
-                'shortcuts-home-end'          => 'पंक्ति का पहला / अंतिम स्तंभ',
-                'shortcuts-ctrl-home-end'     => 'ग्रिड का पहला / अंतिम सेल',
-                'shortcuts-extend-selection'  => 'चयन बढ़ाएँ',
-                'shortcuts-select-all'        => 'सभी सेल चुनें',
-                'shortcuts-enter-edit'        => 'संपादन मोड में जाएँ',
-                'shortcuts-confirm-move-down' => 'पुष्टि करें + नीचे जाएँ',
-                'shortcuts-confirm-move-right'=> 'पुष्टि करें + दाएँ जाएँ',
-                'shortcuts-escape-revert'     => 'मान पुनर्स्थापित करें + संपादन से बाहर निकलें',
-                'shortcuts-clear-cell'        => 'सेल साफ़ करें',
-                'shortcuts-copy'              => 'कॉपी करें',
-                'shortcuts-cut'               => 'काटें',
-                'shortcuts-paste'             => 'पेस्ट करें',
-                'shortcuts-fill-down'         => 'नीचे भरें',
-                'shortcuts-fill-right'        => 'दाएँ भरें',
-                'shortcuts-undo'              => 'पूर्ववत करें',
-                'shortcuts-redo'              => 'फिर से करें',
-                'shortcuts-help'              => 'कीबोर्ड शॉर्टकट दिखाएँ/छुपाएँ',
+                'id'                           => 'आईडी',
+                'no-changes'                   => 'सहेजने के लिए कोई परिवर्तन नहीं है।',
+                'invalid-datetime'             => 'कृपया मान्य दिनांक और समय दर्ज करें।',
+                'resize-column'                => 'कॉलम का आकार बदलने के लिए खींचें',
+                'success'                      => 'ऑपरेशन सफलतापूर्वक पूरा हुआ।',
+                'fetch-failed'                 => 'डेटा प्राप्त करने में विफल।',
+                'action'                       => 'बल्क संपादन',
+                'description'                  => 'एक साथ कई उत्पादों को संपादित करें। परिवर्तन पृष्ठभूमि में संसाधित किए जाते हैं।',
+                'gallery-preview'              => 'गैलरी पूर्वावलोकन',
+                'img-preview'                  => 'छवि पूर्वावलोकन',
+                'no-image'                     => 'कोई छवि नहीं',
+                'img-fail'                     => 'छवि अपलोड विफल रहा।',
+                'no-option'                    => 'कोई विकल्प नहीं',
+                'keyboard-shortcuts'           => 'कीबोर्ड शॉर्टकट',
+                'shortcuts-navigation'         => 'नेविगेशन',
+                'shortcuts-editing'            => 'संपादन',
+                'shortcuts-selection'          => 'चयन',
+                'shortcuts-clipboard'          => 'क्लिपबोर्ड और भरना',
+                'shortcuts-move-cell'          => 'सेल के बीच जाएँ',
+                'shortcuts-move-down'          => 'नीचे जाएँ / संपादन की पुष्टि करें',
+                'shortcuts-move-up'            => 'ऊपर जाएँ',
+                'shortcuts-move-right-left'    => 'दाएँ / बाएँ जाएँ',
+                'shortcuts-home-end'           => 'पंक्ति का पहला / अंतिम स्तंभ',
+                'shortcuts-ctrl-home-end'      => 'ग्रिड का पहला / अंतिम सेल',
+                'shortcuts-extend-selection'   => 'चयन बढ़ाएँ',
+                'shortcuts-select-all'         => 'सभी सेल चुनें',
+                'shortcuts-enter-edit'         => 'संपादन मोड में जाएँ',
+                'shortcuts-confirm-move-down'  => 'पुष्टि करें + नीचे जाएँ',
+                'shortcuts-confirm-move-right' => 'पुष्टि करें + दाएँ जाएँ',
+                'shortcuts-escape-revert'      => 'मान पुनर्स्थापित करें + संपादन से बाहर निकलें',
+                'shortcuts-clear-cell'         => 'सेल साफ़ करें',
+                'shortcuts-copy'               => 'कॉपी करें',
+                'shortcuts-cut'                => 'काटें',
+                'shortcuts-paste'              => 'पेस्ट करें',
+                'shortcuts-fill-down'          => 'नीचे भरें',
+                'shortcuts-fill-right'         => 'दाएँ भरें',
+                'shortcuts-undo'               => 'पूर्ववत करें',
+                'shortcuts-redo'               => 'फिर से करें',
+                'shortcuts-help'               => 'कीबोर्ड शॉर्टकट दिखाएँ/छुपाएँ',
             ],
             'create-success'          => 'उत्पाद सफलतापूर्वक बनाया गया',
             'delete-failed'           => 'उत्पाद हटाए गए विफल',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'फ़िल्टर योग्य है',
                 'ai-translate'          => 'एआई अनुवाद',
                 'invalid-swatch-type'   => ':attribute के लिए :type के साथ :swatch_type स्वैच प्रकार की अनुमति नहीं है।',
-
                 'single-object-only'    => 'प्रत्येक क्रिएट अनुरोध में केवल एक विशेषता ऑब्जेक्ट भेजा जाना चाहिए।',
                 'option'                => [
                     'color'    => 'रंग आदर्श',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'विशेषता सफलतापूर्वक हटा दी गई',
             'update-success'    => 'ATTRIBURE को सफलतापूर्वक अपडेट किया गया',
             'user-define-error' => 'सिस्टम विशेषता को हटा नहीं सकते',
-
             'immutable-fields'  => 'निम्न फ़ील्ड्स संशोधित नहीं की जा सकतीं: :fields.',
             'not-found'         => 'कोड के साथ विशेषता ":code" नहीं मिल सकता है',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'श्रेणी फ़ील्ड सफलतापूर्वक अपडेट किया गया',
             'user-define-error' => 'सिस्टम श्रेणी फ़ील्ड को हटा नहीं सकते',
             'not-found'         => 'कोड के साथ श्रेणी फ़ील्ड ":code" नहीं मिला',
-
             'immutable-fields'  => 'निम्न फ़ील्ड्स संशोधित नहीं की जा सकतीं: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'कॉन्फ़िगर करने योग्य विकल्पों को अपडेट नहीं कर सकते क्योंकि इस परिवार में पहले से ही वैरिएंट उत्पाद हैं।',
         ],
         'history' => [
-            'view' => 'संस्करण विवरण देखें',
-
+            'view'  => 'संस्करण विवरण देखें',
             'index' => [
                 'datagrid' => [
                     'version'   => 'संस्करण',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'रुका हुआ',
                         'cancelled'            => 'रद्द किया गया',
                         'failed'               => 'असफल',
-
-                        'view'       => 'देखें',
+                        'view'                 => 'देखें',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'प्रॉम्प्ट्स',
-
             ],
-
             'datagrid' => [
                 'id'               => 'आईडी',
                 'title'            => 'शीर्षक',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'सिस्टम प्रॉम्प्ट्स',
-
             ],
-
             'datagrid' => [
                 'id'          => 'आईडी',
                 'title'       => 'शीर्षक',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'फ़िल्टर',
                 ],
                 'search_by' => [
-                    'code'       => 'कोड द्वारा खोजें',
-                    'code_or_id' => 'कोड या आईडी द्वारा खोजें',
+                    'code'        => 'कोड द्वारा खोजें',
+                    'code_or_id'  => 'कोड या आईडी द्वारा खोजें',
+                    'sku_or_user' => 'SKU या उपयोगकर्ता द्वारा खोजें',
                 ],
                 'search' => [
                     'title' => 'खोज',

--- a/packages/Webkul/Admin/src/Resources/lang/hr_HR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hr_HR/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Unesite valjani URL.',
                     'regex'                      => 'Vrijednost ne odgovara traženom obrascu.',
                     'invalid-pattern'            => 'Unesen je nevažeći prilagođeni obrazac.',
-
                     'numeric'                    => 'Vrijednost numeričkog atributa „:attribute“ mora biti valjani broj.',
                     'select-attribute-or-family' => 'Molimo odaberite barem jedan atribut ili obitelj atributa.',
                     'failed'                     => 'Provjera valjanosti nije uspjela.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Grupno uređivanje je uspješno.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Nema promjena za spremiti.',
-
-                'invalid-datetime'            => 'Unesite valjani datum i vrijeme.',
-
-                'resize-column'               => 'Povucite za promjenu širine stupca',
-                'success'                     => 'Operacija uspješno izvršena.',
-                'fetch-failed'                => 'Preuzimanje nije uspjelo.',
-                'action'                      => 'Grupno uređivanje',
-                'description'                 => 'Uredite više proizvoda odjednom. Promjene se obrađuju u pozadini.',
-                'gallery-preview'             => 'Pregled galerije',
-                'img-preview'                 => 'Pregled slike',
-                'no-image'                    => 'Nema slike',
-                'img-fail'                    => 'Neuspješno učitavanje slike.',
-                'no-option'                   => 'Nema opcija',
-                'keyboard-shortcuts'          => 'Tipkovnički prečaci',
-                'shortcuts-navigation'        => 'Navigacija',
-                'shortcuts-editing'           => 'Uređivanje',
-                'shortcuts-selection'         => 'Odabir',
-                'shortcuts-clipboard'         => 'Međuspremnik i ispuna',
-                'shortcuts-move-cell'         => 'Premještanje između ćelija',
-                'shortcuts-move-down'         => 'Premjesti dolje / potvrdi uređivanje',
-                'shortcuts-move-up'           => 'Premjesti gore',
-                'shortcuts-move-right-left'   => 'Premjesti desno / lijevo',
-                'shortcuts-home-end'          => 'Prvi / zadnji stupac u retku',
-                'shortcuts-ctrl-home-end'     => 'Prva / zadnja ćelija u mreži',
-                'shortcuts-extend-selection'  => 'Proširi odabir',
-                'shortcuts-select-all'        => 'Odaberi sve ćelije',
-                'shortcuts-enter-edit'        => 'Uđi u način uređivanja',
-                'shortcuts-confirm-move-down' => 'Potvrdi + premjesti dolje',
-                'shortcuts-confirm-move-right'=> 'Potvrdi + premjesti desno',
-                'shortcuts-escape-revert'     => 'Vrati vrijednost + izađi iz uređivanja',
-                'shortcuts-clear-cell'        => 'Očisti ćeliju',
-                'shortcuts-copy'              => 'Kopiraj',
-                'shortcuts-cut'               => 'Izreži',
-                'shortcuts-paste'             => 'Zalijepi',
-                'shortcuts-fill-down'         => 'Ispuni prema dolje',
-                'shortcuts-fill-right'        => 'Ispuni prema desno',
-                'shortcuts-undo'              => 'Poništi',
-                'shortcuts-redo'              => 'Ponovi',
-                'shortcuts-help'              => 'Uključi/isključi tipkovničke prečace',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Nema promjena za spremiti.',
+                'invalid-datetime'             => 'Unesite valjani datum i vrijeme.',
+                'resize-column'                => 'Povucite za promjenu širine stupca',
+                'success'                      => 'Operacija uspješno izvršena.',
+                'fetch-failed'                 => 'Preuzimanje nije uspjelo.',
+                'action'                       => 'Grupno uređivanje',
+                'description'                  => 'Uredite više proizvoda odjednom. Promjene se obrađuju u pozadini.',
+                'gallery-preview'              => 'Pregled galerije',
+                'img-preview'                  => 'Pregled slike',
+                'no-image'                     => 'Nema slike',
+                'img-fail'                     => 'Neuspješno učitavanje slike.',
+                'no-option'                    => 'Nema opcija',
+                'keyboard-shortcuts'           => 'Tipkovnički prečaci',
+                'shortcuts-navigation'         => 'Navigacija',
+                'shortcuts-editing'            => 'Uređivanje',
+                'shortcuts-selection'          => 'Odabir',
+                'shortcuts-clipboard'          => 'Međuspremnik i ispuna',
+                'shortcuts-move-cell'          => 'Premještanje između ćelija',
+                'shortcuts-move-down'          => 'Premjesti dolje / potvrdi uređivanje',
+                'shortcuts-move-up'            => 'Premjesti gore',
+                'shortcuts-move-right-left'    => 'Premjesti desno / lijevo',
+                'shortcuts-home-end'           => 'Prvi / zadnji stupac u retku',
+                'shortcuts-ctrl-home-end'      => 'Prva / zadnja ćelija u mreži',
+                'shortcuts-extend-selection'   => 'Proširi odabir',
+                'shortcuts-select-all'         => 'Odaberi sve ćelije',
+                'shortcuts-enter-edit'         => 'Uđi u način uređivanja',
+                'shortcuts-confirm-move-down'  => 'Potvrdi + premjesti dolje',
+                'shortcuts-confirm-move-right' => 'Potvrdi + premjesti desno',
+                'shortcuts-escape-revert'      => 'Vrati vrijednost + izađi iz uređivanja',
+                'shortcuts-clear-cell'         => 'Očisti ćeliju',
+                'shortcuts-copy'               => 'Kopiraj',
+                'shortcuts-cut'                => 'Izreži',
+                'shortcuts-paste'              => 'Zalijepi',
+                'shortcuts-fill-down'          => 'Ispuni prema dolje',
+                'shortcuts-fill-right'         => 'Ispuni prema desno',
+                'shortcuts-undo'               => 'Poništi',
+                'shortcuts-redo'               => 'Ponovi',
+                'shortcuts-help'               => 'Uključi/isključi tipkovničke prečace',
             ],
             'create-success'          => 'Proizvod uspješno stvoren',
             'delete-failed'           => 'Brisanje proizvoda nije uspjelo',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Je filtrabilno',
                 'ai-translate'          => 'AI Prevod',
                 'invalid-swatch-type'   => ':attribute nije dozvoljen za tip atributa :type s tipom uzorka :swatch_type.',
-
                 'single-object-only'    => 'Svaki zahtjev za stvaranje mora sadržavati samo jedan objekt atributa.',
                 'option'                => [
                     'color'    => 'Boja uzorka',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atribut uspješno izbrisan',
             'update-success'    => 'Atribut uspješno ažuriran',
             'user-define-error' => 'Ne možete obrisati sistemski atribut',
-
             'immutable-fields'  => 'Sljedeća polja ne mogu se mijenjati: :fields.',
             'not-found'         => 'Atribut s kodom ":code" nije pronađen',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Polje Kategorije Ažurirano Uspješno',
             'user-define-error' => 'Ne možete obrisati sistemsko Polje Kategorije',
             'not-found'         => 'Polje Kategorije s kodom ":code" nije pronađeno',
-
             'immutable-fields'  => 'Sljedeća polja ne mogu se mijenjati: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Ne možete ažurirati opcije konfiguracije jer ova obitelj već ima varijante proizvoda.',
         ],
         'history' => [
-            'view' => 'Pogledaj detalje verzije',
-
+            'view'  => 'Pogledaj detalje verzije',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Verzija',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Pauzirano',
                         'cancelled'            => 'Otkazano',
                         'failed'               => 'Neuspješno',
-
-                        'view'       => 'Pregled',
+                        'view'                 => 'Pregled',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Promptovi',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Naslov',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Sustavni promptovi',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Naslov',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtriraj',
                 ],
                 'search_by' => [
-                    'code'       => 'Pretraži prema kodu',
-                    'code_or_id' => 'Pretraži prema kodu ili ID-u',
+                    'code'        => 'Pretraži prema kodu',
+                    'code_or_id'  => 'Pretraži prema kodu ili ID-u',
+                    'sku_or_user' => 'Pretraži prema SKU ili korisniku',
                 ],
                 'search' => [
                     'title' => 'Pretraži',

--- a/packages/Webkul/Admin/src/Resources/lang/id_ID/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/id_ID/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Silakan masukkan URL yang valid.',
                     'regex'                      => 'Nilai tidak sesuai dengan pola yang diperlukan.',
                     'invalid-pattern'            => 'Pola khusus tidak valid.',
-
                     'numeric'                    => 'Nilai untuk atribut numerik ":attribute" harus berupa angka yang valid.',
                     'select-attribute-or-family' => 'Silakan pilih setidaknya satu atribut atau satu keluarga atribut.',
                     'failed'                     => 'Validasi gagal.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Sunting massal berhasil.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Tidak ada perubahan untuk disimpan.',
-
-                'invalid-datetime'            => 'Masukkan tanggal dan waktu yang valid.',
-
-                'resize-column'               => 'Seret untuk mengubah lebar kolom',
-                'success'                     => 'Pekerjaan berhasil dijalankan.',
-                'fetch-failed'                => 'Gagal mengambil data.',
-                'action'                      => 'Edit Massal',
-                'description'                 => 'Edit beberapa produk sekaligus. Perubahan diproses di latar belakang.',
-                'gallery-preview'             => 'Pratinjau Galeri',
-                'img-preview'                 => 'Pratinjau Gambar',
-                'no-image'                    => 'Tidak Ada Gambar',
-                'img-fail'                    => 'Unggah gambar gagal',
-                'no-option'                   => 'Tidak Ada Opsi',
-                'keyboard-shortcuts'          => 'Pintasan Keyboard',
-                'shortcuts-navigation'        => 'Navigasi',
-                'shortcuts-editing'           => 'Pengeditan',
-                'shortcuts-selection'         => 'Pemilihan',
-                'shortcuts-clipboard'         => 'Papan Klip & Isi',
-                'shortcuts-move-cell'         => 'Berpindah antar sel',
-                'shortcuts-move-down'         => 'Turun / konfirmasi edit',
-                'shortcuts-move-up'           => 'Naik',
-                'shortcuts-move-right-left'   => 'Kanan / kiri',
-                'shortcuts-home-end'          => 'Kolom pertama / terakhir dalam baris',
-                'shortcuts-ctrl-home-end'     => 'Sel pertama / terakhir dalam kisi',
-                'shortcuts-extend-selection'  => 'Perluas pilihan',
-                'shortcuts-select-all'        => 'Pilih semua sel',
-                'shortcuts-enter-edit'        => 'Masuk mode edit',
-                'shortcuts-confirm-move-down' => 'Konfirmasi + turun',
-                'shortcuts-confirm-move-right'=> 'Konfirmasi + ke kanan',
-                'shortcuts-escape-revert'     => 'Kembalikan nilai + keluar dari edit',
-                'shortcuts-clear-cell'        => 'Hapus sel',
-                'shortcuts-copy'              => 'Salin',
-                'shortcuts-cut'               => 'Potong',
-                'shortcuts-paste'             => 'Tempel',
-                'shortcuts-fill-down'         => 'Isi ke bawah',
-                'shortcuts-fill-right'        => 'Isi ke kanan',
-                'shortcuts-undo'              => 'Urungkan',
-                'shortcuts-redo'              => 'Ulangi',
-                'shortcuts-help'              => 'Tampilkan/sembunyikan pintasan keyboard',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Tidak ada perubahan untuk disimpan.',
+                'invalid-datetime'             => 'Masukkan tanggal dan waktu yang valid.',
+                'resize-column'                => 'Seret untuk mengubah lebar kolom',
+                'success'                      => 'Pekerjaan berhasil dijalankan.',
+                'fetch-failed'                 => 'Gagal mengambil data.',
+                'action'                       => 'Edit Massal',
+                'description'                  => 'Edit beberapa produk sekaligus. Perubahan diproses di latar belakang.',
+                'gallery-preview'              => 'Pratinjau Galeri',
+                'img-preview'                  => 'Pratinjau Gambar',
+                'no-image'                     => 'Tidak Ada Gambar',
+                'img-fail'                     => 'Unggah gambar gagal',
+                'no-option'                    => 'Tidak Ada Opsi',
+                'keyboard-shortcuts'           => 'Pintasan Keyboard',
+                'shortcuts-navigation'         => 'Navigasi',
+                'shortcuts-editing'            => 'Pengeditan',
+                'shortcuts-selection'          => 'Pemilihan',
+                'shortcuts-clipboard'          => 'Papan Klip & Isi',
+                'shortcuts-move-cell'          => 'Berpindah antar sel',
+                'shortcuts-move-down'          => 'Turun / konfirmasi edit',
+                'shortcuts-move-up'            => 'Naik',
+                'shortcuts-move-right-left'    => 'Kanan / kiri',
+                'shortcuts-home-end'           => 'Kolom pertama / terakhir dalam baris',
+                'shortcuts-ctrl-home-end'      => 'Sel pertama / terakhir dalam kisi',
+                'shortcuts-extend-selection'   => 'Perluas pilihan',
+                'shortcuts-select-all'         => 'Pilih semua sel',
+                'shortcuts-enter-edit'         => 'Masuk mode edit',
+                'shortcuts-confirm-move-down'  => 'Konfirmasi + turun',
+                'shortcuts-confirm-move-right' => 'Konfirmasi + ke kanan',
+                'shortcuts-escape-revert'      => 'Kembalikan nilai + keluar dari edit',
+                'shortcuts-clear-cell'         => 'Hapus sel',
+                'shortcuts-copy'               => 'Salin',
+                'shortcuts-cut'                => 'Potong',
+                'shortcuts-paste'              => 'Tempel',
+                'shortcuts-fill-down'          => 'Isi ke bawah',
+                'shortcuts-fill-right'         => 'Isi ke kanan',
+                'shortcuts-undo'               => 'Urungkan',
+                'shortcuts-redo'               => 'Ulangi',
+                'shortcuts-help'               => 'Tampilkan/sembunyikan pintasan keyboard',
             ],
             'create-success'          => 'Produk berhasil dibuat',
             'delete-failed'           => 'Produk dihapus gagal',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Dapat difilter',
                 'ai-translate'          => 'AI Terjemahan',
                 'invalid-swatch-type'   => 'Atribut :attribute tidak diperbolehkan untuk tipe atribut :type dengan tipe swatch :swatch_type.',
-
                 'single-object-only'    => 'Setiap permintaan pembuatan harus mengirim satu objek atribut.',
                 'option'                => [
                     'color'    => 'Swatch Warna',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atribut berhasil dihapus',
             'update-success'    => 'Atribut berhasil diperbarui',
             'user-define-error' => 'Tidak dapat menghapus atribut sistem',
-
             'immutable-fields'  => 'Field berikut tidak dapat diubah: :fields.',
             'not-found'         => 'Atribut dengan kode ":code" tidak dapat ditemukan',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Bidang kategori berhasil diperbarui',
             'user-define-error' => 'Tidak dapat menghapus bidang kategori sistem',
             'not-found'         => 'Bidang kategori dengan kode ":code" tidak dapat ditemukan',
-
             'immutable-fields'  => 'Field berikut tidak dapat diubah: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Tidak dapat memperbarui opsi yang dapat dikonfigurasi karena keluarga ini sudah memiliki produk varian.',
         ],
         'history' => [
-            'view' => 'Lihat Detail Versi',
-
+            'view'  => 'Lihat Detail Versi',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versi',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Dijeda',
                         'cancelled'            => 'Dibatalkan',
                         'failed'               => 'Gagal',
-
-                        'view'       => 'Lihat',
+                        'view'                 => 'Lihat',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompt',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Judul',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'System Prompt',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Judul',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Saring',
                 ],
                 'search_by' => [
-                    'code'       => 'Cari dengan kode',
-                    'code_or_id' => 'Cari dengan kode atau ID',
+                    'code'        => 'Cari dengan kode',
+                    'code_or_id'  => 'Cari dengan kode atau ID',
+                    'sku_or_user' => 'Cari dengan SKU atau pengguna',
                 ],
                 'search' => [
                     'title' => 'Mencari',

--- a/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Inserisci un URL valido.',
                     'regex'                      => 'Il valore non corrisponde al formato richiesto.',
                     'invalid-pattern'            => 'Formato personalizzato non valido.',
-
                     'numeric'                    => 'Il valore per l\'attributo numerico ":attribute" deve essere un numero valido.',
                     'select-attribute-or-family' => 'Seleziona almeno un attributo o una famiglia di attributi.',
                     'failed'                     => 'Validazione non riuscita.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Modifica massiva completata con successo.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Nessuna modifica da salvare.',
-
-                'invalid-datetime'            => 'Inserisci una data e un\'ora valide.',
-
-                'resize-column'               => 'Trascina per ridimensionare la colonna',
-                'success'                     => 'Operazione completata con successo.',
-                'fetch-failed'                => 'Impossibile recuperare i dati.',
-                'action'                      => 'Modifica di massa',
-                'description'                 => 'Modifica più prodotti contemporaneamente. Le modifiche vengono elaborate in background.',
-                'gallery-preview'             => 'Anteprima Galleria',
-                'img-preview'                 => 'Anteprima Immagine',
-                'no-image'                    => 'Nessuna Immagine',
-                'img-fail'                    => 'Caricamento immagine fallito',
-                'no-option'                   => 'Nessuna opzione',
-                'keyboard-shortcuts'          => 'Scorciatoie da tastiera',
-                'shortcuts-navigation'        => 'Navigazione',
-                'shortcuts-editing'           => 'Modifica',
-                'shortcuts-selection'         => 'Selezione',
-                'shortcuts-clipboard'         => 'Appunti e riempimento',
-                'shortcuts-move-cell'         => 'Spostarsi tra le celle',
-                'shortcuts-move-down'         => 'Scendi / conferma modifica',
-                'shortcuts-move-up'           => 'Sali',
-                'shortcuts-move-right-left'   => 'Sposta a destra / sinistra',
-                'shortcuts-home-end'          => 'Prima / ultima colonna nella riga',
-                'shortcuts-ctrl-home-end'     => 'Prima / ultima cella nella griglia',
-                'shortcuts-extend-selection'  => 'Estendi selezione',
-                'shortcuts-select-all'        => 'Seleziona tutte le celle',
-                'shortcuts-enter-edit'        => 'Entra in modalità modifica',
-                'shortcuts-confirm-move-down' => 'Conferma + scendi',
-                'shortcuts-confirm-move-right'=> 'Conferma + sposta a destra',
-                'shortcuts-escape-revert'     => 'Ripristina valore + esci dalla modifica',
-                'shortcuts-clear-cell'        => 'Svuota cella',
-                'shortcuts-copy'              => 'Copia',
-                'shortcuts-cut'               => 'Taglia',
-                'shortcuts-paste'             => 'Incolla',
-                'shortcuts-fill-down'         => 'Riempi verso il basso',
-                'shortcuts-fill-right'        => 'Riempi verso destra',
-                'shortcuts-undo'              => 'Annulla',
-                'shortcuts-redo'              => 'Ripristina',
-                'shortcuts-help'              => 'Mostra/nascondi scorciatoie da tastiera',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Nessuna modifica da salvare.',
+                'invalid-datetime'             => 'Inserisci una data e un\'ora valide.',
+                'resize-column'                => 'Trascina per ridimensionare la colonna',
+                'success'                      => 'Operazione completata con successo.',
+                'fetch-failed'                 => 'Impossibile recuperare i dati.',
+                'action'                       => 'Modifica di massa',
+                'description'                  => 'Modifica più prodotti contemporaneamente. Le modifiche vengono elaborate in background.',
+                'gallery-preview'              => 'Anteprima Galleria',
+                'img-preview'                  => 'Anteprima Immagine',
+                'no-image'                     => 'Nessuna Immagine',
+                'img-fail'                     => 'Caricamento immagine fallito',
+                'no-option'                    => 'Nessuna opzione',
+                'keyboard-shortcuts'           => 'Scorciatoie da tastiera',
+                'shortcuts-navigation'         => 'Navigazione',
+                'shortcuts-editing'            => 'Modifica',
+                'shortcuts-selection'          => 'Selezione',
+                'shortcuts-clipboard'          => 'Appunti e riempimento',
+                'shortcuts-move-cell'          => 'Spostarsi tra le celle',
+                'shortcuts-move-down'          => 'Scendi / conferma modifica',
+                'shortcuts-move-up'            => 'Sali',
+                'shortcuts-move-right-left'    => 'Sposta a destra / sinistra',
+                'shortcuts-home-end'           => 'Prima / ultima colonna nella riga',
+                'shortcuts-ctrl-home-end'      => 'Prima / ultima cella nella griglia',
+                'shortcuts-extend-selection'   => 'Estendi selezione',
+                'shortcuts-select-all'         => 'Seleziona tutte le celle',
+                'shortcuts-enter-edit'         => 'Entra in modalità modifica',
+                'shortcuts-confirm-move-down'  => 'Conferma + scendi',
+                'shortcuts-confirm-move-right' => 'Conferma + sposta a destra',
+                'shortcuts-escape-revert'      => 'Ripristina valore + esci dalla modifica',
+                'shortcuts-clear-cell'         => 'Svuota cella',
+                'shortcuts-copy'               => 'Copia',
+                'shortcuts-cut'                => 'Taglia',
+                'shortcuts-paste'              => 'Incolla',
+                'shortcuts-fill-down'          => 'Riempi verso il basso',
+                'shortcuts-fill-right'         => 'Riempi verso destra',
+                'shortcuts-undo'               => 'Annulla',
+                'shortcuts-redo'               => 'Ripristina',
+                'shortcuts-help'               => 'Mostra/nascondi scorciatoie da tastiera',
             ],
             'create-success'          => 'Prodotto creato con successo',
             'delete-failed'           => 'Eliminazione del prodotto non riuscita',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'È filtrabile',
                 'ai-translate'          => 'Traduzione IA',
                 'invalid-swatch-type'   => 'L\'attributo :attribute non è consentito per il tipo di attributo :type con il tipo di campione :swatch_type.',
-
                 'single-object-only'    => 'Ogni richiesta di creazione deve inviare un solo oggetto attributo.',
                 'option'                => [
                     'color'    => 'Colore campione',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attributo eliminato con successo',
             'update-success'    => 'Attributo aggiornato con successo',
             'user-define-error' => 'Non è possibile eliminare un attributo di sistema',
-
             'immutable-fields'  => 'I seguenti campi non possono essere modificati: :fields.',
             'not-found'         => 'Attributo con codice ":code" non trovato',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Campo Categoria Aggiornato con Successo',
             'user-define-error' => 'Non puoi eliminare il campo categoria di sistema',
             'not-found'         => 'Campo Categoria con codice ":code" non trovato',
-
             'immutable-fields'  => 'I seguenti campi non possono essere modificati: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Impossibile aggiornare le opzioni di configurazione poiché questa famiglia ha già varianti di prodotto.',
         ],
         'history' => [
-            'view' => 'Visualizza dettagli versione',
-
+            'view'  => 'Visualizza dettagli versione',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versione',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'In pausa',
                         'cancelled'            => 'Annullato',
                         'failed'               => 'Fallito',
-
-                        'view'       => 'Visualizza',
+                        'view'                 => 'Visualizza',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompt',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titolo',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompt di sistema',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titolo',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtra',
                 ],
                 'search_by' => [
-                    'code'       => 'Cerca per codice',
-                    'code_or_id' => 'Cerca per codice o id',
+                    'code'        => 'Cerca per codice',
+                    'code_or_id'  => 'Cerca per codice o id',
+                    'sku_or_user' => 'Cerca per SKU o utente',
                 ],
                 'search' => [
                     'title' => 'Cerca',

--- a/packages/Webkul/Admin/src/Resources/lang/ja_JP/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja_JP/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => '有効なURLを入力してください。',
                     'regex'                      => '値が必要なパターンと一致しません。',
                     'invalid-pattern'            => '無効なカスタムパターンが指定されました。',
-
                     'numeric'                    => '数値属性「:attribute」の値は有効な数値である必要があります。',
                     'select-attribute-or-family' => '少なくとも1つの属性または属性ファミリーを選択してください。',
                     'failed'                     => '検証に失敗しました。',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => '一括編集に成功しました。',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => '保存する変更はありません。',
-
-                'invalid-datetime'            => '有効な日付と時刻を入力してください。',
-
-                'resize-column'               => 'ドラッグして列幅を変更',
-                'success'                     => 'ジョブが正常に実行されました。',
-                'fetch-failed'                => '取得に失敗しました。',
-                'action'                      => '一括編集',
-                'description'                 => '複数の商品を一括編集します。変更はバックグラウンドで処理されます。',
-                'gallery-preview'             => 'ギャラリープレビュー',
-                'img-preview'                 => '画像プレビュー',
-                'no-image'                    => '画像なし',
-                'img-fail'                    => '画像のアップロードに失敗しました',
-                'no-option'                   => 'オプションなし',
-                'keyboard-shortcuts'          => 'キーボードショートカット',
-                'shortcuts-navigation'        => 'ナビゲーション',
-                'shortcuts-editing'           => '編集',
-                'shortcuts-selection'         => '選択',
-                'shortcuts-clipboard'         => 'クリップボードと入力',
-                'shortcuts-move-cell'         => 'セル間の移動',
-                'shortcuts-move-down'         => '下に移動 / 編集を確定',
-                'shortcuts-move-up'           => '上に移動',
-                'shortcuts-move-right-left'   => '右 / 左に移動',
-                'shortcuts-home-end'          => '行の最初 / 最後の列',
-                'shortcuts-ctrl-home-end'     => 'グリッドの最初 / 最後のセル',
-                'shortcuts-extend-selection'  => '選択範囲を拡張',
-                'shortcuts-select-all'        => 'すべてのセルを選択',
-                'shortcuts-enter-edit'        => '編集モードに入る',
-                'shortcuts-confirm-move-down' => '確定 + 下に移動',
-                'shortcuts-confirm-move-right'=> '確定 + 右に移動',
-                'shortcuts-escape-revert'     => '値を元に戻す + 編集を終了',
-                'shortcuts-clear-cell'        => 'セルをクリア',
-                'shortcuts-copy'              => 'コピー',
-                'shortcuts-cut'               => '切り取り',
-                'shortcuts-paste'             => '貼り付け',
-                'shortcuts-fill-down'         => '下にフィル',
-                'shortcuts-fill-right'        => '右にフィル',
-                'shortcuts-undo'              => '元に戻す',
-                'shortcuts-redo'              => 'やり直し',
-                'shortcuts-help'              => 'キーボードショートカットの表示切替',
+                'id'                           => 'ID',
+                'no-changes'                   => '保存する変更はありません。',
+                'invalid-datetime'             => '有効な日付と時刻を入力してください。',
+                'resize-column'                => 'ドラッグして列幅を変更',
+                'success'                      => 'ジョブが正常に実行されました。',
+                'fetch-failed'                 => '取得に失敗しました。',
+                'action'                       => '一括編集',
+                'description'                  => '複数の商品を一括編集します。変更はバックグラウンドで処理されます。',
+                'gallery-preview'              => 'ギャラリープレビュー',
+                'img-preview'                  => '画像プレビュー',
+                'no-image'                     => '画像なし',
+                'img-fail'                     => '画像のアップロードに失敗しました',
+                'no-option'                    => 'オプションなし',
+                'keyboard-shortcuts'           => 'キーボードショートカット',
+                'shortcuts-navigation'         => 'ナビゲーション',
+                'shortcuts-editing'            => '編集',
+                'shortcuts-selection'          => '選択',
+                'shortcuts-clipboard'          => 'クリップボードと入力',
+                'shortcuts-move-cell'          => 'セル間の移動',
+                'shortcuts-move-down'          => '下に移動 / 編集を確定',
+                'shortcuts-move-up'            => '上に移動',
+                'shortcuts-move-right-left'    => '右 / 左に移動',
+                'shortcuts-home-end'           => '行の最初 / 最後の列',
+                'shortcuts-ctrl-home-end'      => 'グリッドの最初 / 最後のセル',
+                'shortcuts-extend-selection'   => '選択範囲を拡張',
+                'shortcuts-select-all'         => 'すべてのセルを選択',
+                'shortcuts-enter-edit'         => '編集モードに入る',
+                'shortcuts-confirm-move-down'  => '確定 + 下に移動',
+                'shortcuts-confirm-move-right' => '確定 + 右に移動',
+                'shortcuts-escape-revert'      => '値を元に戻す + 編集を終了',
+                'shortcuts-clear-cell'         => 'セルをクリア',
+                'shortcuts-copy'               => 'コピー',
+                'shortcuts-cut'                => '切り取り',
+                'shortcuts-paste'              => '貼り付け',
+                'shortcuts-fill-down'          => '下にフィル',
+                'shortcuts-fill-right'         => '右にフィル',
+                'shortcuts-undo'               => '元に戻す',
+                'shortcuts-redo'               => 'やり直し',
+                'shortcuts-help'               => 'キーボードショートカットの表示切替',
             ],
             'create-success'          => '製品が正常に作成されました',
             'delete-failed'           => '製品の削除に失敗しました',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'フィルタリング可能',
                 'ai-translate'          => 'AI翻訳',
                 'invalid-swatch-type'   => ':attribute は、スウォッチタイプ :swatch_type の属性タイプ :type には許可されていません。',
-
                 'single-object-only'    => '属性の作成リクエストには属性オブジェクトを1つだけ送信してください。',
                 'option'                => [
                     'color'    => 'カラー スウォッチ',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => '属性が正常に削除されました',
             'update-success'    => '属性が正常に更新されました',
             'user-define-error' => 'システム属性を削除できません',
-
             'immutable-fields'  => '次のフィールドは変更できません: :fields。',
             'not-found'         => 'コード ":code" の属性が見つかりませんでした',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'カテゴリ フィールドが正常に更新されました',
             'user-define-error' => 'システム カテゴリ フィールドを削除できません',
             'not-found'         => 'コード ":code" のカテゴリ フィールドが見つかりませんでした',
-
             'immutable-fields'  => '次のフィールドは変更できません: :fields。',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'このファミリにはすでにバリアント製品があるため、構成可能なオプションを更新できません。',
         ],
         'history' => [
-            'view' => 'バージョンの詳細を表示',
-
+            'view'  => 'バージョンの詳細を表示',
             'index' => [
                 'datagrid' => [
                     'version'   => 'バージョン',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => '一時停止中',
                         'cancelled'            => 'キャンセル済み',
                         'failed'               => '失敗',
-
-                        'view'       => '表示',
+                        'view'                 => '表示',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'プロンプト',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'タイトル',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'システムプロンプト',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'タイトル',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'フィルター',
                 ],
                 'search_by' => [
-                    'code'       => 'コードで検索',
-                    'code_or_id' => 'コードまたはIDで検索',
+                    'code'        => 'コードで検索',
+                    'code_or_id'  => 'コードまたはIDで検索',
+                    'sku_or_user' => 'SKUまたはユーザーで検索',
                 ],
                 'search' => [
                     'title' => '検索',

--- a/packages/Webkul/Admin/src/Resources/lang/ko_KR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ko_KR/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => '유효한 URL을 입력하세요.',
                     'regex'                      => '값이 요구되는 패턴과 일치하지 않습니다.',
                     'invalid-pattern'            => '잘못된 사용자 지정 패턴입니다.',
-
                     'numeric'                    => '숫자 속성 ":attribute"의 값은 유효한 숫자여야 합니다.',
                     'select-attribute-or-family' => '하나 이상의 속성 또는 속성 패밀리를 선택하세요.',
                     'failed'                     => '유효성 검사 실패.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => '일괄 편집이 성공적으로 완료되었습니다.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => '저장할 변경 사항이 없습니다.',
-
-                'invalid-datetime'            => '유효한 날짜와 시간을 입력하세요.',
-
-                'resize-column'               => '드래그하여 열 너비 조정',
-                'success'                     => '작업이 성공적으로 실행되었습니다.',
-                'fetch-failed'                => '가져오기 실패.',
-                'action'                      => '일괄 편집',
-                'description'                 => '여러 제품을 한 번에 편집합니다. 변경 사항은 백그라운드에서 처리됩니다.',
-                'gallery-preview'             => '갤러리 미리보기',
-                'img-preview'                 => '이미지 미리보기',
-                'no-image'                    => '이미지 없음',
-                'img-fail'                    => '이미지 업로드 실패',
-                'no-option'                   => '옵션 없음',
-                'keyboard-shortcuts'          => '키보드 단축키',
-                'shortcuts-navigation'        => '탐색',
-                'shortcuts-editing'           => '편집',
-                'shortcuts-selection'         => '선택',
-                'shortcuts-clipboard'         => '클립보드 및 채우기',
-                'shortcuts-move-cell'         => '셀 간 이동',
-                'shortcuts-move-down'         => '아래로 이동 / 편집 확인',
-                'shortcuts-move-up'           => '위로 이동',
-                'shortcuts-move-right-left'   => '오른쪽 / 왼쪽으로 이동',
-                'shortcuts-home-end'          => '행의 첫 번째 / 마지막 열',
-                'shortcuts-ctrl-home-end'     => '그리드의 첫 번째 / 마지막 셀',
-                'shortcuts-extend-selection'  => '선택 범위 확장',
-                'shortcuts-select-all'        => '모든 셀 선택',
-                'shortcuts-enter-edit'        => '편집 모드 진입',
-                'shortcuts-confirm-move-down' => '확인 + 아래로 이동',
-                'shortcuts-confirm-move-right'=> '확인 + 오른쪽으로 이동',
-                'shortcuts-escape-revert'     => '값 되돌리기 + 편집 종료',
-                'shortcuts-clear-cell'        => '셀 지우기',
-                'shortcuts-copy'              => '복사',
-                'shortcuts-cut'               => '잘라내기',
-                'shortcuts-paste'             => '붙여넣기',
-                'shortcuts-fill-down'         => '아래로 채우기',
-                'shortcuts-fill-right'        => '오른쪽으로 채우기',
-                'shortcuts-undo'              => '실행 취소',
-                'shortcuts-redo'              => '다시 실행',
-                'shortcuts-help'              => '키보드 단축키 표시/숨기기',
+                'id'                           => 'ID',
+                'no-changes'                   => '저장할 변경 사항이 없습니다.',
+                'invalid-datetime'             => '유효한 날짜와 시간을 입력하세요.',
+                'resize-column'                => '드래그하여 열 너비 조정',
+                'success'                      => '작업이 성공적으로 실행되었습니다.',
+                'fetch-failed'                 => '가져오기 실패.',
+                'action'                       => '일괄 편집',
+                'description'                  => '여러 제품을 한 번에 편집합니다. 변경 사항은 백그라운드에서 처리됩니다.',
+                'gallery-preview'              => '갤러리 미리보기',
+                'img-preview'                  => '이미지 미리보기',
+                'no-image'                     => '이미지 없음',
+                'img-fail'                     => '이미지 업로드 실패',
+                'no-option'                    => '옵션 없음',
+                'keyboard-shortcuts'           => '키보드 단축키',
+                'shortcuts-navigation'         => '탐색',
+                'shortcuts-editing'            => '편집',
+                'shortcuts-selection'          => '선택',
+                'shortcuts-clipboard'          => '클립보드 및 채우기',
+                'shortcuts-move-cell'          => '셀 간 이동',
+                'shortcuts-move-down'          => '아래로 이동 / 편집 확인',
+                'shortcuts-move-up'            => '위로 이동',
+                'shortcuts-move-right-left'    => '오른쪽 / 왼쪽으로 이동',
+                'shortcuts-home-end'           => '행의 첫 번째 / 마지막 열',
+                'shortcuts-ctrl-home-end'      => '그리드의 첫 번째 / 마지막 셀',
+                'shortcuts-extend-selection'   => '선택 범위 확장',
+                'shortcuts-select-all'         => '모든 셀 선택',
+                'shortcuts-enter-edit'         => '편집 모드 진입',
+                'shortcuts-confirm-move-down'  => '확인 + 아래로 이동',
+                'shortcuts-confirm-move-right' => '확인 + 오른쪽으로 이동',
+                'shortcuts-escape-revert'      => '값 되돌리기 + 편집 종료',
+                'shortcuts-clear-cell'         => '셀 지우기',
+                'shortcuts-copy'               => '복사',
+                'shortcuts-cut'                => '잘라내기',
+                'shortcuts-paste'              => '붙여넣기',
+                'shortcuts-fill-down'          => '아래로 채우기',
+                'shortcuts-fill-right'         => '오른쪽으로 채우기',
+                'shortcuts-undo'               => '실행 취소',
+                'shortcuts-redo'               => '다시 실행',
+                'shortcuts-help'               => '키보드 단축키 표시/숨기기',
             ],
             'create-success'          => '제품이 성공적으로 생성되었습니다',
             'delete-failed'           => '제품 삭제 실패',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => '필터링 가능',
                 'ai-translate'          => 'AI 번역',
                 'invalid-swatch-type'   => ':attribute는 스와치 유형 :swatch_type의 속성 유형 :type에 대해 허용되지 않습니다.',
-
                 'single-object-only'    => '각 생성 요청은 속성 객체를 하나만 보내야 합니다.',
                 'option'                => [
                     'color'    => '샘플 색상',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => '속성 삭제 성공',
             'update-success'    => '속성 수정 성공',
             'user-define-error' => '시스템 속성은 삭제할 수 없습니다',
-
             'immutable-fields'  => '다음 필드는 수정할 수 없습니다: :fields.',
             'not-found'         => '코드 ":code"에 해당하는 속성을 찾을 수 없습니다',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => '카테고리 필드 업데이트 성공',
             'user-define-error' => '시스템 카테고리 필드는 삭제할 수 없습니다.',
             'not-found'         => '코드 ":code"의 카테고리 필드를 찾을 수 없습니다.',
-
             'immutable-fields'  => '다음 필드는 수정할 수 없습니다: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => '이 가족에는 이미 제품 변형이 있어 구성 옵션을 업데이트할 수 없습니다.',
         ],
         'history' => [
-            'view' => '버전 세부 정보 보기',
-
+            'view'  => '버전 세부 정보 보기',
             'index' => [
                 'datagrid' => [
                     'version'   => '버전',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => '일시 중지됨',
                         'cancelled'            => '취소됨',
                         'failed'               => '실패',
-
-                        'view'       => '보기',
+                        'view'                 => '보기',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => '프롬프트',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => '제목',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => '시스템 프롬프트',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => '제목',
@@ -2011,8 +1997,9 @@ return [
                     'title' => '필터',
                 ],
                 'search_by' => [
-                    'code'       => '코드로 검색',
-                    'code_or_id' => '코드 또는 ID로 검색',
+                    'code'        => '코드로 검색',
+                    'code_or_id'  => '코드 또는 ID로 검색',
+                    'sku_or_user' => 'SKU 또는 사용자로 검색',
                 ],
                 'search' => [
                     'title' => '검색',

--- a/packages/Webkul/Admin/src/Resources/lang/mn_MN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/mn_MN/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Зөв URL оруулна уу.',
                     'regex'                      => 'Утга шаардлагатай загварт тохирохгүй байна.',
                     'invalid-pattern'            => 'Буруу хэрэглэгчийн загвар өгөгдсөн.',
-
                     'numeric'                    => '«:attribute» тоон шинж чанарын утга зөв тоо байх ёстой.',
                     'select-attribute-or-family' => 'Дор хаяж нэг атрибут эсвэл атрибутын бүлгийг сонгоно уу.',
                     'failed'                     => 'Шалгалт амжилтгүй боллоо.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Бөөнөөр засвар амжилттай.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Хадгалах өөрчлөлт алга.',
-
-                'invalid-datetime'            => 'Хүчинтэй огноо, цаг оруулна уу.',
-
-                'resize-column'               => 'Баганы өргөнийг өөрчлөх',
-                'success'                     => 'Ажил амжилттай гүйцэтгэгдлээ.',
-                'fetch-failed'                => 'Мэдээлэл татаж чадсангүй.',
-                'action'                      => 'Бөөнөөр засах',
-                'description'                 => 'Олон бүтээгдэхүүнийг нэг дор засварлана. Өөрчлөлтүүд цаана нь боловсруулагдана.',
-                'gallery-preview'             => 'Галлерейн урьдчилсан харагдац',
-                'img-preview'                 => 'Зургийн урьдчилсан харагдац',
-                'no-image'                    => 'Зураг алга',
-                'img-fail'                    => 'Зураг байршуулах амжилтгүй боллоо',
-                'no-option'                   => 'Сонголт байхгүй',
-                'keyboard-shortcuts'          => 'Гарын товчлолууд',
-                'shortcuts-navigation'        => 'Навигаци',
-                'shortcuts-editing'           => 'Засварлах',
-                'shortcuts-selection'         => 'Сонголт',
-                'shortcuts-clipboard'         => 'Хурамтлуур ба дүүргэх',
-                'shortcuts-move-cell'         => 'Нүднүүдийн хооронд шилжих',
-                'shortcuts-move-down'         => 'Доош шилжих / засварыг баталгаажуулах',
-                'shortcuts-move-up'           => 'Дээш шилжих',
-                'shortcuts-move-right-left'   => 'Баруун / зүүн тийш шилжих',
-                'shortcuts-home-end'          => 'Мөрийн эхний / сүүлийн багана',
-                'shortcuts-ctrl-home-end'     => 'Хүснэгтийн эхний / сүүлийн нүд',
-                'shortcuts-extend-selection'  => 'Сонголтыг өргөтгөх',
-                'shortcuts-select-all'        => 'Бүх нүдийг сонгох',
-                'shortcuts-enter-edit'        => 'Засварлах горимд орох',
-                'shortcuts-confirm-move-down' => 'Баталгаажуулах + доош шилжих',
-                'shortcuts-confirm-move-right'=> 'Баталгаажуулах + баруун тийш шилжих',
-                'shortcuts-escape-revert'     => 'Утгыг сэргээх + засварлахаас гарах',
-                'shortcuts-clear-cell'        => 'Нүдийг цэвэрлэх',
-                'shortcuts-copy'              => 'Хуулах',
-                'shortcuts-cut'               => 'Тайрах',
-                'shortcuts-paste'             => 'Буулгах',
-                'shortcuts-fill-down'         => 'Доош дүүргэх',
-                'shortcuts-fill-right'        => 'Баруун тийш дүүргэх',
-                'shortcuts-undo'              => 'Буцаах',
-                'shortcuts-redo'              => 'Дахин хийх',
-                'shortcuts-help'              => 'Гарын товчлолуудыг харуулах/нуух',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Хадгалах өөрчлөлт алга.',
+                'invalid-datetime'             => 'Хүчинтэй огноо, цаг оруулна уу.',
+                'resize-column'                => 'Баганы өргөнийг өөрчлөх',
+                'success'                      => 'Ажил амжилттай гүйцэтгэгдлээ.',
+                'fetch-failed'                 => 'Мэдээлэл татаж чадсангүй.',
+                'action'                       => 'Бөөнөөр засах',
+                'description'                  => 'Олон бүтээгдэхүүнийг нэг дор засварлана. Өөрчлөлтүүд цаана нь боловсруулагдана.',
+                'gallery-preview'              => 'Галлерейн урьдчилсан харагдац',
+                'img-preview'                  => 'Зургийн урьдчилсан харагдац',
+                'no-image'                     => 'Зураг алга',
+                'img-fail'                     => 'Зураг байршуулах амжилтгүй боллоо',
+                'no-option'                    => 'Сонголт байхгүй',
+                'keyboard-shortcuts'           => 'Гарын товчлолууд',
+                'shortcuts-navigation'         => 'Навигаци',
+                'shortcuts-editing'            => 'Засварлах',
+                'shortcuts-selection'          => 'Сонголт',
+                'shortcuts-clipboard'          => 'Хурамтлуур ба дүүргэх',
+                'shortcuts-move-cell'          => 'Нүднүүдийн хооронд шилжих',
+                'shortcuts-move-down'          => 'Доош шилжих / засварыг баталгаажуулах',
+                'shortcuts-move-up'            => 'Дээш шилжих',
+                'shortcuts-move-right-left'    => 'Баруун / зүүн тийш шилжих',
+                'shortcuts-home-end'           => 'Мөрийн эхний / сүүлийн багана',
+                'shortcuts-ctrl-home-end'      => 'Хүснэгтийн эхний / сүүлийн нүд',
+                'shortcuts-extend-selection'   => 'Сонголтыг өргөтгөх',
+                'shortcuts-select-all'         => 'Бүх нүдийг сонгох',
+                'shortcuts-enter-edit'         => 'Засварлах горимд орох',
+                'shortcuts-confirm-move-down'  => 'Баталгаажуулах + доош шилжих',
+                'shortcuts-confirm-move-right' => 'Баталгаажуулах + баруун тийш шилжих',
+                'shortcuts-escape-revert'      => 'Утгыг сэргээх + засварлахаас гарах',
+                'shortcuts-clear-cell'         => 'Нүдийг цэвэрлэх',
+                'shortcuts-copy'               => 'Хуулах',
+                'shortcuts-cut'                => 'Тайрах',
+                'shortcuts-paste'              => 'Буулгах',
+                'shortcuts-fill-down'          => 'Доош дүүргэх',
+                'shortcuts-fill-right'         => 'Баруун тийш дүүргэх',
+                'shortcuts-undo'               => 'Буцаах',
+                'shortcuts-redo'               => 'Дахин хийх',
+                'shortcuts-help'               => 'Гарын товчлолуудыг харуулах/нуух',
             ],
             'create-success'          => 'Бүтээгдэхүүн амжилттай бүтээгдсэн',
             'delete-failed'           => 'Бүтээгдэхүүнийг устгасан бүтэлгүйтэв',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Шүүж болох',
                 'ai-translate'          => 'ХИ Орчуулга',
                 'invalid-swatch-type'   => ':attribute нь :type төрлийн шинж чанарт :swatch_type өнгөний төрлийг ашиглахыг зөвшөөрөхгүй.',
-
                 'single-object-only'    => 'Үүсгэх хүсэлт бүр нь зөвхөн нэг шинж чанарын объект илгээх ёстой.',
                 'option'                => [
                     'color'    => 'Өнгөт сэлгэлт',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Аттрибут амжилттай устгасан',
             'update-success'    => 'Аттрибут амжилттай шинэчлэгдсэн',
             'user-define-error' => 'Системийн шинж чанарыг устгах боломжгүй',
-
             'immutable-fields'  => 'Дараах талбаруудыг өөрчилөх боломжгүй: :fields.',
             'not-found'         => '":code" кодтой атрибут олдсонгүй',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Ангилалын талбар амжилттай шинэчлэгдсэн',
             'user-define-error' => 'Системийн ангиллын талбарыг устгах боломжгүй',
             'not-found'         => '":code" кодтой ангиллын талбар олдсонгүй',
-
             'immutable-fields'  => 'Дараах талбаруудыг өөрчилөх боломжгүй: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Энэ гэр бүлд аль хэдийн хувьсагчдын хувилбаруудтай тохируулах сонголтыг шинэчлэх боломжгүй байна.',
         ],
         'history' => [
-            'view' => 'Хувилбарын дэлгэрэнгүйг харах',
-
+            'view'  => 'Хувилбарын дэлгэрэнгүйг харах',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Таамаглал',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Түр зогссон',
                         'cancelled'            => 'Цуцлагдсан',
                         'failed'               => 'Амсхийээгүй',
-
-                        'view'       => 'Харах',
+                        'view'                 => 'Харах',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Санамжууд',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Гарчиг',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Системийн санамжууд',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Гарчиг',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Шүүх',
                 ],
                 'search_by' => [
-                    'code'       => 'Кодоор хайлт хийх',
-                    'code_or_id' => 'Код эсвэл ID-ээр хайх',
+                    'code'        => 'Кодоор хайлт хийх',
+                    'code_or_id'  => 'Код эсвэл ID-ээр хайх',
+                    'sku_or_user' => 'SKU эсвэл хэрэглэгчээр хайх',
                 ],
                 'search' => [
                     'title' => 'Эрэл хайгуул хийх',

--- a/packages/Webkul/Admin/src/Resources/lang/nl_NL/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl_NL/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Voer een geldige URL in.',
                     'regex'                      => 'Waarde komt niet overeen met het vereiste patroon.',
                     'invalid-pattern'            => 'Ongeldig aangepast patroon opgegeven.',
-
                     'numeric'                    => 'De waarde voor het numerieke attribuut ":attribute" moet een geldig getal zijn.',
                     'select-attribute-or-family' => 'Selecteer ten minste één attribuut of een attribuutset.',
                     'failed'                     => 'Validatie mislukt.',
@@ -385,45 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Bulkbewerking succesvol uitgevoerd.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Geen wijzigingen om op te slaan.',
-                'invalid-datetime'            => 'Voer een geldige datum en tijd in.',
-                'resize-column'               => 'Sleep om de kolom te vergroten of verkleinen.',
-                'success'                     => 'Taak succesvol uitgevoerd.',
-                'fetch-failed'                => 'Ophalen mislukt.',
-                'action'                      => 'Bulkbewerken',
-                'description'                 => 'Bewerk meerdere producten tegelijk. Wijzigingen worden op de achtergrond verwerkt.',
-                'gallery-preview'             => 'Galerijvoorbeeld',
-                'img-preview'                 => 'Afbeeldingsvoorbeeld',
-                'no-image'                    => 'Geen afbeelding',
-                'img-fail'                    => 'Uploaden van afbeelding mislukt.',
-                'no-option'                   => 'Geen opties',
-                'keyboard-shortcuts'          => 'Sneltoetsen',
-                'shortcuts-navigation'        => 'Navigatie',
-                'shortcuts-editing'           => 'Bewerken',
-                'shortcuts-selection'         => 'Selectie',
-                'shortcuts-clipboard'         => 'Klembord en invullen',
-                'shortcuts-move-cell'         => 'Bewegen tussen cellen',
-                'shortcuts-move-down'         => 'Naar beneden / bewerking bevestigen',
-                'shortcuts-move-up'           => 'Naar boven',
-                'shortcuts-move-right-left'   => 'Naar rechts / links',
-                'shortcuts-home-end'          => 'Eerste / laatste kolom in rij',
-                'shortcuts-ctrl-home-end'     => 'Eerste / laatste cel in raster',
-                'shortcuts-extend-selection'  => 'Selectie uitbreiden',
-                'shortcuts-select-all'        => 'Alle cellen selecteren',
-                'shortcuts-enter-edit'        => 'Bewerkingsmodus activeren',
-                'shortcuts-confirm-move-down' => 'Bevestigen + naar beneden',
-                'shortcuts-confirm-move-right'=> 'Bevestigen + naar rechts',
-                'shortcuts-escape-revert'     => 'Waarde herstellen + bewerking verlaten',
-                'shortcuts-clear-cell'        => 'Cel wissen',
-                'shortcuts-copy'              => 'Kopiëren',
-                'shortcuts-cut'               => 'Knippen',
-                'shortcuts-paste'             => 'Plakken',
-                'shortcuts-fill-down'         => 'Naar beneden vullen',
-                'shortcuts-fill-right'        => 'Naar rechts vullen',
-                'shortcuts-undo'              => 'Ongedaan maken',
-                'shortcuts-redo'              => 'Opnieuw uitvoeren',
-                'shortcuts-help'              => 'Sneltoetsen weergeven/verbergen',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Geen wijzigingen om op te slaan.',
+                'invalid-datetime'             => 'Voer een geldige datum en tijd in.',
+                'resize-column'                => 'Sleep om de kolom te vergroten of verkleinen.',
+                'success'                      => 'Taak succesvol uitgevoerd.',
+                'fetch-failed'                 => 'Ophalen mislukt.',
+                'action'                       => 'Bulkbewerken',
+                'description'                  => 'Bewerk meerdere producten tegelijk. Wijzigingen worden op de achtergrond verwerkt.',
+                'gallery-preview'              => 'Galerijvoorbeeld',
+                'img-preview'                  => 'Afbeeldingsvoorbeeld',
+                'no-image'                     => 'Geen afbeelding',
+                'img-fail'                     => 'Uploaden van afbeelding mislukt.',
+                'no-option'                    => 'Geen opties',
+                'keyboard-shortcuts'           => 'Sneltoetsen',
+                'shortcuts-navigation'         => 'Navigatie',
+                'shortcuts-editing'            => 'Bewerken',
+                'shortcuts-selection'          => 'Selectie',
+                'shortcuts-clipboard'          => 'Klembord en invullen',
+                'shortcuts-move-cell'          => 'Bewegen tussen cellen',
+                'shortcuts-move-down'          => 'Naar beneden / bewerking bevestigen',
+                'shortcuts-move-up'            => 'Naar boven',
+                'shortcuts-move-right-left'    => 'Naar rechts / links',
+                'shortcuts-home-end'           => 'Eerste / laatste kolom in rij',
+                'shortcuts-ctrl-home-end'      => 'Eerste / laatste cel in raster',
+                'shortcuts-extend-selection'   => 'Selectie uitbreiden',
+                'shortcuts-select-all'         => 'Alle cellen selecteren',
+                'shortcuts-enter-edit'         => 'Bewerkingsmodus activeren',
+                'shortcuts-confirm-move-down'  => 'Bevestigen + naar beneden',
+                'shortcuts-confirm-move-right' => 'Bevestigen + naar rechts',
+                'shortcuts-escape-revert'      => 'Waarde herstellen + bewerking verlaten',
+                'shortcuts-clear-cell'         => 'Cel wissen',
+                'shortcuts-copy'               => 'Kopiëren',
+                'shortcuts-cut'                => 'Knippen',
+                'shortcuts-paste'              => 'Plakken',
+                'shortcuts-fill-down'          => 'Naar beneden vullen',
+                'shortcuts-fill-right'         => 'Naar rechts vullen',
+                'shortcuts-undo'               => 'Ongedaan maken',
+                'shortcuts-redo'               => 'Opnieuw uitvoeren',
+                'shortcuts-help'               => 'Sneltoetsen weergeven/verbergen',
             ],
             'create-success'          => 'Product succesvol aangemaakt.',
             'delete-failed'           => 'Product verwijderen mislukt.',
@@ -518,7 +517,6 @@ return [
                 'is-filterable'         => 'Filterbaar',
                 'ai-translate'          => 'AI-vertaling',
                 'invalid-swatch-type'   => 'De :attribute is niet toegestaan voor attribuuttype :type met staaltype :swatch_type.',
-
                 'single-object-only'    => 'Per aanvraag mag slechts één attribuutobject worden aangemaakt.',
                 'option'                => [
                     'color'    => 'Kleurstaal',
@@ -602,7 +600,6 @@ return [
             'delete-success'    => 'Attribuut succesvol verwijderd.',
             'update-success'    => 'Attribuut succesvol bijgewerkt.',
             'user-define-error' => 'Kan het systeemattribuut niet verwijderen.',
-
             'immutable-fields'  => 'De volgende velden kunnen niet worden gewijzigd: :fields.',
             'not-found'         => 'Attribuut met code ":code" kon niet worden gevonden.',
         ],
@@ -885,7 +882,6 @@ return [
             'update-success'    => 'Categorieveld succesvol bijgewerkt.',
             'user-define-error' => 'Kan het systeemcategorieveld niet verwijderen.',
             'not-found'         => 'Categorieveld met code ":code" kon niet worden gevonden.',
-
             'immutable-fields'  => 'De volgende velden kunnen niet worden gewijzigd: :fields.',
         ],
         'category-fields-options' => [
@@ -987,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Kan configureerbare opties niet bijwerken, omdat deze attribuutset al variantproducten heeft.',
         ],
         'history' => [
-            'view' => 'Versiedetails bekijken',
-
+            'view'  => 'Versiedetails bekijken',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versie',
@@ -1122,8 +1117,7 @@ return [
                         'paused'               => 'Gepauzeerd',
                         'cancelled'            => 'Geannuleerd',
                         'failed'               => 'Mislukt',
-
-                        'view'       => 'Bekijken',
+                        'view'                 => 'Bekijken',
                     ],
                 ],
                 'import' => [
@@ -1781,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titel',
@@ -1829,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Systeemprompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titel',
@@ -2009,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Zoeken op code',
-                    'code_or_id' => 'Zoek op code of ID',
+                    'code'        => 'Zoeken op code',
+                    'code_or_id'  => 'Zoek op code of ID',
+                    'sku_or_user' => 'Zoeken op SKU of gebruiker',
                 ],
                 'search' => [
                     'title' => 'Zoeken',

--- a/packages/Webkul/Admin/src/Resources/lang/no_NO/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/no_NO/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Vennligst oppgi en gyldig URL.',
                     'regex'                      => 'Verdien samsvarer ikke med det nødvendige mønsteret.',
                     'invalid-pattern'            => 'Ugyldig egendefinert mønster angitt.',
-
                     'numeric'                    => 'Verdien for det numeriske attributtet «:attribute» må være et gyldig tall.',
                     'select-attribute-or-family' => 'Vennligst velg minst ett attributt eller en attributtfamilie.',
                     'failed'                     => 'Validering mislyktes.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Masseendring vellykket.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Ingen endringer å lagre.',
-
-                'invalid-datetime'            => 'Angi en gyldig dato og et gyldig klokkeslett.',
-
-                'resize-column'               => 'Dra for å endre kolonnebredde',
-                'success'                     => 'Jobb fullført.',
-                'fetch-failed'                => 'Henting mislyktes.',
-                'action'                      => 'Masseendring',
-                'description'                 => 'Rediger flere produkter samtidig. Endringene behandles i bakgrunnen.',
-                'gallery-preview'             => 'Galleri forhåndsvisning',
-                'img-preview'                 => 'Bilde forhåndsvisning',
-                'no-image'                    => 'Ingen bilde',
-                'img-fail'                    => 'Opplasting av bilde mislyktes',
-                'no-option'                   => 'Ingen alternativer',
-                'keyboard-shortcuts'          => 'Tastatursnarveier',
-                'shortcuts-navigation'        => 'Navigasjon',
-                'shortcuts-editing'           => 'Redigering',
-                'shortcuts-selection'         => 'Utvalg',
-                'shortcuts-clipboard'         => 'Utklippstavle og fyll',
-                'shortcuts-move-cell'         => 'Flytt mellom celler',
-                'shortcuts-move-down'         => 'Flytt ned / bekreft redigering',
-                'shortcuts-move-up'           => 'Flytt opp',
-                'shortcuts-move-right-left'   => 'Flytt til høyre / venstre',
-                'shortcuts-home-end'          => 'Første / siste kolonne i raden',
-                'shortcuts-ctrl-home-end'     => 'Første / siste celle i rutenettet',
-                'shortcuts-extend-selection'  => 'Utvid utvalget',
-                'shortcuts-select-all'        => 'Velg alle celler',
-                'shortcuts-enter-edit'        => 'Gå til redigeringsmodus',
-                'shortcuts-confirm-move-down' => 'Bekreft + flytt ned',
-                'shortcuts-confirm-move-right'=> 'Bekreft + flytt til høyre',
-                'shortcuts-escape-revert'     => 'Gjenopprett verdi + avslutt redigering',
-                'shortcuts-clear-cell'        => 'Tøm celle',
-                'shortcuts-copy'              => 'Kopier',
-                'shortcuts-cut'               => 'Klipp ut',
-                'shortcuts-paste'             => 'Lim inn',
-                'shortcuts-fill-down'         => 'Fyll nedover',
-                'shortcuts-fill-right'        => 'Fyll til høyre',
-                'shortcuts-undo'              => 'Angre',
-                'shortcuts-redo'              => 'Gjør om',
-                'shortcuts-help'              => 'Vis/skjul tastatursnarveier',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Ingen endringer å lagre.',
+                'invalid-datetime'             => 'Angi en gyldig dato og et gyldig klokkeslett.',
+                'resize-column'                => 'Dra for å endre kolonnebredde',
+                'success'                      => 'Jobb fullført.',
+                'fetch-failed'                 => 'Henting mislyktes.',
+                'action'                       => 'Masseendring',
+                'description'                  => 'Rediger flere produkter samtidig. Endringene behandles i bakgrunnen.',
+                'gallery-preview'              => 'Galleri forhåndsvisning',
+                'img-preview'                  => 'Bilde forhåndsvisning',
+                'no-image'                     => 'Ingen bilde',
+                'img-fail'                     => 'Opplasting av bilde mislyktes',
+                'no-option'                    => 'Ingen alternativer',
+                'keyboard-shortcuts'           => 'Tastatursnarveier',
+                'shortcuts-navigation'         => 'Navigasjon',
+                'shortcuts-editing'            => 'Redigering',
+                'shortcuts-selection'          => 'Utvalg',
+                'shortcuts-clipboard'          => 'Utklippstavle og fyll',
+                'shortcuts-move-cell'          => 'Flytt mellom celler',
+                'shortcuts-move-down'          => 'Flytt ned / bekreft redigering',
+                'shortcuts-move-up'            => 'Flytt opp',
+                'shortcuts-move-right-left'    => 'Flytt til høyre / venstre',
+                'shortcuts-home-end'           => 'Første / siste kolonne i raden',
+                'shortcuts-ctrl-home-end'      => 'Første / siste celle i rutenettet',
+                'shortcuts-extend-selection'   => 'Utvid utvalget',
+                'shortcuts-select-all'         => 'Velg alle celler',
+                'shortcuts-enter-edit'         => 'Gå til redigeringsmodus',
+                'shortcuts-confirm-move-down'  => 'Bekreft + flytt ned',
+                'shortcuts-confirm-move-right' => 'Bekreft + flytt til høyre',
+                'shortcuts-escape-revert'      => 'Gjenopprett verdi + avslutt redigering',
+                'shortcuts-clear-cell'         => 'Tøm celle',
+                'shortcuts-copy'               => 'Kopier',
+                'shortcuts-cut'                => 'Klipp ut',
+                'shortcuts-paste'              => 'Lim inn',
+                'shortcuts-fill-down'          => 'Fyll nedover',
+                'shortcuts-fill-right'         => 'Fyll til høyre',
+                'shortcuts-undo'               => 'Angre',
+                'shortcuts-redo'               => 'Gjør om',
+                'shortcuts-help'               => 'Vis/skjul tastatursnarveier',
             ],
             'create-success'          => 'Produkt opprettet vellykket',
             'delete-failed'           => 'Sletting av produkt mislyktes',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Er filtrerbar',
                 'ai-translate'          => 'AI Oversettelse',
                 'invalid-swatch-type'   => ':attribute er ikke tillatt for attributttype :type med fargeprøvetype :swatch_type.',
-
                 'single-object-only'    => 'Hver opprettelsesforespørsel må inneholde kun ett attributtobjekt.',
                 'option'                => [
                     'color'    => 'Fargeprøve',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attributt slettet',
             'update-success'    => 'Attributt oppdatert',
             'user-define-error' => 'Kan ikke slette systemattributt',
-
             'immutable-fields'  => 'Følgende felter kan ikke endres: :fields.',
             'not-found'         => 'Fant ikke attributt med kode ":code"',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Kategorifelt Oppdatert',
             'user-define-error' => 'Kan ikke slette system Kategorifelt',
             'not-found'         => 'Kategorifelt med kode ":code" ble ikke funnet',
-
             'immutable-fields'  => 'Følgende felter kan ikke endres: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Kan ikke oppdatere konfigurasjonsalternativer, fordi denne familien allerede har produktvarianter.',
         ],
         'history' => [
-            'view' => 'Vis versjonsdetaljer',
-
+            'view'  => 'Vis versjonsdetaljer',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versjon',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Satt på pause',
                         'cancelled'            => 'Avbrutt',
                         'failed'               => 'Mislyktes',
-
-                        'view'       => 'Vis',
+                        'view'                 => 'Vis',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Tittel',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Systemprompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Tittel',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Søk etter kode',
-                    'code_or_id' => 'Søk etter kode eller id',
+                    'code'        => 'Søk etter kode',
+                    'code_or_id'  => 'Søk etter kode eller id',
+                    'sku_or_user' => 'Søk etter SKU eller bruker',
                 ],
                 'search' => [
                     'title' => 'Søk',

--- a/packages/Webkul/Admin/src/Resources/lang/pl_PL/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pl_PL/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Wprowadź poprawny adres URL.',
                     'regex'                      => 'Wartość nie pasuje do wymaganego wzoru.',
                     'invalid-pattern'            => 'Podano nieprawidłowy własny wzorzec.',
-
                     'numeric'                    => 'Wartość numerycznego atrybutu „:attribute” musi być prawidłową liczbą.',
                     'select-attribute-or-family' => 'Proszę wybrać co najmniej jeden atrybut lub rodzinę atrybutów.',
                     'failed'                     => 'Walidacja nie powiodła się.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Edycja zbiorcza zakończona sukcesem.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Brak zmian do zapisania.',
-
-                'invalid-datetime'            => 'Wprowadź prawidłową datę i godzinę.',
-
-                'resize-column'               => 'Przeciągnij, aby zmienić szerokość kolumny',
-                'success'                     => 'Zadanie zostało pomyślnie wykonane.',
-                'fetch-failed'                => 'Nie udało się pobrać.',
-                'action'                      => 'Edycja zbiorcza',
-                'description'                 => 'Edytuj wiele produktów jednocześnie. Zmiany są przetwarzane w tle.',
-                'gallery-preview'             => 'Podgląd galerii',
-                'img-preview'                 => 'Podgląd obrazu',
-                'no-image'                    => 'Brak obrazu',
-                'img-fail'                    => 'Przesyłanie obrazu nie powiodło się',
-                'no-option'                   => 'Brak opcji',
-                'keyboard-shortcuts'          => 'Skróty klawiszowe',
-                'shortcuts-navigation'        => 'Nawigacja',
-                'shortcuts-editing'           => 'Edycja',
-                'shortcuts-selection'         => 'Zaznaczenie',
-                'shortcuts-clipboard'         => 'Schowek i wypełnianie',
-                'shortcuts-move-cell'         => 'Poruszanie się między komórkami',
-                'shortcuts-move-down'         => 'Przesuń w dół / potwierdź edycję',
-                'shortcuts-move-up'           => 'Przesuń w górę',
-                'shortcuts-move-right-left'   => 'Przesuń w prawo / w lewo',
-                'shortcuts-home-end'          => 'Pierwsza / ostatnia kolumna w wierszu',
-                'shortcuts-ctrl-home-end'     => 'Pierwsza / ostatnia komórka w siatce',
-                'shortcuts-extend-selection'  => 'Rozszerz zaznaczenie',
-                'shortcuts-select-all'        => 'Zaznacz wszystkie komórki',
-                'shortcuts-enter-edit'        => 'Wejdź w tryb edycji',
-                'shortcuts-confirm-move-down' => 'Potwierdź + przesuń w dół',
-                'shortcuts-confirm-move-right'=> 'Potwierdź + przesuń w prawo',
-                'shortcuts-escape-revert'     => 'Przywróć wartość + wyjdź z edycji',
-                'shortcuts-clear-cell'        => 'Wyczyść komórkę',
-                'shortcuts-copy'              => 'Kopiuj',
-                'shortcuts-cut'               => 'Wytnij',
-                'shortcuts-paste'             => 'Wklej',
-                'shortcuts-fill-down'         => 'Wypełnij w dół',
-                'shortcuts-fill-right'        => 'Wypełnij w prawo',
-                'shortcuts-undo'              => 'Cofnij',
-                'shortcuts-redo'              => 'Ponów',
-                'shortcuts-help'              => 'Pokaż/ukryj skróty klawiszowe',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Brak zmian do zapisania.',
+                'invalid-datetime'             => 'Wprowadź prawidłową datę i godzinę.',
+                'resize-column'                => 'Przeciągnij, aby zmienić szerokość kolumny',
+                'success'                      => 'Zadanie zostało pomyślnie wykonane.',
+                'fetch-failed'                 => 'Nie udało się pobrać.',
+                'action'                       => 'Edycja zbiorcza',
+                'description'                  => 'Edytuj wiele produktów jednocześnie. Zmiany są przetwarzane w tle.',
+                'gallery-preview'              => 'Podgląd galerii',
+                'img-preview'                  => 'Podgląd obrazu',
+                'no-image'                     => 'Brak obrazu',
+                'img-fail'                     => 'Przesyłanie obrazu nie powiodło się',
+                'no-option'                    => 'Brak opcji',
+                'keyboard-shortcuts'           => 'Skróty klawiszowe',
+                'shortcuts-navigation'         => 'Nawigacja',
+                'shortcuts-editing'            => 'Edycja',
+                'shortcuts-selection'          => 'Zaznaczenie',
+                'shortcuts-clipboard'          => 'Schowek i wypełnianie',
+                'shortcuts-move-cell'          => 'Poruszanie się między komórkami',
+                'shortcuts-move-down'          => 'Przesuń w dół / potwierdź edycję',
+                'shortcuts-move-up'            => 'Przesuń w górę',
+                'shortcuts-move-right-left'    => 'Przesuń w prawo / w lewo',
+                'shortcuts-home-end'           => 'Pierwsza / ostatnia kolumna w wierszu',
+                'shortcuts-ctrl-home-end'      => 'Pierwsza / ostatnia komórka w siatce',
+                'shortcuts-extend-selection'   => 'Rozszerz zaznaczenie',
+                'shortcuts-select-all'         => 'Zaznacz wszystkie komórki',
+                'shortcuts-enter-edit'         => 'Wejdź w tryb edycji',
+                'shortcuts-confirm-move-down'  => 'Potwierdź + przesuń w dół',
+                'shortcuts-confirm-move-right' => 'Potwierdź + przesuń w prawo',
+                'shortcuts-escape-revert'      => 'Przywróć wartość + wyjdź z edycji',
+                'shortcuts-clear-cell'         => 'Wyczyść komórkę',
+                'shortcuts-copy'               => 'Kopiuj',
+                'shortcuts-cut'                => 'Wytnij',
+                'shortcuts-paste'              => 'Wklej',
+                'shortcuts-fill-down'          => 'Wypełnij w dół',
+                'shortcuts-fill-right'         => 'Wypełnij w prawo',
+                'shortcuts-undo'               => 'Cofnij',
+                'shortcuts-redo'               => 'Ponów',
+                'shortcuts-help'               => 'Pokaż/ukryj skróty klawiszowe',
             ],
             'create-success'          => 'Produkt został pomyślnie utworzony',
             'delete-failed'           => 'Usuwanie produktu nie powiodło się',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Jest filtrowalne',
                 'ai-translate'          => 'Tłumaczenie SI',
                 'invalid-swatch-type'   => 'Atrybut :attribute nie jest dozwolony dla typu atrybutu :type z typem próbki :swatch_type.',
-
                 'single-object-only'    => 'Każde żądanie tworzenia musi zawierać tylko jeden obiekt atrybutu.',
                 'option'                => [
                     'color'    => 'Kolor próbki',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atrybut usunięty',
             'update-success'    => 'Atrybut zaktualizowany',
             'user-define-error' => 'Nie można usunąć atrybutu systemowego',
-
             'immutable-fields'  => 'Następujących pól nie można zmodyfikować: :fields.',
             'not-found'         => 'Nie znaleziono atrybutu o kodzie ":code"',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Pole kategorii zostało zaktualizowane',
             'user-define-error' => 'Nie można usunąć systemowego pola kategorii',
             'not-found'         => 'Nie znaleziono pola kategorii o kodzie ":code"',
-
             'immutable-fields'  => 'Następujących pól nie można zmodyfikować: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Nie można zaktualizować opcji konfiguracji, ponieważ ta rodzina ma już warianty produktów.',
         ],
         'history' => [
-            'view' => 'Wyświetl szczegóły wersji',
-
+            'view'  => 'Wyświetl szczegóły wersji',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Wersja',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Wstrzymano',
                         'cancelled'            => 'Anulowano',
                         'failed'               => 'Niepowodzenie',
-
-                        'view'       => 'Zobacz',
+                        'view'                 => 'Zobacz',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompty',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Tytuł',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompty systemowe',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Tytuł',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtr',
                 ],
                 'search_by' => [
-                    'code'       => 'Szukaj po kodzie',
-                    'code_or_id' => 'Szukaj po kodzie lub ID',
+                    'code'        => 'Szukaj po kodzie',
+                    'code_or_id'  => 'Szukaj po kodzie lub ID',
+                    'sku_or_user' => 'Szukaj po SKU lub użytkowniku',
                 ],
                 'search' => [
                     'title' => 'Szukaj',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Por favor, insira uma URL válida.',
                     'regex'                      => 'O valor não corresponde ao padrão exigido.',
                     'invalid-pattern'            => 'Padrão personalizado inválido fornecido.',
-
                     'numeric'                    => 'O valor do atributo numérico ":attribute" deve ser um número válido.',
                     'select-attribute-or-family' => 'Selecione pelo menos um atributo ou uma família de atributos.',
                     'failed'                     => 'A validação falhou.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Edição em massa realizada com sucesso.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Nenhuma alteração para salvar.',
-
-                'invalid-datetime'            => 'Informe uma data e hora válidas.',
-
-                'resize-column'               => 'Arraste para redimensionar a coluna',
-                'success'                     => 'A tarefa foi executada com sucesso.',
-                'fetch-failed'                => 'Falha ao buscar.',
-                'action'                      => 'Edição em massa',
-                'description'                 => 'Edite vários produtos de uma vez. As alterações são processadas em segundo plano.',
-                'gallery-preview'             => 'Pré-visualização da Galeria',
-                'img-preview'                 => 'Pré-visualização da Imagem',
-                'no-image'                    => 'Sem Imagem',
-                'img-fail'                    => 'Falha no envio da imagem',
-                'no-option'                   => 'Sem opções',
-                'keyboard-shortcuts'          => 'Atalhos de teclado',
-                'shortcuts-navigation'        => 'Navegação',
-                'shortcuts-editing'           => 'Edição',
-                'shortcuts-selection'         => 'Seleção',
-                'shortcuts-clipboard'         => 'Área de transferência e preenchimento',
-                'shortcuts-move-cell'         => 'Mover entre células',
-                'shortcuts-move-down'         => 'Mover para baixo / confirmar edição',
-                'shortcuts-move-up'           => 'Mover para cima',
-                'shortcuts-move-right-left'   => 'Mover para a direita / esquerda',
-                'shortcuts-home-end'          => 'Primeira / última coluna na linha',
-                'shortcuts-ctrl-home-end'     => 'Primeira / última célula na grade',
-                'shortcuts-extend-selection'  => 'Ampliar seleção',
-                'shortcuts-select-all'        => 'Selecionar todas as células',
-                'shortcuts-enter-edit'        => 'Entrar no modo de edição',
-                'shortcuts-confirm-move-down' => 'Confirmar + mover para baixo',
-                'shortcuts-confirm-move-right'=> 'Confirmar + mover para a direita',
-                'shortcuts-escape-revert'     => 'Reverter valor + sair da edição',
-                'shortcuts-clear-cell'        => 'Limpar célula',
-                'shortcuts-copy'              => 'Copiar',
-                'shortcuts-cut'               => 'Recortar',
-                'shortcuts-paste'             => 'Colar',
-                'shortcuts-fill-down'         => 'Preencher para baixo',
-                'shortcuts-fill-right'        => 'Preencher para a direita',
-                'shortcuts-undo'              => 'Desfazer',
-                'shortcuts-redo'              => 'Refazer',
-                'shortcuts-help'              => 'Mostrar/ocultar atalhos de teclado',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Nenhuma alteração para salvar.',
+                'invalid-datetime'             => 'Informe uma data e hora válidas.',
+                'resize-column'                => 'Arraste para redimensionar a coluna',
+                'success'                      => 'A tarefa foi executada com sucesso.',
+                'fetch-failed'                 => 'Falha ao buscar.',
+                'action'                       => 'Edição em massa',
+                'description'                  => 'Edite vários produtos de uma vez. As alterações são processadas em segundo plano.',
+                'gallery-preview'              => 'Pré-visualização da Galeria',
+                'img-preview'                  => 'Pré-visualização da Imagem',
+                'no-image'                     => 'Sem Imagem',
+                'img-fail'                     => 'Falha no envio da imagem',
+                'no-option'                    => 'Sem opções',
+                'keyboard-shortcuts'           => 'Atalhos de teclado',
+                'shortcuts-navigation'         => 'Navegação',
+                'shortcuts-editing'            => 'Edição',
+                'shortcuts-selection'          => 'Seleção',
+                'shortcuts-clipboard'          => 'Área de transferência e preenchimento',
+                'shortcuts-move-cell'          => 'Mover entre células',
+                'shortcuts-move-down'          => 'Mover para baixo / confirmar edição',
+                'shortcuts-move-up'            => 'Mover para cima',
+                'shortcuts-move-right-left'    => 'Mover para a direita / esquerda',
+                'shortcuts-home-end'           => 'Primeira / última coluna na linha',
+                'shortcuts-ctrl-home-end'      => 'Primeira / última célula na grade',
+                'shortcuts-extend-selection'   => 'Ampliar seleção',
+                'shortcuts-select-all'         => 'Selecionar todas as células',
+                'shortcuts-enter-edit'         => 'Entrar no modo de edição',
+                'shortcuts-confirm-move-down'  => 'Confirmar + mover para baixo',
+                'shortcuts-confirm-move-right' => 'Confirmar + mover para a direita',
+                'shortcuts-escape-revert'      => 'Reverter valor + sair da edição',
+                'shortcuts-clear-cell'         => 'Limpar célula',
+                'shortcuts-copy'               => 'Copiar',
+                'shortcuts-cut'                => 'Recortar',
+                'shortcuts-paste'              => 'Colar',
+                'shortcuts-fill-down'          => 'Preencher para baixo',
+                'shortcuts-fill-right'         => 'Preencher para a direita',
+                'shortcuts-undo'               => 'Desfazer',
+                'shortcuts-redo'               => 'Refazer',
+                'shortcuts-help'               => 'Mostrar/ocultar atalhos de teclado',
             ],
             'create-success'          => 'Produto criado com sucesso',
             'delete-failed'           => 'Falha ao excluir o produto',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'É filtrável',
                 'ai-translate'          => 'Tradução IA',
                 'invalid-swatch-type'   => 'O :attribute não é permitido para o tipo de atributo :type com o tipo de amostra :swatch_type.',
-
                 'single-object-only'    => 'Cada requisição de criação deve enviar um único objeto de atributo.',
                 'option'                => [
                     'color'    => 'Amostra de cor',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atributo excluído',
             'update-success'    => 'Atributo atualizado',
             'user-define-error' => 'Não é possível excluir atributo do sistema',
-
             'immutable-fields'  => 'Os seguintes campos não podem ser modificados: :fields.',
             'not-found'         => 'Atributo com o código ":code" não encontrado',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Campo de categoria atualizado com sucesso',
             'user-define-error' => 'Não é possível excluir o campo de categoria do sistema',
             'not-found'         => 'Campo de categoria com o código ":code" não encontrado',
-
             'immutable-fields'  => 'Os seguintes campos não podem ser modificados: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Não é possível atualizar as opções de configuração, pois esta família já possui variantes de produtos.',
         ],
         'history' => [
-            'view' => 'Ver detalhes da versão',
-
+            'view'  => 'Ver detalhes da versão',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versão',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Pausado',
                         'cancelled'            => 'Cancelado',
                         'failed'               => 'Falhou',
-
-                        'view'       => 'Ver',
+                        'view'                 => 'Ver',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Título',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts do sistema',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Título',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtro',
                 ],
                 'search_by' => [
-                    'code'       => 'Buscar por código',
-                    'code_or_id' => 'Buscar por código ou id',
+                    'code'        => 'Buscar por código',
+                    'code_or_id'  => 'Buscar por código ou id',
+                    'sku_or_user' => 'Buscar por SKU ou usuário',
                 ],
                 'search' => [
                     'title' => 'Buscar',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_PT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_PT/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Por favor, insira um URL válido.',
                     'regex'                      => 'O valor não corresponde ao padrão requerido.',
                     'invalid-pattern'            => 'Padrão personalizado inválido fornecido.',
-
                     'numeric'                    => 'O valor do atributo numérico ":attribute" deve ser um número válido.',
                     'select-attribute-or-family' => 'Por favor, selecione pelo menos um atributo ou uma família de atributos.',
                     'failed'                     => 'A validação falhou.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Edição em massa concluída com sucesso.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Sem alterações para guardar.',
-
-                'invalid-datetime'            => 'Introduza uma data e hora válidas.',
-
-                'resize-column'               => 'Arraste para redimensionar a coluna',
-                'success'                     => 'Tarefa executada com sucesso.',
-                'fetch-failed'                => 'Falha ao obter dados.',
-                'action'                      => 'Edição em massa',
-                'description'                 => 'Edite vários produtos de uma vez. As alterações são processadas em segundo plano.',
-                'gallery-preview'             => 'Pré-visualização da Galeria',
-                'img-preview'                 => 'Pré-visualização da Imagem',
-                'no-image'                    => 'Sem imagem',
-                'img-fail'                    => 'Falha ao carregar a imagem',
-                'no-option'                   => 'Sem opções',
-                'keyboard-shortcuts'          => 'Atalhos de teclado',
-                'shortcuts-navigation'        => 'Navegação',
-                'shortcuts-editing'           => 'Edição',
-                'shortcuts-selection'         => 'Seleção',
-                'shortcuts-clipboard'         => 'Área de transferência e preenchimento',
-                'shortcuts-move-cell'         => 'Mover entre células',
-                'shortcuts-move-down'         => 'Mover para baixo / confirmar edição',
-                'shortcuts-move-up'           => 'Mover para cima',
-                'shortcuts-move-right-left'   => 'Mover para a direita / esquerda',
-                'shortcuts-home-end'          => 'Primeira / última coluna na linha',
-                'shortcuts-ctrl-home-end'     => 'Primeira / última célula na grelha',
-                'shortcuts-extend-selection'  => 'Expandir seleção',
-                'shortcuts-select-all'        => 'Selecionar todas as células',
-                'shortcuts-enter-edit'        => 'Entrar no modo de edição',
-                'shortcuts-confirm-move-down' => 'Confirmar + mover para baixo',
-                'shortcuts-confirm-move-right'=> 'Confirmar + mover para a direita',
-                'shortcuts-escape-revert'     => 'Reverter valor + sair da edição',
-                'shortcuts-clear-cell'        => 'Limpar célula',
-                'shortcuts-copy'              => 'Copiar',
-                'shortcuts-cut'               => 'Cortar',
-                'shortcuts-paste'             => 'Colar',
-                'shortcuts-fill-down'         => 'Preencher para baixo',
-                'shortcuts-fill-right'        => 'Preencher para a direita',
-                'shortcuts-undo'              => 'Desfazer',
-                'shortcuts-redo'              => 'Refazer',
-                'shortcuts-help'              => 'Mostrar/ocultar atalhos de teclado',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Sem alterações para guardar.',
+                'invalid-datetime'             => 'Introduza uma data e hora válidas.',
+                'resize-column'                => 'Arraste para redimensionar a coluna',
+                'success'                      => 'Tarefa executada com sucesso.',
+                'fetch-failed'                 => 'Falha ao obter dados.',
+                'action'                       => 'Edição em massa',
+                'description'                  => 'Edite vários produtos de uma vez. As alterações são processadas em segundo plano.',
+                'gallery-preview'              => 'Pré-visualização da Galeria',
+                'img-preview'                  => 'Pré-visualização da Imagem',
+                'no-image'                     => 'Sem imagem',
+                'img-fail'                     => 'Falha ao carregar a imagem',
+                'no-option'                    => 'Sem opções',
+                'keyboard-shortcuts'           => 'Atalhos de teclado',
+                'shortcuts-navigation'         => 'Navegação',
+                'shortcuts-editing'            => 'Edição',
+                'shortcuts-selection'          => 'Seleção',
+                'shortcuts-clipboard'          => 'Área de transferência e preenchimento',
+                'shortcuts-move-cell'          => 'Mover entre células',
+                'shortcuts-move-down'          => 'Mover para baixo / confirmar edição',
+                'shortcuts-move-up'            => 'Mover para cima',
+                'shortcuts-move-right-left'    => 'Mover para a direita / esquerda',
+                'shortcuts-home-end'           => 'Primeira / última coluna na linha',
+                'shortcuts-ctrl-home-end'      => 'Primeira / última célula na grelha',
+                'shortcuts-extend-selection'   => 'Expandir seleção',
+                'shortcuts-select-all'         => 'Selecionar todas as células',
+                'shortcuts-enter-edit'         => 'Entrar no modo de edição',
+                'shortcuts-confirm-move-down'  => 'Confirmar + mover para baixo',
+                'shortcuts-confirm-move-right' => 'Confirmar + mover para a direita',
+                'shortcuts-escape-revert'      => 'Reverter valor + sair da edição',
+                'shortcuts-clear-cell'         => 'Limpar célula',
+                'shortcuts-copy'               => 'Copiar',
+                'shortcuts-cut'                => 'Cortar',
+                'shortcuts-paste'              => 'Colar',
+                'shortcuts-fill-down'          => 'Preencher para baixo',
+                'shortcuts-fill-right'         => 'Preencher para a direita',
+                'shortcuts-undo'               => 'Desfazer',
+                'shortcuts-redo'               => 'Refazer',
+                'shortcuts-help'               => 'Mostrar/ocultar atalhos de teclado',
             ],
             'create-success'          => 'Produto criado com sucesso',
             'delete-failed'           => 'Falha ao excluir o produto',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'É filtrável',
                 'ai-translate'          => 'Tradução IA',
                 'invalid-swatch-type'   => 'O :attribute não é permitido para o tipo de atributo :type com o tipo de amostra :swatch_type.',
-
                 'single-object-only'    => 'Cada pedido de criação deve enviar um único objeto de atributo.',
                 'option'                => [
                     'color'    => 'Amostra de cor',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atributo excluído',
             'update-success'    => 'Atributo atualizado',
             'user-define-error' => 'Não é possível excluir atributo do sistema',
-
             'immutable-fields'  => 'Os seguintes campos não podem ser modificados: :fields.',
             'not-found'         => 'Atributo com o código ":code" não encontrado',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Campo de Categoria Atualizado com Sucesso',
             'user-define-error' => 'Não é possível excluir um Campo de Categoria do sistema',
             'not-found'         => 'Campo de Categoria com código ":code" não encontrado',
-
             'immutable-fields'  => 'Os seguintes campos não podem ser modificados: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Não é possível atualizar as opções de configuração, pois esta família já possui variantes de produtos.',
         ],
         'history' => [
-            'view' => 'Ver detalhes da versão',
-
+            'view'  => 'Ver detalhes da versão',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versão',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Em pausa',
                         'cancelled'            => 'Cancelado',
                         'failed'               => 'Falhou',
-
-                        'view'       => 'Ver',
+                        'view'                 => 'Ver',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Título',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompts do sistema',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Título',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtro',
                 ],
                 'search_by' => [
-                    'code'       => 'Buscar por código',
-                    'code_or_id' => 'Buscar por código ou id',
+                    'code'        => 'Buscar por código',
+                    'code_or_id'  => 'Buscar por código ou id',
+                    'sku_or_user' => 'Buscar por SKU ou utilizador',
                 ],
                 'search' => [
                     'title' => 'Buscar',

--- a/packages/Webkul/Admin/src/Resources/lang/ro_RO/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ro_RO/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Introduceți un URL valid.',
                     'regex'                      => 'Valoarea nu se potrivește cu modelul necesar.',
                     'invalid-pattern'            => 'Model personalizat invalid furnizat.',
-
                     'numeric'                    => 'Valoarea atributului numeric „:attribute” trebuie să fie un număr valid.',
                     'select-attribute-or-family' => 'Vă rugăm să selectați cel puțin un atribut sau o familie de atribute.',
                     'failed'                     => 'Validarea a eșuat.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Editarea în masă a reușit.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Nicio modificare de salvat.',
-
-                'invalid-datetime'            => 'Introduceți o dată și oră valide.',
-
-                'resize-column'               => 'Trageți pentru a redimensiona coloana',
-                'success'                     => 'Sarcină executată cu succes.',
-                'fetch-failed'                => 'Eroare la preluare.',
-                'action'                      => 'Editare în masă',
-                'description'                 => 'Editați mai multe produse simultan. Modificările sunt procesate în fundal.',
-                'gallery-preview'             => 'Previzualizare galerie',
-                'img-preview'                 => 'Previzualizare imagine',
-                'no-image'                    => 'Nicio imagine',
-                'img-fail'                    => 'Încărcarea imaginii a eșuat',
-                'no-option'                   => 'Fără opțiuni',
-                'keyboard-shortcuts'          => 'Comenzi rapide de la tastatură',
-                'shortcuts-navigation'        => 'Navigare',
-                'shortcuts-editing'           => 'Editare',
-                'shortcuts-selection'         => 'Selecție',
-                'shortcuts-clipboard'         => 'Clipboard și completare',
-                'shortcuts-move-cell'         => 'Deplasare între celule',
-                'shortcuts-move-down'         => 'Deplasare în jos / confirmare editare',
-                'shortcuts-move-up'           => 'Deplasare în sus',
-                'shortcuts-move-right-left'   => 'Deplasare la dreapta / stânga',
-                'shortcuts-home-end'          => 'Prima / ultima coloană din rând',
-                'shortcuts-ctrl-home-end'     => 'Prima / ultima celulă din grilă',
-                'shortcuts-extend-selection'  => 'Extinde selecția',
-                'shortcuts-select-all'        => 'Selectează toate celulele',
-                'shortcuts-enter-edit'        => 'Intră în modul de editare',
-                'shortcuts-confirm-move-down' => 'Confirmă + deplasare în jos',
-                'shortcuts-confirm-move-right'=> 'Confirmă + deplasare la dreapta',
-                'shortcuts-escape-revert'     => 'Revenire la valoare + ieșire din editare',
-                'shortcuts-clear-cell'        => 'Șterge celula',
-                'shortcuts-copy'              => 'Copiază',
-                'shortcuts-cut'               => 'Taie',
-                'shortcuts-paste'             => 'Lipește',
-                'shortcuts-fill-down'         => 'Completează în jos',
-                'shortcuts-fill-right'        => 'Completează la dreapta',
-                'shortcuts-undo'              => 'Anulează',
-                'shortcuts-redo'              => 'Refă',
-                'shortcuts-help'              => 'Afișează/ascunde comenzile rapide',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Nicio modificare de salvat.',
+                'invalid-datetime'             => 'Introduceți o dată și oră valide.',
+                'resize-column'                => 'Trageți pentru a redimensiona coloana',
+                'success'                      => 'Sarcină executată cu succes.',
+                'fetch-failed'                 => 'Eroare la preluare.',
+                'action'                       => 'Editare în masă',
+                'description'                  => 'Editați mai multe produse simultan. Modificările sunt procesate în fundal.',
+                'gallery-preview'              => 'Previzualizare galerie',
+                'img-preview'                  => 'Previzualizare imagine',
+                'no-image'                     => 'Nicio imagine',
+                'img-fail'                     => 'Încărcarea imaginii a eșuat',
+                'no-option'                    => 'Fără opțiuni',
+                'keyboard-shortcuts'           => 'Comenzi rapide de la tastatură',
+                'shortcuts-navigation'         => 'Navigare',
+                'shortcuts-editing'            => 'Editare',
+                'shortcuts-selection'          => 'Selecție',
+                'shortcuts-clipboard'          => 'Clipboard și completare',
+                'shortcuts-move-cell'          => 'Deplasare între celule',
+                'shortcuts-move-down'          => 'Deplasare în jos / confirmare editare',
+                'shortcuts-move-up'            => 'Deplasare în sus',
+                'shortcuts-move-right-left'    => 'Deplasare la dreapta / stânga',
+                'shortcuts-home-end'           => 'Prima / ultima coloană din rând',
+                'shortcuts-ctrl-home-end'      => 'Prima / ultima celulă din grilă',
+                'shortcuts-extend-selection'   => 'Extinde selecția',
+                'shortcuts-select-all'         => 'Selectează toate celulele',
+                'shortcuts-enter-edit'         => 'Intră în modul de editare',
+                'shortcuts-confirm-move-down'  => 'Confirmă + deplasare în jos',
+                'shortcuts-confirm-move-right' => 'Confirmă + deplasare la dreapta',
+                'shortcuts-escape-revert'      => 'Revenire la valoare + ieșire din editare',
+                'shortcuts-clear-cell'         => 'Șterge celula',
+                'shortcuts-copy'               => 'Copiază',
+                'shortcuts-cut'                => 'Taie',
+                'shortcuts-paste'              => 'Lipește',
+                'shortcuts-fill-down'          => 'Completează în jos',
+                'shortcuts-fill-right'         => 'Completează la dreapta',
+                'shortcuts-undo'               => 'Anulează',
+                'shortcuts-redo'               => 'Refă',
+                'shortcuts-help'               => 'Afișează/ascunde comenzile rapide',
             ],
             'create-success'          => 'Produs creat cu succes',
             'delete-failed'           => 'Ștergerea produsului a eșuat',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Este filtrabil',
                 'ai-translate'          => 'Traducere IA',
                 'invalid-swatch-type'   => 'Atributul :attribute nu este permis pentru tipul de atribut :type cu tipul de eșantion :swatch_type.',
-
                 'single-object-only'    => 'Fiecare cerere de creare trebuie să trimită un singur obiect de atribut.',
                 'option'                => [
                     'color'    => 'Eșantion de culoare',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Atribut șters',
             'update-success'    => 'Atribut actualizat',
             'user-define-error' => 'Nu se poate șterge atributul de sistem',
-
             'immutable-fields'  => 'Următoarele câmpuri nu pot fi modificate: :fields.',
             'not-found'         => 'Atributul cu codul ":code" nu a fost găsit',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Câmp de categorie actualizat cu succes',
             'user-define-error' => 'Nu se poate șterge câmpul de categorie sistem',
             'not-found'         => 'Câmp de categorie cu codul ":code" nu a fost găsit',
-
             'immutable-fields'  => 'Următoarele câmpuri nu pot fi modificate: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Nu se pot actualiza opțiunile de configurare deoarece această familie are deja variante de produse.',
         ],
         'history' => [
-            'view' => 'Vizualizare detalii versiune',
-
+            'view'  => 'Vizualizare detalii versiune',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versiune',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Suspendat',
                         'cancelled'            => 'Anulat',
                         'failed'               => 'Eșuat',
-
-                        'view'       => 'Vizualizare',
+                        'view'                 => 'Vizualizare',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompturi',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titlu',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Prompturi de sistem',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titlu',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtru',
                 ],
                 'search_by' => [
-                    'code'       => 'Căutare după cod',
-                    'code_or_id' => 'Căutare după cod sau ID',
+                    'code'        => 'Căutare după cod',
+                    'code_or_id'  => 'Căutare după cod sau ID',
+                    'sku_or_user' => 'Căutare după SKU sau utilizator',
                 ],
                 'search' => [
                     'title' => 'Căutare',

--- a/packages/Webkul/Admin/src/Resources/lang/ru_RU/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ru_RU/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Пожалуйста, введите допустимый URL.',
                     'regex'                      => 'Значение не соответствует требуемому шаблону.',
                     'invalid-pattern'            => 'Указан недопустимый пользовательский шаблон.',
-
                     'numeric'                    => 'Значение числового атрибута «:attribute» должно быть корректным числом.',
                     'select-attribute-or-family' => 'Пожалуйста, выберите хотя бы один атрибут или семейство атрибутов.',
                     'failed'                     => 'Ошибка проверки.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Массовое редактирование выполнено успешно.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Нет изменений для сохранения.',
-
-                'invalid-datetime'            => 'Введите корректную дату и время.',
-
-                'resize-column'               => 'Потяните, чтобы изменить ширину столбца',
-                'success'                     => 'Задание успешно выполнено.',
-                'fetch-failed'                => 'Не удалось получить данные.',
-                'action'                      => 'Массовое редактирование',
-                'description'                 => 'Редактируйте несколько товаров одновременно. Изменения обрабатываются в фоновом режиме.',
-                'gallery-preview'             => 'Предварительный просмотр галереи',
-                'img-preview'                 => 'Предварительный просмотр изображения',
-                'no-image'                    => 'Нет изображения',
-                'img-fail'                    => 'Не удалось загрузить изображение',
-                'no-option'                   => 'Нет вариантов',
-                'keyboard-shortcuts'          => 'Горячие клавиши',
-                'shortcuts-navigation'        => 'Навигация',
-                'shortcuts-editing'           => 'Редактирование',
-                'shortcuts-selection'         => 'Выделение',
-                'shortcuts-clipboard'         => 'Буфер обмена и заполнение',
-                'shortcuts-move-cell'         => 'Перемещение между ячейками',
-                'shortcuts-move-down'         => 'Вниз / подтвердить редактирование',
-                'shortcuts-move-up'           => 'Вверх',
-                'shortcuts-move-right-left'   => 'Вправо / влево',
-                'shortcuts-home-end'          => 'Первый / последний столбец в строке',
-                'shortcuts-ctrl-home-end'     => 'Первая / последняя ячейка в сетке',
-                'shortcuts-extend-selection'  => 'Расширить выделение',
-                'shortcuts-select-all'        => 'Выделить все ячейки',
-                'shortcuts-enter-edit'        => 'Войти в режим редактирования',
-                'shortcuts-confirm-move-down' => 'Подтвердить + вниз',
-                'shortcuts-confirm-move-right'=> 'Подтвердить + вправо',
-                'shortcuts-escape-revert'     => 'Восстановить значение + выйти из редактирования',
-                'shortcuts-clear-cell'        => 'Очистить ячейку',
-                'shortcuts-copy'              => 'Копировать',
-                'shortcuts-cut'               => 'Вырезать',
-                'shortcuts-paste'             => 'Вставить',
-                'shortcuts-fill-down'         => 'Заполнить вниз',
-                'shortcuts-fill-right'        => 'Заполнить вправо',
-                'shortcuts-undo'              => 'Отменить',
-                'shortcuts-redo'              => 'Повторить',
-                'shortcuts-help'              => 'Показать/скрыть горячие клавиши',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Нет изменений для сохранения.',
+                'invalid-datetime'             => 'Введите корректную дату и время.',
+                'resize-column'                => 'Потяните, чтобы изменить ширину столбца',
+                'success'                      => 'Задание успешно выполнено.',
+                'fetch-failed'                 => 'Не удалось получить данные.',
+                'action'                       => 'Массовое редактирование',
+                'description'                  => 'Редактируйте несколько товаров одновременно. Изменения обрабатываются в фоновом режиме.',
+                'gallery-preview'              => 'Предварительный просмотр галереи',
+                'img-preview'                  => 'Предварительный просмотр изображения',
+                'no-image'                     => 'Нет изображения',
+                'img-fail'                     => 'Не удалось загрузить изображение',
+                'no-option'                    => 'Нет вариантов',
+                'keyboard-shortcuts'           => 'Горячие клавиши',
+                'shortcuts-navigation'         => 'Навигация',
+                'shortcuts-editing'            => 'Редактирование',
+                'shortcuts-selection'          => 'Выделение',
+                'shortcuts-clipboard'          => 'Буфер обмена и заполнение',
+                'shortcuts-move-cell'          => 'Перемещение между ячейками',
+                'shortcuts-move-down'          => 'Вниз / подтвердить редактирование',
+                'shortcuts-move-up'            => 'Вверх',
+                'shortcuts-move-right-left'    => 'Вправо / влево',
+                'shortcuts-home-end'           => 'Первый / последний столбец в строке',
+                'shortcuts-ctrl-home-end'      => 'Первая / последняя ячейка в сетке',
+                'shortcuts-extend-selection'   => 'Расширить выделение',
+                'shortcuts-select-all'         => 'Выделить все ячейки',
+                'shortcuts-enter-edit'         => 'Войти в режим редактирования',
+                'shortcuts-confirm-move-down'  => 'Подтвердить + вниз',
+                'shortcuts-confirm-move-right' => 'Подтвердить + вправо',
+                'shortcuts-escape-revert'      => 'Восстановить значение + выйти из редактирования',
+                'shortcuts-clear-cell'         => 'Очистить ячейку',
+                'shortcuts-copy'               => 'Копировать',
+                'shortcuts-cut'                => 'Вырезать',
+                'shortcuts-paste'              => 'Вставить',
+                'shortcuts-fill-down'          => 'Заполнить вниз',
+                'shortcuts-fill-right'         => 'Заполнить вправо',
+                'shortcuts-undo'               => 'Отменить',
+                'shortcuts-redo'               => 'Повторить',
+                'shortcuts-help'               => 'Показать/скрыть горячие клавиши',
             ],
             'create-success'          => 'Продукт создан успешно',
             'delete-failed'           => 'Удален продукта не удалось',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Фильтруемый',
                 'ai-translate'          => 'Перевод ИИ',
                 'invalid-swatch-type'   => 'Тип :attribute не разрешен для типа атрибута :type с типом образца :swatch_type.',
-
                 'single-object-only'    => 'В каждом запросе на создание можно передать только один объект атрибута.',
                 'option'                => [
                     'color'    => 'Образец цвета',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Атрибут удален успешно',
             'update-success'    => 'Атрибут обновлен успешно',
             'user-define-error' => 'Не может удалить атрибут системы',
-
             'immutable-fields'  => 'Следующие поля нельзя изменить: :fields.',
             'not-found'         => 'Атрибут с кодом ":code" не найден',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Поле категории успешно обновлено',
             'user-define-error' => 'Не может удалить поле категории системы',
             'not-found'         => 'Поле категории с кодом ":code" не найдено',
-
             'immutable-fields'  => 'Следующие поля нельзя изменить: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Не может обновить настраиваемые параметры, так как у этого семейства уже есть варианты продуктов.',
         ],
         'history' => [
-            'view' => 'Просмотр деталей версии',
-
+            'view'  => 'Просмотр деталей версии',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Версия',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Приостановлено',
                         'cancelled'            => 'Отменено',
                         'failed'               => 'Неуспешный',
-
-                        'view'       => 'Просмотр',
+                        'view'                 => 'Просмотр',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Подсказки',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Заголовок',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Системные подсказки',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Название',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Фильтр',
                 ],
                 'search_by' => [
-                    'code'       => 'Поиск по коду',
-                    'code_or_id' => 'Поиск по коду или идентификатору',
+                    'code'        => 'Поиск по коду',
+                    'code_or_id'  => 'Поиск по коду или идентификатору',
+                    'sku_or_user' => 'Поиск по SKU или пользователю',
                 ],
                 'search' => [
                     'title' => 'Поиск',

--- a/packages/Webkul/Admin/src/Resources/lang/sv_SE/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/sv_SE/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Ange en giltig URL.',
                     'regex'                      => 'Värdet matchar inte det krävs mönstret.',
                     'invalid-pattern'            => 'Ogiltigt anpassat mönster angivet.',
-
                     'numeric'                    => 'Värdet för det numeriska attributet ":attribute" måste vara ett giltigt tal.',
                     'select-attribute-or-family' => 'Välj minst ett attribut eller en attributfamilj.',
                     'failed'                     => 'Valideringen misslyckades.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Massredigeringen lyckades.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Inga ändringar att spara.',
-
-                'invalid-datetime'            => 'Ange ett giltigt datum och klockslag.',
-
-                'resize-column'               => 'Dra för att ändra kolumnbredd',
-                'success'                     => 'Uppgiften har utförts.',
-                'fetch-failed'                => 'Misslyckades med att hämta.',
-                'action'                      => 'Massredigering',
-                'description'                 => 'Redigera flera produkter samtidigt. Ändringar bearbetas i bakgrunden.',
-                'gallery-preview'             => 'Galleri Förhandsgranskning',
-                'img-preview'                 => 'Bildförhandsvisning',
-                'no-image'                    => 'Ingen bild',
-                'img-fail'                    => 'Misslyckades med att ladda upp bilden',
-                'no-option'                   => 'Inga alternativ',
-                'keyboard-shortcuts'          => 'Tangentbordsgenvägar',
-                'shortcuts-navigation'        => 'Navigering',
-                'shortcuts-editing'           => 'Redigering',
-                'shortcuts-selection'         => 'Markering',
-                'shortcuts-clipboard'         => 'Urklipp och fyllning',
-                'shortcuts-move-cell'         => 'Flytta mellan celler',
-                'shortcuts-move-down'         => 'Flytta ned / bekräfta redigering',
-                'shortcuts-move-up'           => 'Flytta upp',
-                'shortcuts-move-right-left'   => 'Flytta höger / vänster',
-                'shortcuts-home-end'          => 'Första / sista kolumnen i raden',
-                'shortcuts-ctrl-home-end'     => 'Första / sista cellen i rutnätet',
-                'shortcuts-extend-selection'  => 'Utöka markering',
-                'shortcuts-select-all'        => 'Markera alla celler',
-                'shortcuts-enter-edit'        => 'Gå till redigeringsläge',
-                'shortcuts-confirm-move-down' => 'Bekräfta + flytta ned',
-                'shortcuts-confirm-move-right'=> 'Bekräfta + flytta höger',
-                'shortcuts-escape-revert'     => 'Återställ värde + lämna redigering',
-                'shortcuts-clear-cell'        => 'Rensa cell',
-                'shortcuts-copy'              => 'Kopiera',
-                'shortcuts-cut'               => 'Klipp ut',
-                'shortcuts-paste'             => 'Klistra in',
-                'shortcuts-fill-down'         => 'Fyll nedåt',
-                'shortcuts-fill-right'        => 'Fyll åt höger',
-                'shortcuts-undo'              => 'Ångra',
-                'shortcuts-redo'              => 'Gör om',
-                'shortcuts-help'              => 'Visa/dölj tangentbordsgenvägar',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Inga ändringar att spara.',
+                'invalid-datetime'             => 'Ange ett giltigt datum och klockslag.',
+                'resize-column'                => 'Dra för att ändra kolumnbredd',
+                'success'                      => 'Uppgiften har utförts.',
+                'fetch-failed'                 => 'Misslyckades med att hämta.',
+                'action'                       => 'Massredigering',
+                'description'                  => 'Redigera flera produkter samtidigt. Ändringar bearbetas i bakgrunden.',
+                'gallery-preview'              => 'Galleri Förhandsgranskning',
+                'img-preview'                  => 'Bildförhandsvisning',
+                'no-image'                     => 'Ingen bild',
+                'img-fail'                     => 'Misslyckades med att ladda upp bilden',
+                'no-option'                    => 'Inga alternativ',
+                'keyboard-shortcuts'           => 'Tangentbordsgenvägar',
+                'shortcuts-navigation'         => 'Navigering',
+                'shortcuts-editing'            => 'Redigering',
+                'shortcuts-selection'          => 'Markering',
+                'shortcuts-clipboard'          => 'Urklipp och fyllning',
+                'shortcuts-move-cell'          => 'Flytta mellan celler',
+                'shortcuts-move-down'          => 'Flytta ned / bekräfta redigering',
+                'shortcuts-move-up'            => 'Flytta upp',
+                'shortcuts-move-right-left'    => 'Flytta höger / vänster',
+                'shortcuts-home-end'           => 'Första / sista kolumnen i raden',
+                'shortcuts-ctrl-home-end'      => 'Första / sista cellen i rutnätet',
+                'shortcuts-extend-selection'   => 'Utöka markering',
+                'shortcuts-select-all'         => 'Markera alla celler',
+                'shortcuts-enter-edit'         => 'Gå till redigeringsläge',
+                'shortcuts-confirm-move-down'  => 'Bekräfta + flytta ned',
+                'shortcuts-confirm-move-right' => 'Bekräfta + flytta höger',
+                'shortcuts-escape-revert'      => 'Återställ värde + lämna redigering',
+                'shortcuts-clear-cell'         => 'Rensa cell',
+                'shortcuts-copy'               => 'Kopiera',
+                'shortcuts-cut'                => 'Klipp ut',
+                'shortcuts-paste'              => 'Klistra in',
+                'shortcuts-fill-down'          => 'Fyll nedåt',
+                'shortcuts-fill-right'         => 'Fyll åt höger',
+                'shortcuts-undo'               => 'Ångra',
+                'shortcuts-redo'               => 'Gör om',
+                'shortcuts-help'               => 'Visa/dölj tangentbordsgenvägar',
             ],
             'create-success'          => 'Produkten skapades framgångsrikt',
             'delete-failed'           => 'Fel vid radering av produkt',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Är filtrerbar',
                 'ai-translate'          => 'AI Översättning',
                 'invalid-swatch-type'   => 'Attributet :attribute är inte tillåtet för attributtyp :type med swatchtyp :swatch_type.',
-
                 'single-object-only'    => 'Varje skapandeförfrågan får endast innehålla ett attributobjekt.',
                 'option'                => [
                     'color'    => 'Färgväljare',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Attribut borttaget',
             'update-success'    => 'Attribut uppdaterad',
             'user-define-error' => 'Det går inte att ta bort systemattribut',
-
             'immutable-fields'  => 'Följande fält kan inte ändras: :fields.',
             'not-found'         => 'Attributet med koden ":code" hittades inte',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Kategori fält uppdaterades framgångsrikt',
             'user-define-error' => 'Det går inte att radera systemdefinierade fält',
             'not-found'         => 'Kategori fält med kod ":code" kunde inte hittas',
-
             'immutable-fields'  => 'Följande fält kan inte ändras: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Kan inte uppdatera konfigurationsalternativ eftersom denna familj redan har produktvarianter.',
         ],
         'history' => [
-            'view' => 'Visa versionsdetaljer',
-
+            'view'  => 'Visa versionsdetaljer',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Version',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Pausad',
                         'cancelled'            => 'Avbruten',
                         'failed'               => 'Misslyckades',
-
-                        'view'       => 'Visa',
+                        'view'                 => 'Visa',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Prompts',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Titel',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Systemprompts',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Titel',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filter',
                 ],
                 'search_by' => [
-                    'code'       => 'Sök efter kod',
-                    'code_or_id' => 'Sök efter kod eller ID',
+                    'code'        => 'Sök efter kod',
+                    'code_or_id'  => 'Sök efter kod eller ID',
+                    'sku_or_user' => 'Sök efter SKU eller användare',
                 ],
                 'search' => [
                     'title' => 'Sök',

--- a/packages/Webkul/Admin/src/Resources/lang/tl_PH/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tl_PH/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Pakilagay ng wastong URL.',
                     'regex'                      => 'Hindi tumutugma ang halaga sa kinakailangang pattern.',
                     'invalid-pattern'            => 'Di-wastong pasadyang pattern ang ibinigay.',
-
                     'numeric'                    => 'Ang halaga ng numerikong attribute na ":attribute" ay dapat maging wastong numero.',
                     'select-attribute-or-family' => 'Mangyaring pumili ng kahit isang attribute o isang pamilya ng attribute.',
                     'failed'                     => 'Nabigo ang pagpapatunay.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Matagumpay ang bulk edit.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Walang pagbabago para i-save.',
-
-                'invalid-datetime'            => 'Maglagay ng wastong petsa at oras.',
-
-                'resize-column'               => 'I-drag upang baguhin ang lapad ng column',
-                'success'                     => 'Matagumpay na naisagawa ang gawain.',
-                'fetch-failed'                => 'Hindi nakuha ang datos.',
-                'action'                      => 'Maramihang Pag-edit',
-                'description'                 => 'I-edit ang maraming produkto nang sabay-sabay. Ang mga pagbabago ay pinoproseso sa background.',
-                'gallery-preview'             => 'Preview ng Gallery',
-                'img-preview'                 => 'Preview ng Imahe',
-                'no-image'                    => 'Walang Imahe',
-                'img-fail'                    => 'Nabigo ang pag-upload ng imahe',
-                'no-option'                   => 'Walang Pagpipilian',
-                'keyboard-shortcuts'          => 'Mga Shortcut sa Keyboard',
-                'shortcuts-navigation'        => 'Nabigasyon',
-                'shortcuts-editing'           => 'Pag-edit',
-                'shortcuts-selection'         => 'Pagpili',
-                'shortcuts-clipboard'         => 'Clipboard at Punan',
-                'shortcuts-move-cell'         => 'Lumipat sa pagitan ng mga cell',
-                'shortcuts-move-down'         => 'Bumaba / kumpirmahin ang pag-edit',
-                'shortcuts-move-up'           => 'Umakyat',
-                'shortcuts-move-right-left'   => 'Pumunta sa kanan / kaliwa',
-                'shortcuts-home-end'          => 'Una / huling kolumna sa hilera',
-                'shortcuts-ctrl-home-end'     => 'Una / huling cell sa grid',
-                'shortcuts-extend-selection'  => 'Palawakin ang pagpili',
-                'shortcuts-select-all'        => 'Piliin ang lahat ng cell',
-                'shortcuts-enter-edit'        => 'Pumasok sa edit mode',
-                'shortcuts-confirm-move-down' => 'Kumpirmahin + bumaba',
-                'shortcuts-confirm-move-right'=> 'Kumpirmahin + pumunta sa kanan',
-                'shortcuts-escape-revert'     => 'Ibalik ang halaga + lumabas sa pag-edit',
-                'shortcuts-clear-cell'        => 'Linisin ang cell',
-                'shortcuts-copy'              => 'Kopyahin',
-                'shortcuts-cut'               => 'I-cut',
-                'shortcuts-paste'             => 'I-paste',
-                'shortcuts-fill-down'         => 'Punan pababa',
-                'shortcuts-fill-right'        => 'Punan pakanan',
-                'shortcuts-undo'              => 'I-undo',
-                'shortcuts-redo'              => 'I-redo',
-                'shortcuts-help'              => 'Ipakita/itago ang mga shortcut sa keyboard',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Walang pagbabago para i-save.',
+                'invalid-datetime'             => 'Maglagay ng wastong petsa at oras.',
+                'resize-column'                => 'I-drag upang baguhin ang lapad ng column',
+                'success'                      => 'Matagumpay na naisagawa ang gawain.',
+                'fetch-failed'                 => 'Hindi nakuha ang datos.',
+                'action'                       => 'Maramihang Pag-edit',
+                'description'                  => 'I-edit ang maraming produkto nang sabay-sabay. Ang mga pagbabago ay pinoproseso sa background.',
+                'gallery-preview'              => 'Preview ng Gallery',
+                'img-preview'                  => 'Preview ng Imahe',
+                'no-image'                     => 'Walang Imahe',
+                'img-fail'                     => 'Nabigo ang pag-upload ng imahe',
+                'no-option'                    => 'Walang Pagpipilian',
+                'keyboard-shortcuts'           => 'Mga Shortcut sa Keyboard',
+                'shortcuts-navigation'         => 'Nabigasyon',
+                'shortcuts-editing'            => 'Pag-edit',
+                'shortcuts-selection'          => 'Pagpili',
+                'shortcuts-clipboard'          => 'Clipboard at Punan',
+                'shortcuts-move-cell'          => 'Lumipat sa pagitan ng mga cell',
+                'shortcuts-move-down'          => 'Bumaba / kumpirmahin ang pag-edit',
+                'shortcuts-move-up'            => 'Umakyat',
+                'shortcuts-move-right-left'    => 'Pumunta sa kanan / kaliwa',
+                'shortcuts-home-end'           => 'Una / huling kolumna sa hilera',
+                'shortcuts-ctrl-home-end'      => 'Una / huling cell sa grid',
+                'shortcuts-extend-selection'   => 'Palawakin ang pagpili',
+                'shortcuts-select-all'         => 'Piliin ang lahat ng cell',
+                'shortcuts-enter-edit'         => 'Pumasok sa edit mode',
+                'shortcuts-confirm-move-down'  => 'Kumpirmahin + bumaba',
+                'shortcuts-confirm-move-right' => 'Kumpirmahin + pumunta sa kanan',
+                'shortcuts-escape-revert'      => 'Ibalik ang halaga + lumabas sa pag-edit',
+                'shortcuts-clear-cell'         => 'Linisin ang cell',
+                'shortcuts-copy'               => 'Kopyahin',
+                'shortcuts-cut'                => 'I-cut',
+                'shortcuts-paste'              => 'I-paste',
+                'shortcuts-fill-down'          => 'Punan pababa',
+                'shortcuts-fill-right'         => 'Punan pakanan',
+                'shortcuts-undo'               => 'I-undo',
+                'shortcuts-redo'               => 'I-redo',
+                'shortcuts-help'               => 'Ipakita/itago ang mga shortcut sa keyboard',
             ],
             'create-success'          => 'Matagumpay na nalikha ang produkto',
             'delete-failed'           => 'Nabigong tanggalin ang produkto',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Nafifilter',
                 'ai-translate'          => 'AI Pagsasalin',
                 'invalid-swatch-type'   => 'Ang :attribute ay hindi pinapayagan para sa uri ng katangian :type na may uri ng swatch :swatch_type.',
-
                 'single-object-only'    => 'Ang bawat create request ay dapat magpadala ng iisang attribute object.',
                 'option'                => [
                     'color'    => 'Color Swatch',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Katangian natanggal',
             'update-success'    => 'Katangian na-update',
             'user-define-error' => 'Hindi ma-delete ang system attribute',
-
             'immutable-fields'  => 'Ang mga sumusunod na field ay hindi maaaring baguhin: :fields.',
             'not-found'         => 'Ang katangian na may code ":code" ay hindi natagpuan',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Matagumpay na na-update ang field ng kategorya',
             'user-define-error' => 'Hindi maaaring tanggalin ang field ng kategorya ng sistema',
             'not-found'         => 'Hindi natagpuan ang field ng kategorya na may code ":code"',
-
             'immutable-fields'  => 'Ang mga sumusunod na field ay hindi maaaring baguhin: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Hindi ma-update ang mga opsyon ng configuration dahil mayroon nang mga produkto ng variant sa pamilya.',
         ],
         'history' => [
-            'view' => 'Tingnan ang Mga Detalye ng Bersyon',
-
+            'view'  => 'Tingnan ang Mga Detalye ng Bersyon',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Bersyon',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Naka-pause',
                         'cancelled'            => 'Na-cancel',
                         'failed'               => 'Nabigo',
-
-                        'view'       => 'Tingnan',
+                        'view'                 => 'Tingnan',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Mga Prompt',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Pamagat',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Mga System Prompt',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Pamagat',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Salain',
                 ],
                 'search_by' => [
-                    'code'       => 'Maghanap ayon sa code',
-                    'code_or_id' => 'Maghanap ayon sa code o id',
+                    'code'        => 'Maghanap ayon sa code',
+                    'code_or_id'  => 'Maghanap ayon sa code o id',
+                    'sku_or_user' => 'Maghanap ayon sa SKU o user',
                 ],
                 'search' => [
                     'title' => 'Maghanap',

--- a/packages/Webkul/Admin/src/Resources/lang/tr_TR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr_TR/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Lütfen geçerli bir URL girin.',
                     'regex'                      => 'Değer gerekli desenle eşleşmiyor.',
                     'invalid-pattern'            => 'Geçersiz özel desen sağlandı.',
-
                     'numeric'                    => '":attribute" sayısal özelliğinin değeri geçerli bir sayı olmalıdır.',
                     'select-attribute-or-family' => 'Lütfen en az bir özellik veya özellik ailesi seçin.',
                     'failed'                     => 'Doğrulama başarısız oldu.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Toplu düzenleme başarıyla tamamlandı.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Kaydedilecek değişiklik yok.',
-
-                'invalid-datetime'            => 'Geçerli bir tarih ve saat girin.',
-
-                'resize-column'               => 'Sütun genişliğini değiştirmek için sürükleyin',
-                'success'                     => 'İşlem başarıyla gerçekleştirildi.',
-                'fetch-failed'                => 'Veri alınamadı.',
-                'action'                      => 'Toplu Düzenleme',
-                'description'                 => 'Birden fazla ürünü aynı anda düzenleyin. Değişiklikler arka planda işlenir.',
-                'gallery-preview'             => 'Galeri Önizleme',
-                'img-preview'                 => 'Resim Önizleme',
-                'no-image'                    => 'Resim Yok',
-                'img-fail'                    => 'Resim yüklenemedi',
-                'no-option'                   => 'Seçenek Yok',
-                'keyboard-shortcuts'          => 'Klavye Kısayolları',
-                'shortcuts-navigation'        => 'Gezinme',
-                'shortcuts-editing'           => 'Düzenleme',
-                'shortcuts-selection'         => 'Seçim',
-                'shortcuts-clipboard'         => 'Pano ve Doldurma',
-                'shortcuts-move-cell'         => 'Hücreler arasında gezin',
-                'shortcuts-move-down'         => 'Aşağı taşı / düzenlemeyi onayla',
-                'shortcuts-move-up'           => 'Yukarı taşı',
-                'shortcuts-move-right-left'   => 'Sağa / sola taşı',
-                'shortcuts-home-end'          => 'Satırdaki ilk / son sütun',
-                'shortcuts-ctrl-home-end'     => 'Izgaradaki ilk / son hücre',
-                'shortcuts-extend-selection'  => 'Seçimi genişlet',
-                'shortcuts-select-all'        => 'Tüm hücreleri seç',
-                'shortcuts-enter-edit'        => 'Düzenleme moduna gir',
-                'shortcuts-confirm-move-down' => 'Onayla + aşağı taşı',
-                'shortcuts-confirm-move-right'=> 'Onayla + sağa taşı',
-                'shortcuts-escape-revert'     => 'Değeri geri al + düzenlemeden çık',
-                'shortcuts-clear-cell'        => 'Hücreyi temizle',
-                'shortcuts-copy'              => 'Kopyala',
-                'shortcuts-cut'               => 'Kes',
-                'shortcuts-paste'             => 'Yapıştır',
-                'shortcuts-fill-down'         => 'Aşağı doldur',
-                'shortcuts-fill-right'        => 'Sağa doldur',
-                'shortcuts-undo'              => 'Geri al',
-                'shortcuts-redo'              => 'Yinele',
-                'shortcuts-help'              => 'Klavye kısayollarını göster/gizle',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Kaydedilecek değişiklik yok.',
+                'invalid-datetime'             => 'Geçerli bir tarih ve saat girin.',
+                'resize-column'                => 'Sütun genişliğini değiştirmek için sürükleyin',
+                'success'                      => 'İşlem başarıyla gerçekleştirildi.',
+                'fetch-failed'                 => 'Veri alınamadı.',
+                'action'                       => 'Toplu Düzenleme',
+                'description'                  => 'Birden fazla ürünü aynı anda düzenleyin. Değişiklikler arka planda işlenir.',
+                'gallery-preview'              => 'Galeri Önizleme',
+                'img-preview'                  => 'Resim Önizleme',
+                'no-image'                     => 'Resim Yok',
+                'img-fail'                     => 'Resim yüklenemedi',
+                'no-option'                    => 'Seçenek Yok',
+                'keyboard-shortcuts'           => 'Klavye Kısayolları',
+                'shortcuts-navigation'         => 'Gezinme',
+                'shortcuts-editing'            => 'Düzenleme',
+                'shortcuts-selection'          => 'Seçim',
+                'shortcuts-clipboard'          => 'Pano ve Doldurma',
+                'shortcuts-move-cell'          => 'Hücreler arasında gezin',
+                'shortcuts-move-down'          => 'Aşağı taşı / düzenlemeyi onayla',
+                'shortcuts-move-up'            => 'Yukarı taşı',
+                'shortcuts-move-right-left'    => 'Sağa / sola taşı',
+                'shortcuts-home-end'           => 'Satırdaki ilk / son sütun',
+                'shortcuts-ctrl-home-end'      => 'Izgaradaki ilk / son hücre',
+                'shortcuts-extend-selection'   => 'Seçimi genişlet',
+                'shortcuts-select-all'         => 'Tüm hücreleri seç',
+                'shortcuts-enter-edit'         => 'Düzenleme moduna gir',
+                'shortcuts-confirm-move-down'  => 'Onayla + aşağı taşı',
+                'shortcuts-confirm-move-right' => 'Onayla + sağa taşı',
+                'shortcuts-escape-revert'      => 'Değeri geri al + düzenlemeden çık',
+                'shortcuts-clear-cell'         => 'Hücreyi temizle',
+                'shortcuts-copy'               => 'Kopyala',
+                'shortcuts-cut'                => 'Kes',
+                'shortcuts-paste'              => 'Yapıştır',
+                'shortcuts-fill-down'          => 'Aşağı doldur',
+                'shortcuts-fill-right'         => 'Sağa doldur',
+                'shortcuts-undo'               => 'Geri al',
+                'shortcuts-redo'               => 'Yinele',
+                'shortcuts-help'               => 'Klavye kısayollarını göster/gizle',
             ],
             'create-success'          => 'Ürün başarıyla oluşturuldu',
             'delete-failed'           => 'Ürün silinirken hata oluştu',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Filtrelenebilir',
                 'ai-translate'          => 'AI Çeviri',
                 'invalid-swatch-type'   => ':attribute, :type türü için :swatch_type swatch türü ile kullanılamaz.',
-
                 'single-object-only'    => 'Her oluşturma isteği yalnızca bir öznitelik nesnesi göndermelidir.',
                 'option'                => [
                     'color'    => 'Renk Örneği',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Öznitelik Silindi',
             'update-success'    => 'Öznitelik Güncellendi',
             'user-define-error' => 'Sistem öznitelikleri silinemez',
-
             'immutable-fields'  => 'Şu alanlar değiştirilemez: :fields.',
             'not-found'         => '":code" kodlu öznitelik bulunamadı',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Kategori Alanı başarıyla güncellendi',
             'user-define-error' => 'Sistem tanımlı kategori alanı silinemez',
             'not-found'         => 'Kategori Alanı ":code" bulunamadı',
-
             'immutable-fields'  => 'Şu alanlar değiştirilemez: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Bu ailede zaten ürün varyantları olduğu için konfigürasyon seçenekleri güncellenemiyor.',
         ],
         'history' => [
-            'view' => 'Sürüm Ayrıntılarını Görüntüle',
-
+            'view'  => 'Sürüm Ayrıntılarını Görüntüle',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Versiyon',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Duraklatıldı',
                         'cancelled'            => 'İptal Edildi',
                         'failed'               => 'Başarısız',
-
-                        'view'       => 'Görüntüle',
+                        'view'                 => 'Görüntüle',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'İstemler',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Başlık',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Sistem istemleri',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Başlık',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Filtre',
                 ],
                 'search_by' => [
-                    'code'       => 'Kod ile Ara',
-                    'code_or_id' => 'Kod veya ID ile Ara',
+                    'code'        => 'Kod ile Ara',
+                    'code_or_id'  => 'Kod veya ID ile Ara',
+                    'sku_or_user' => 'SKU veya Kullanıcı ile Ara',
                 ],
                 'search' => [
                     'title' => 'Ara',

--- a/packages/Webkul/Admin/src/Resources/lang/uk_UA/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/uk_UA/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Будь ласка, введіть дійсний URL.',
                     'regex'                      => 'Значення не відповідає необхідному шаблону.',
                     'invalid-pattern'            => 'Вказано недійсний користувацький шаблон.',
-
                     'numeric'                    => 'Значення числового атрибута «:attribute» має бути коректним числом.',
                     'select-attribute-or-family' => 'Будь ласка, виберіть принаймні один атрибут або сімейство атрибутів.',
                     'failed'                     => 'Помилка валідації.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Масове редагування виконано успішно.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Немає змін для збереження.',
-
-                'invalid-datetime'            => 'Введіть коректну дату й час.',
-
-                'resize-column'               => 'Потягніть, щоб змінити ширину колонки',
-                'success'                     => 'Завдання успішно виконано.',
-                'fetch-failed'                => 'Не вдалося отримати дані.',
-                'action'                      => 'Масове редагування',
-                'description'                 => 'Редагуйте кілька товарів одночасно. Зміни обробляються у фоновому режимі.',
-                'gallery-preview'             => 'Попередній перегляд галереї',
-                'img-preview'                 => 'Попередній перегляд зображення',
-                'no-image'                    => 'Немає зображення',
-                'img-fail'                    => 'Не вдалося завантажити зображення',
-                'no-option'                   => 'Немає варіантів',
-                'keyboard-shortcuts'          => 'Гарячі клавіші',
-                'shortcuts-navigation'        => 'Навігація',
-                'shortcuts-editing'           => 'Редагування',
-                'shortcuts-selection'         => 'Виділення',
-                'shortcuts-clipboard'         => 'Буфер обміну та заповнення',
-                'shortcuts-move-cell'         => 'Переміщення між комірками',
-                'shortcuts-move-down'         => 'Вниз / підтвердити редагування',
-                'shortcuts-move-up'           => 'Вгору',
-                'shortcuts-move-right-left'   => 'Вправо / вліво',
-                'shortcuts-home-end'          => 'Перший / останній стовпець у рядку',
-                'shortcuts-ctrl-home-end'     => 'Перша / остання комірка у сітці',
-                'shortcuts-extend-selection'  => 'Розширити виділення',
-                'shortcuts-select-all'        => 'Виділити всі комірки',
-                'shortcuts-enter-edit'        => 'Увійти в режим редагування',
-                'shortcuts-confirm-move-down' => 'Підтвердити + вниз',
-                'shortcuts-confirm-move-right'=> 'Підтвердити + вправо',
-                'shortcuts-escape-revert'     => 'Відновити значення + вийти з редагування',
-                'shortcuts-clear-cell'        => 'Очистити комірку',
-                'shortcuts-copy'              => 'Копіювати',
-                'shortcuts-cut'               => 'Вирізати',
-                'shortcuts-paste'             => 'Вставити',
-                'shortcuts-fill-down'         => 'Заповнити вниз',
-                'shortcuts-fill-right'        => 'Заповнити вправо',
-                'shortcuts-undo'              => 'Скасувати',
-                'shortcuts-redo'              => 'Повторити',
-                'shortcuts-help'              => 'Показати/приховати гарячі клавіші',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Немає змін для збереження.',
+                'invalid-datetime'             => 'Введіть коректну дату й час.',
+                'resize-column'                => 'Потягніть, щоб змінити ширину колонки',
+                'success'                      => 'Завдання успішно виконано.',
+                'fetch-failed'                 => 'Не вдалося отримати дані.',
+                'action'                       => 'Масове редагування',
+                'description'                  => 'Редагуйте кілька товарів одночасно. Зміни обробляються у фоновому режимі.',
+                'gallery-preview'              => 'Попередній перегляд галереї',
+                'img-preview'                  => 'Попередній перегляд зображення',
+                'no-image'                     => 'Немає зображення',
+                'img-fail'                     => 'Не вдалося завантажити зображення',
+                'no-option'                    => 'Немає варіантів',
+                'keyboard-shortcuts'           => 'Гарячі клавіші',
+                'shortcuts-navigation'         => 'Навігація',
+                'shortcuts-editing'            => 'Редагування',
+                'shortcuts-selection'          => 'Виділення',
+                'shortcuts-clipboard'          => 'Буфер обміну та заповнення',
+                'shortcuts-move-cell'          => 'Переміщення між комірками',
+                'shortcuts-move-down'          => 'Вниз / підтвердити редагування',
+                'shortcuts-move-up'            => 'Вгору',
+                'shortcuts-move-right-left'    => 'Вправо / вліво',
+                'shortcuts-home-end'           => 'Перший / останній стовпець у рядку',
+                'shortcuts-ctrl-home-end'      => 'Перша / остання комірка у сітці',
+                'shortcuts-extend-selection'   => 'Розширити виділення',
+                'shortcuts-select-all'         => 'Виділити всі комірки',
+                'shortcuts-enter-edit'         => 'Увійти в режим редагування',
+                'shortcuts-confirm-move-down'  => 'Підтвердити + вниз',
+                'shortcuts-confirm-move-right' => 'Підтвердити + вправо',
+                'shortcuts-escape-revert'      => 'Відновити значення + вийти з редагування',
+                'shortcuts-clear-cell'         => 'Очистити комірку',
+                'shortcuts-copy'               => 'Копіювати',
+                'shortcuts-cut'                => 'Вирізати',
+                'shortcuts-paste'              => 'Вставити',
+                'shortcuts-fill-down'          => 'Заповнити вниз',
+                'shortcuts-fill-right'         => 'Заповнити вправо',
+                'shortcuts-undo'               => 'Скасувати',
+                'shortcuts-redo'               => 'Повторити',
+                'shortcuts-help'               => 'Показати/приховати гарячі клавіші',
             ],
             'create-success'          => 'Продукт успішно створений',
             'delete-failed'           => 'Помилка видалення продукту',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Фільтрований',
                 'ai-translate'          => 'Переклад ШІ',
                 'invalid-swatch-type'   => ':attribute не дозволено для типу атрибута :type з типом зразка :swatch_type.',
-
                 'single-object-only'    => 'Кожен запит на створення має містити лише один об\'єкт атрибута.',
                 'option'                => [
                     'color'    => 'Колір шаблону',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Атрибут видалено',
             'update-success'    => 'Атрибут оновлено',
             'user-define-error' => 'Не можна видаляти системні атрибути',
-
             'immutable-fields'  => 'Наступні поля не можна змінювати: :fields.',
             'not-found'         => 'Атрибут з кодом ":code" не знайдено',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Поле категорії успішно оновлено',
             'user-define-error' => 'Поле категорії системи не можна видалити',
             'not-found'         => 'Поле категорії ":code" не знайдено',
-
             'immutable-fields'  => 'Наступні поля не можна змінювати: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Не можна оновити опції конфігурації, оскільки ця родина вже має варіанти продуктів.',
         ],
         'history' => [
-            'view' => 'Переглянути деталі версії',
-
+            'view'  => 'Переглянути деталі версії',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Версія',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Призупинено',
                         'cancelled'            => 'Скасовано',
                         'failed'               => 'Не вдалося',
-
-                        'view'       => 'Переглянути',
+                        'view'                 => 'Переглянути',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Підказки',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Назва',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Системні підказки',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Назва',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Фільтр',
                 ],
                 'search_by' => [
-                    'code'       => 'Шукати за кодом',
-                    'code_or_id' => 'Шукати за кодом або ID',
+                    'code'        => 'Шукати за кодом',
+                    'code_or_id'  => 'Шукати за кодом або ID',
+                    'sku_or_user' => 'Шукати за SKU або користувачем',
                 ],
                 'search' => [
                     'title' => 'Пошук',

--- a/packages/Webkul/Admin/src/Resources/lang/vi_VN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi_VN/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => 'Vui lòng nhập một URL hợp lệ.',
                     'regex'                      => 'Giá trị không khớp với mẫu yêu cầu.',
                     'invalid-pattern'            => 'Mẫu tùy chỉnh không hợp lệ.',
-
                     'numeric'                    => 'Giá trị cho thuộc tính số ":attribute" phải là một số hợp lệ.',
                     'select-attribute-or-family' => 'Vui lòng chọn ít nhất một thuộc tính hoặc một nhóm thuộc tính.',
                     'failed'                     => 'Xác thực không thành công.',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => 'Chỉnh sửa hàng loạt thành công.',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => 'Không có thay đổi nào để lưu.',
-
-                'invalid-datetime'            => 'Vui lòng nhập ngày và giờ hợp lệ.',
-
-                'resize-column'               => 'Kéo để thay đổi kích thước cột',
-                'success'                     => 'Thực thi công việc thành công.',
-                'fetch-failed'                => 'Lấy dữ liệu thất bại.',
-                'action'                      => 'Chỉnh sửa hàng loạt',
-                'description'                 => 'Chỉnh sửa nhiều sản phẩm cùng lúc. Các thay đổi được xử lý trong nền.',
-                'gallery-preview'             => 'Xem trước thư viện',
-                'img-preview'                 => 'Xem trước hình ảnh',
-                'no-image'                    => 'Không có hình ảnh',
-                'img-fail'                    => 'Tải hình ảnh thất bại',
-                'no-option'                   => 'Không có tùy chọn',
-                'keyboard-shortcuts'          => 'Phím tắt bàn phím',
-                'shortcuts-navigation'        => 'Điều hướng',
-                'shortcuts-editing'           => 'Chỉnh sửa',
-                'shortcuts-selection'         => 'Chọn',
-                'shortcuts-clipboard'         => 'Bộ nhớ tạm & Điền',
-                'shortcuts-move-cell'         => 'Di chuyển giữa các ô',
-                'shortcuts-move-down'         => 'Di chuyển xuống / xác nhận chỉnh sửa',
-                'shortcuts-move-up'           => 'Di chuyển lên',
-                'shortcuts-move-right-left'   => 'Di chuyển phải / trái',
-                'shortcuts-home-end'          => 'Cột đầu / cuối trong hàng',
-                'shortcuts-ctrl-home-end'     => 'Ô đầu / cuối trong lưới',
-                'shortcuts-extend-selection'  => 'Mở rộng vùng chọn',
-                'shortcuts-select-all'        => 'Chọn tất cả các ô',
-                'shortcuts-enter-edit'        => 'Vào chế độ chỉnh sửa',
-                'shortcuts-confirm-move-down' => 'Xác nhận + di chuyển xuống',
-                'shortcuts-confirm-move-right'=> 'Xác nhận + di chuyển phải',
-                'shortcuts-escape-revert'     => 'Hoàn tác giá trị + thoát chỉnh sửa',
-                'shortcuts-clear-cell'        => 'Xóa ô',
-                'shortcuts-copy'              => 'Sao chép',
-                'shortcuts-cut'               => 'Cắt',
-                'shortcuts-paste'             => 'Dán',
-                'shortcuts-fill-down'         => 'Điền xuống',
-                'shortcuts-fill-right'        => 'Điền phải',
-                'shortcuts-undo'              => 'Hoàn tác',
-                'shortcuts-redo'              => 'Làm lại',
-                'shortcuts-help'              => 'Hiện/ẩn phím tắt bàn phím',
+                'id'                           => 'ID',
+                'no-changes'                   => 'Không có thay đổi nào để lưu.',
+                'invalid-datetime'             => 'Vui lòng nhập ngày và giờ hợp lệ.',
+                'resize-column'                => 'Kéo để thay đổi kích thước cột',
+                'success'                      => 'Thực thi công việc thành công.',
+                'fetch-failed'                 => 'Lấy dữ liệu thất bại.',
+                'action'                       => 'Chỉnh sửa hàng loạt',
+                'description'                  => 'Chỉnh sửa nhiều sản phẩm cùng lúc. Các thay đổi được xử lý trong nền.',
+                'gallery-preview'              => 'Xem trước thư viện',
+                'img-preview'                  => 'Xem trước hình ảnh',
+                'no-image'                     => 'Không có hình ảnh',
+                'img-fail'                     => 'Tải hình ảnh thất bại',
+                'no-option'                    => 'Không có tùy chọn',
+                'keyboard-shortcuts'           => 'Phím tắt bàn phím',
+                'shortcuts-navigation'         => 'Điều hướng',
+                'shortcuts-editing'            => 'Chỉnh sửa',
+                'shortcuts-selection'          => 'Chọn',
+                'shortcuts-clipboard'          => 'Bộ nhớ tạm & Điền',
+                'shortcuts-move-cell'          => 'Di chuyển giữa các ô',
+                'shortcuts-move-down'          => 'Di chuyển xuống / xác nhận chỉnh sửa',
+                'shortcuts-move-up'            => 'Di chuyển lên',
+                'shortcuts-move-right-left'    => 'Di chuyển phải / trái',
+                'shortcuts-home-end'           => 'Cột đầu / cuối trong hàng',
+                'shortcuts-ctrl-home-end'      => 'Ô đầu / cuối trong lưới',
+                'shortcuts-extend-selection'   => 'Mở rộng vùng chọn',
+                'shortcuts-select-all'         => 'Chọn tất cả các ô',
+                'shortcuts-enter-edit'         => 'Vào chế độ chỉnh sửa',
+                'shortcuts-confirm-move-down'  => 'Xác nhận + di chuyển xuống',
+                'shortcuts-confirm-move-right' => 'Xác nhận + di chuyển phải',
+                'shortcuts-escape-revert'      => 'Hoàn tác giá trị + thoát chỉnh sửa',
+                'shortcuts-clear-cell'         => 'Xóa ô',
+                'shortcuts-copy'               => 'Sao chép',
+                'shortcuts-cut'                => 'Cắt',
+                'shortcuts-paste'              => 'Dán',
+                'shortcuts-fill-down'          => 'Điền xuống',
+                'shortcuts-fill-right'         => 'Điền phải',
+                'shortcuts-undo'               => 'Hoàn tác',
+                'shortcuts-redo'               => 'Làm lại',
+                'shortcuts-help'               => 'Hiện/ẩn phím tắt bàn phím',
             ],
             'create-success'          => 'Sản phẩm đã được tạo thành công',
             'delete-failed'           => 'Đã có lỗi khi xóa sản phẩm',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => 'Có thể lọc',
                 'ai-translate'          => 'Dịch thuật AI',
                 'invalid-swatch-type'   => ':attribute không được phép cho loại thuộc tính :type với loại mẫu :swatch_type.',
-
                 'single-object-only'    => 'Mỗi yêu cầu tạo chỉ được gửi một đối tượng thuộc tính.',
                 'option'                => [
                     'color'    => 'Mẫu màu sắc',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => 'Thuộc tính đã bị xoá',
             'update-success'    => 'Thuộc tính đã được cập nhật',
             'user-define-error' => 'Không thể xoá thuộc tính hệ thống',
-
             'immutable-fields'  => 'Không thể sửa các trường sau: :fields.',
             'not-found'         => 'Không tìm thấy thuộc tính với mã ":code"',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => 'Cập Nhật Trường Danh Mục Thành Công',
             'user-define-error' => 'Không thể xóa Trường Danh Mục hệ thống',
             'not-found'         => 'Không tìm thấy Trường Danh Mục với mã ":code"',
-
             'immutable-fields'  => 'Không thể sửa các trường sau: :fields.',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => 'Không thể cập nhật tùy chọn cấu hình vì gia đình này đã có sản phẩm biến thể.',
         ],
         'history' => [
-            'view' => 'Xem chi tiết phiên bản',
-
+            'view'  => 'Xem chi tiết phiên bản',
             'index' => [
                 'datagrid' => [
                     'version'   => 'Phiên bản',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => 'Đã tạm dừng',
                         'cancelled'            => 'Đã hủy',
                         'failed'               => 'Thất bại',
-
-                        'view'       => 'Xem',
+                        'view'                 => 'Xem',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => 'Lời nhắc',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => 'Tiêu đề',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => 'Lời nhắc hệ thống',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => 'Tiêu đề',
@@ -2011,8 +1997,9 @@ return [
                     'title' => 'Lọc',
                 ],
                 'search_by' => [
-                    'code'       => 'Tìm kiếm theo mã',
-                    'code_or_id' => 'Tìm kiếm theo mã hoặc ID',
+                    'code'        => 'Tìm kiếm theo mã',
+                    'code_or_id'  => 'Tìm kiếm theo mã hoặc ID',
+                    'sku_or_user' => 'Tìm kiếm theo SKU hoặc người dùng',
                 ],
                 'search' => [
                     'title' => 'Tìm kiếm',

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => '请输入有效的URL地址。',
                     'regex'                      => '该值不符合所需的模式。',
                     'invalid-pattern'            => '提供了无效的自定义模式。',
-
                     'numeric'                    => '数字属性":attribute"的值必须为有效的数字。',
                     'select-attribute-or-family' => '请选择至少一个属性或一个属性族。',
                     'failed'                     => '验证失败。',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => '批量编辑成功。',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => '没有可保存的更改。',
-
-                'invalid-datetime'            => '请输入有效的日期和时间。',
-
-                'resize-column'               => '拖动以调整列宽',
-                'success'                     => '任务已成功执行。',
-                'fetch-failed'                => '获取失败。',
-                'action'                      => '批量编辑',
-                'description'                 => '一次编辑多个产品。更改将在后台处理。',
-                'gallery-preview'             => '图库预览',
-                'img-preview'                 => '图片预览',
-                'no-image'                    => '无图片',
-                'img-fail'                    => '图片上传失败',
-                'no-option'                   => '无选项',
-                'keyboard-shortcuts'          => '键盘快捷键',
-                'shortcuts-navigation'        => '导航',
-                'shortcuts-editing'           => '编辑',
-                'shortcuts-selection'         => '选择',
-                'shortcuts-clipboard'         => '剪贴板与填充',
-                'shortcuts-move-cell'         => '在单元格间移动',
-                'shortcuts-move-down'         => '向下移动 / 确认编辑',
-                'shortcuts-move-up'           => '向上移动',
-                'shortcuts-move-right-left'   => '向右 / 向左移动',
-                'shortcuts-home-end'          => '行中第一 / 最后一列',
-                'shortcuts-ctrl-home-end'     => '网格中第一 / 最后一个单元格',
-                'shortcuts-extend-selection'  => '扩展选择',
-                'shortcuts-select-all'        => '选择所有单元格',
-                'shortcuts-enter-edit'        => '进入编辑模式',
-                'shortcuts-confirm-move-down' => '确认 + 向下移动',
-                'shortcuts-confirm-move-right'=> '确认 + 向右移动',
-                'shortcuts-escape-revert'     => '恢复值 + 退出编辑',
-                'shortcuts-clear-cell'        => '清除单元格',
-                'shortcuts-copy'              => '复制',
-                'shortcuts-cut'               => '剪切',
-                'shortcuts-paste'             => '粘贴',
-                'shortcuts-fill-down'         => '向下填充',
-                'shortcuts-fill-right'        => '向右填充',
-                'shortcuts-undo'              => '撤销',
-                'shortcuts-redo'              => '重做',
-                'shortcuts-help'              => '显示/隐藏键盘快捷键',
+                'id'                           => 'ID',
+                'no-changes'                   => '没有可保存的更改。',
+                'invalid-datetime'             => '请输入有效的日期和时间。',
+                'resize-column'                => '拖动以调整列宽',
+                'success'                      => '任务已成功执行。',
+                'fetch-failed'                 => '获取失败。',
+                'action'                       => '批量编辑',
+                'description'                  => '一次编辑多个产品。更改将在后台处理。',
+                'gallery-preview'              => '图库预览',
+                'img-preview'                  => '图片预览',
+                'no-image'                     => '无图片',
+                'img-fail'                     => '图片上传失败',
+                'no-option'                    => '无选项',
+                'keyboard-shortcuts'           => '键盘快捷键',
+                'shortcuts-navigation'         => '导航',
+                'shortcuts-editing'            => '编辑',
+                'shortcuts-selection'          => '选择',
+                'shortcuts-clipboard'          => '剪贴板与填充',
+                'shortcuts-move-cell'          => '在单元格间移动',
+                'shortcuts-move-down'          => '向下移动 / 确认编辑',
+                'shortcuts-move-up'            => '向上移动',
+                'shortcuts-move-right-left'    => '向右 / 向左移动',
+                'shortcuts-home-end'           => '行中第一 / 最后一列',
+                'shortcuts-ctrl-home-end'      => '网格中第一 / 最后一个单元格',
+                'shortcuts-extend-selection'   => '扩展选择',
+                'shortcuts-select-all'         => '选择所有单元格',
+                'shortcuts-enter-edit'         => '进入编辑模式',
+                'shortcuts-confirm-move-down'  => '确认 + 向下移动',
+                'shortcuts-confirm-move-right' => '确认 + 向右移动',
+                'shortcuts-escape-revert'      => '恢复值 + 退出编辑',
+                'shortcuts-clear-cell'         => '清除单元格',
+                'shortcuts-copy'               => '复制',
+                'shortcuts-cut'                => '剪切',
+                'shortcuts-paste'              => '粘贴',
+                'shortcuts-fill-down'          => '向下填充',
+                'shortcuts-fill-right'         => '向右填充',
+                'shortcuts-undo'               => '撤销',
+                'shortcuts-redo'               => '重做',
+                'shortcuts-help'               => '显示/隐藏键盘快捷键',
             ],
             'create-success'          => '成功创建的产品',
             'delete-failed'           => '产品删除失败',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => '可筛选',
                 'ai-translate'          => 'AI翻译',
                 'invalid-swatch-type'   => ':attribute 不允许用于属性类型 :type 和样本类型 :swatch_type。',
-
                 'single-object-only'    => '每个创建请求只能发送一个属性对象。',
                 'option'                => [
                     'color'    => '色板',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => '属性成功删除',
             'update-success'    => '属性成功更新',
             'user-define-error' => '无法删除系统属性',
-
             'immutable-fields'  => '以下字段无法修改：:fields。',
             'not-found'         => '无法找到代码为“:code”的属性',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => '类别字段成功更新',
             'user-define-error' => '无法删除系统类别字段',
             'not-found'         => '无法找到代码为“:code”的类别字段',
-
             'immutable-fields'  => '以下字段无法修改：:fields。',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => '无法更新可配置的选项，因为该家族已经拥有变体产品。',
         ],
         'history' => [
-            'view' => '查看版本详情',
-
+            'view'  => '查看版本详情',
             'index' => [
                 'datagrid' => [
                     'version'   => '版本',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => '已暂停',
                         'cancelled'            => '已取消',
                         'failed'               => '失败的',
-
-                        'view'       => '查看',
+                        'view'                 => '查看',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => '提示词',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => '标题',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => '系统提示词',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => '标题',
@@ -2011,8 +1997,9 @@ return [
                     'title' => '筛选',
                 ],
                 'search_by' => [
-                    'code'       => '通过代码搜索',
-                    'code_or_id' => '通过代码或ID搜索',
+                    'code'        => '通过代码搜索',
+                    'code_or_id'  => '通过代码或ID搜索',
+                    'sku_or_user' => '按 SKU 或用户搜索',
                 ],
                 'search' => [
                     'title' => '搜索',

--- a/packages/Webkul/Admin/src/Resources/lang/zh_TW/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_TW/app.php
@@ -364,7 +364,6 @@ return [
                     'url'                        => '請輸入有效的網址。',
                     'regex'                      => '值不符合所需的格式。',
                     'invalid-pattern'            => '提供了無效的自訂模式。',
-
                     'numeric'                    => '數字屬性「:attribute」的值必須為有效的數字。',
                     'select-attribute-or-family' => '請至少選擇一個屬性或屬性族。',
                     'failed'                     => '驗證失敗。',
@@ -385,47 +384,45 @@ return [
                 'handle-save' => [
                     'edit-success' => '批次編輯成功。',
                 ],
-                'id'                          => 'ID',
-                'no-changes'                  => '沒有要儲存的變更。',
-
-                'invalid-datetime'            => '請輸入有效的日期與時間。',
-
-                'resize-column'               => '拖動以調整欄寬',
-                'success'                     => '任務執行成功。',
-                'fetch-failed'                => '取得資料失敗。',
-                'action'                      => '批次編輯',
-                'description'                 => '一次編輯多個產品。變更將在背景中處理。',
-                'gallery-preview'             => '圖庫預覽',
-                'img-preview'                 => '圖片預覽',
-                'no-image'                    => '無圖片',
-                'img-fail'                    => '圖片上傳失敗',
-                'no-option'                   => '無選項',
-                'keyboard-shortcuts'          => '鍵盤快捷鍵',
-                'shortcuts-navigation'        => '導覽',
-                'shortcuts-editing'           => '編輯',
-                'shortcuts-selection'         => '選取',
-                'shortcuts-clipboard'         => '剪貼簿與填入',
-                'shortcuts-move-cell'         => '在儲存格間移動',
-                'shortcuts-move-down'         => '向下移動 / 確認編輯',
-                'shortcuts-move-up'           => '向上移動',
-                'shortcuts-move-right-left'   => '向右 / 向左移動',
-                'shortcuts-home-end'          => '列中第一 / 最後一欄',
-                'shortcuts-ctrl-home-end'     => '格中第一 / 最後一個儲存格',
-                'shortcuts-extend-selection'  => '延伸選取',
-                'shortcuts-select-all'        => '選取所有儲存格',
-                'shortcuts-enter-edit'        => '進入編輯模式',
-                'shortcuts-confirm-move-down' => '確認 + 向下移動',
-                'shortcuts-confirm-move-right'=> '確認 + 向右移動',
-                'shortcuts-escape-revert'     => '還原值 + 退出編輯',
-                'shortcuts-clear-cell'        => '清除儲存格',
-                'shortcuts-copy'              => '複製',
-                'shortcuts-cut'               => '剪下',
-                'shortcuts-paste'             => '貼上',
-                'shortcuts-fill-down'         => '向下填入',
-                'shortcuts-fill-right'        => '向右填入',
-                'shortcuts-undo'              => '復原',
-                'shortcuts-redo'              => '取消復原',
-                'shortcuts-help'              => '顯示/隱藏鍵盤快捷鍵',
+                'id'                           => 'ID',
+                'no-changes'                   => '沒有要儲存的變更。',
+                'invalid-datetime'             => '請輸入有效的日期與時間。',
+                'resize-column'                => '拖動以調整欄寬',
+                'success'                      => '任務執行成功。',
+                'fetch-failed'                 => '取得資料失敗。',
+                'action'                       => '批次編輯',
+                'description'                  => '一次編輯多個產品。變更將在背景中處理。',
+                'gallery-preview'              => '圖庫預覽',
+                'img-preview'                  => '圖片預覽',
+                'no-image'                     => '無圖片',
+                'img-fail'                     => '圖片上傳失敗',
+                'no-option'                    => '無選項',
+                'keyboard-shortcuts'           => '鍵盤快捷鍵',
+                'shortcuts-navigation'         => '導覽',
+                'shortcuts-editing'            => '編輯',
+                'shortcuts-selection'          => '選取',
+                'shortcuts-clipboard'          => '剪貼簿與填入',
+                'shortcuts-move-cell'          => '在儲存格間移動',
+                'shortcuts-move-down'          => '向下移動 / 確認編輯',
+                'shortcuts-move-up'            => '向上移動',
+                'shortcuts-move-right-left'    => '向右 / 向左移動',
+                'shortcuts-home-end'           => '列中第一 / 最後一欄',
+                'shortcuts-ctrl-home-end'      => '格中第一 / 最後一個儲存格',
+                'shortcuts-extend-selection'   => '延伸選取',
+                'shortcuts-select-all'         => '選取所有儲存格',
+                'shortcuts-enter-edit'         => '進入編輯模式',
+                'shortcuts-confirm-move-down'  => '確認 + 向下移動',
+                'shortcuts-confirm-move-right' => '確認 + 向右移動',
+                'shortcuts-escape-revert'      => '還原值 + 退出編輯',
+                'shortcuts-clear-cell'         => '清除儲存格',
+                'shortcuts-copy'               => '複製',
+                'shortcuts-cut'                => '剪下',
+                'shortcuts-paste'              => '貼上',
+                'shortcuts-fill-down'          => '向下填入',
+                'shortcuts-fill-right'         => '向右填入',
+                'shortcuts-undo'               => '復原',
+                'shortcuts-redo'               => '取消復原',
+                'shortcuts-help'               => '顯示/隱藏鍵盤快捷鍵',
             ],
             'create-success'          => '產品創建成功',
             'delete-failed'           => '刪除產品時出錯',
@@ -520,7 +517,6 @@ return [
                 'is-filterable'         => '可篩選',
                 'ai-translate'          => '人工智慧翻譯',
                 'invalid-swatch-type'   => ':attribute 不允許用於屬性類型 :type，搭配色板類型 :swatch_type。',
-
                 'single-object-only'    => '每個建立請求只能傳送一個屬性物件。',
                 'option'                => [
                     'color'    => '顏色樣本',
@@ -604,7 +600,6 @@ return [
             'delete-success'    => '屬性已成功刪除',
             'update-success'    => '屬性已成功更新',
             'user-define-error' => '無法刪除系統屬性',
-
             'immutable-fields'  => '以下欄位無法修改：:fields。',
             'not-found'         => '找不到代碼 ":code" 的屬性',
         ],
@@ -887,7 +882,6 @@ return [
             'update-success'    => '類別欄位更新成功',
             'user-define-error' => '無法刪除系統預設類別欄位',
             'not-found'         => '找不到代碼為 ":code" 的類別欄位',
-
             'immutable-fields'  => '以下欄位無法修改：:fields。',
         ],
         'category-fields-options' => [
@@ -989,8 +983,7 @@ return [
             'can-not-update-variant-options' => '此家族已有產品變體，因此無法更新配置選項。',
         ],
         'history' => [
-            'view' => '檢視版本詳情',
-
+            'view'  => '檢視版本詳情',
             'index' => [
                 'datagrid' => [
                     'version'   => '版本',
@@ -1124,8 +1117,7 @@ return [
                         'paused'               => '已暫停',
                         'cancelled'            => '已取消',
                         'failed'               => '失敗',
-
-                        'view'       => '查看',
+                        'view'                 => '查看',
                     ],
                 ],
                 'import' => [
@@ -1783,11 +1775,8 @@ return [
         ],
         'prompt' => [
             'index' => [
-
                 'title' => '提示詞',
-
             ],
-
             'datagrid' => [
                 'id'               => 'ID',
                 'title'            => '標題',
@@ -1831,11 +1820,8 @@ return [
         ],
         'system-prompt' => [
             'index' => [
-
                 'title' => '系統提示詞',
-
             ],
-
             'datagrid' => [
                 'id'          => 'ID',
                 'title'       => '標題',
@@ -2011,8 +1997,9 @@ return [
                     'title' => '過濾',
                 ],
                 'search_by' => [
-                    'code'       => '按代碼搜索',
-                    'code_or_id' => '按代碼或ID搜索',
+                    'code'        => '按代碼搜索',
+                    'code_or_id'  => '按代碼或ID搜索',
+                    'sku_or_user' => '按 SKU 或使用者搜尋',
                 ],
                 'search' => [
                     'title' => '搜索',

--- a/packages/Webkul/Admin/tests/Feature/Webhook/WebhookLogsSearchPlaceholderTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Webhook/WebhookLogsSearchPlaceholderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Webkul\Webhook\DataGrids\LogsDataGrid;
+
+it('webhook logs grid placeholder references the sku/user search key, not code', function () {
+    $grid = new LogsDataGrid;
+
+    $reflection = new ReflectionClass($grid);
+    $property = $reflection->getProperty('searchPlaceholder');
+    $property->setAccessible(true);
+
+    $placeholderKey = $property->getValue($grid);
+
+    expect($placeholderKey)
+        ->toBe('admin::app.components.datagrid.toolbar.search_by.sku_or_user');
+});
+
+it('the sku_or_user translation key resolves to an English string that mentions SKU or user', function () {
+    $resolved = __('admin::app.components.datagrid.toolbar.search_by.sku_or_user', [], 'en_US');
+
+    expect($resolved)
+        ->not->toBe('admin::app.components.datagrid.toolbar.search_by.sku_or_user')
+        ->and(strtolower($resolved))
+        ->toContain('sku');
+});

--- a/packages/Webkul/Admin/tests/Feature/Webhook/WebhookLogsSearchPlaceholderTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Webhook/WebhookLogsSearchPlaceholderTest.php
@@ -21,5 +21,6 @@ it('the sku_or_user translation key resolves to an English string that mentions 
     expect($resolved)
         ->not->toBe('admin::app.components.datagrid.toolbar.search_by.sku_or_user')
         ->and(strtolower($resolved))
-        ->toContain('sku');
+        ->toContain('sku')
+        ->toContain('user');
 });

--- a/packages/Webkul/Webhook/src/DataGrids/LogsDataGrid.php
+++ b/packages/Webkul/Webhook/src/DataGrids/LogsDataGrid.php
@@ -14,7 +14,7 @@ class LogsDataGrid extends DataGrid
      *
      * @var string
      */
-    protected $searchPlaceholder = 'admin::app.components.datagrid.toolbar.search_by.code';
+    protected $searchPlaceholder = 'admin::app.components.datagrid.toolbar.search_by.sku_or_user';
 
     /**
      * Prepare query builder.


### PR DESCRIPTION
## Summary
Fixed The webhook logs grid (`/admin/webhook/settings?logs`) showed "Search by code" in the toolbar, but the underlying datagrid only exposes `sku` and `user` as searchable columns — there is no `code` column on `webhook_logs`, leaving users to guess what "code" referred to.

## Fix
- `LogsDataGrid::$searchPlaceholder` now points at `admin::app.components.datagrid.toolbar.search_by.sku_or_user`.
- New `sku_or_user` key added under `components.datagrid.toolbar.search_by` in **all 33 Admin locale files**, each with a native translation.
- `unopim:translations:check` audit: **224/224 PASS**.

## Test plan
- [x] `pest` — `WebhookLogsSearchPlaceholderTest` (2 tests guarding the placeholder key + resolved English string)
- [x] `pest` — full `Admin/tests/Feature/Webhook` + `DataGrid/tests` suites green
- [x] `pint` — clean on all touched files
- [x] `artisan unopim:translations:check` — 100% per locale
- [ ] Manual: open `/admin/webhook/settings?logs` and verify placeholder reads **"Search by SKU or user"** (and the localized variant when switching UI language)
