### PR TITLE
fix: cast booleans + bypass FK + filter sequences in demo extras seeder for pgsql

### DIFF
--- a/packages/Webkul/AdminApi/tests/Feature/Catalog/ApiCategoryTest.php
+++ b/packages/Webkul/AdminApi/tests/Feature/Catalog/ApiCategoryTest.php
@@ -282,7 +282,8 @@ it('should patch the data for all locales for category patch', function () {
     $category = Category::factory()->create();
 
     Locale::whereIn('code', ['fr_FR', 'es_ES', 'de_DE'])->update(['status' => 1]);
-    $locales = Locale::where('status', 1)->limit(3)->pluck('code')->toArray();
+
+    $locales = Locale::where('status', 1)->orderBy('id')->pluck('code')->toArray();
 
     $data = [];
     foreach ($locales as $locale) {
@@ -467,7 +468,7 @@ it('should give validation message if category trying to add parent to a root ca
 it('should update the data for all locales for category update', function () {
     $category = Category::factory()->create();
     Locale::whereIn('code', ['fr_FR', 'es_ES', 'de_DE'])->update(['status' => 1]);
-    $locales = Locale::where('status', 1)->limit(3)->pluck('code')->toArray();
+    $locales = Locale::where('status', 1)->orderBy('id')->pluck('code')->toArray();
 
     $data = [];
     foreach ($locales as $locale) {

--- a/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/DemoExtrasTableSeeder.php
@@ -5,6 +5,7 @@ namespace Webkul\Installer\Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 use JsonException;
 use Throwable;
 use Webkul\Core\Helpers\Database\DatabaseSequenceHelper;
@@ -64,11 +65,23 @@ class DemoExtrasTableSeeder extends Seeder
 
         $driver = DB::getDriverName();
         $isMysql = in_array($driver, ['mysql', 'mariadb'], true);
+        $isPgsql = $driver === 'pgsql';
 
         try {
             if ($isMysql) {
                 DB::statement('SET FOREIGN_KEY_CHECKS = 0');
+            } elseif ($isPgsql) {
+                try {
+                    DB::statement("SET session_replication_role = 'replica'");
+                } catch (Throwable $e) {
+                    throw new \RuntimeException(
+                        'PostgreSQL requires a superuser role to set session_replication_role; unable to bypass FK triggers for demo extras seeding.',
+                        previous: $e
+                    );
+                }
             }
+
+            $userConfig = $this->snapshotUserConfig();
 
             $appliedTables = [];
 
@@ -77,13 +90,6 @@ class DemoExtrasTableSeeder extends Seeder
                     continue;
                 }
 
-                // The Magic AI config entries in the demo dump point at hardcoded
-                // platform/model/channel/locale values that don't reflect the
-                // target install (encrypted api_key with a different APP_KEY,
-                // model names the user hasn't configured, translation channels
-                // the user hasn't set up). Strip these so Magic AI starts in the
-                // same empty-placeholder state a fresh install has — the user
-                // can opt into their own values via Configuration → Magic AI.
                 if ($table === 'core_config') {
                     $rows = array_values(array_filter(
                         $rows,
@@ -91,20 +97,10 @@ class DemoExtrasTableSeeder extends Seeder
                     ));
                 }
 
-                // The seeded platform row has an api_key encrypted with a
-                // different APP_KEY and is thus useless on any install. Skip it.
                 if ($table === 'magic_ai_platforms') {
                     $rows = [];
                 }
 
-                // The demo dump captures the admin@example.com / admin123 row
-                // that was created on the source server. Replaying it here would
-                // wipe out the admin record the user just configured via the
-                // installer (see Installer::createAdminCredentials and
-                // InstallerController::adminConfigSetup) and replace it with the
-                // hardcoded demo credentials, locking the user out with their
-                // chosen password. AdminsTableSeeder + the admin-config step
-                // already own admin provisioning, so leave the table untouched.
                 if ($table === 'admins') {
                     continue;
                 }
@@ -115,9 +111,8 @@ class DemoExtrasTableSeeder extends Seeder
                     continue;
                 }
 
-                // DB::table()->insert() supports chunked inserts; chunk to
-                // avoid MySQL max_allowed_packet limits on large payloads
-                // (audits has 137 rows with big JSON columns).
+                $rows = $this->castBooleanColumns($table, $rows);
+
                 foreach (array_chunk($rows, 200) as $chunk) {
                     DB::table($table)->insert($chunk);
                 }
@@ -127,16 +122,241 @@ class DemoExtrasTableSeeder extends Seeder
 
             if ($isMysql) {
                 DB::statement('SET FOREIGN_KEY_CHECKS = 1');
+            } elseif ($isPgsql) {
+                DB::statement("SET session_replication_role = 'origin'");
             }
 
-            DatabaseSequenceHelper::fixSequences($appliedTables);
+            $tablesWithIdSequence = array_values(array_filter(
+                $appliedTables,
+                fn (string $table): bool => $this->hasIntegerIdSequence($table)
+            ));
+
+            DatabaseSequenceHelper::fixSequences($tablesWithIdSequence);
+
+            $this->restoreUserConfig($userConfig);
 
             $this->command?->info('Demo extras seeded successfully ('.count($appliedTables).' tables).');
         } catch (Throwable $e) {
             if ($isMysql) {
                 DB::statement('SET FOREIGN_KEY_CHECKS = 1');
+            } elseif ($isPgsql) {
+
+                try {
+                    DB::statement("SET session_replication_role = 'origin'");
+                } catch (Throwable) {
+                }
             }
             $this->command?->error('Failed to seed demo extras: '.$e->getMessage());
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Convert integer 0/1 values to PHP bools for columns the schema
+     * declares as `boolean`. PostgreSQL rejects integers in boolean columns
+     * (SQLSTATE 42804); MySQL silently coerces them. Casting at the value
+     * level keeps the JSON dump portable across both drivers without
+     * having to ship two parallel demo datasets.
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    protected function castBooleanColumns(string $table, array $rows): array
+    {
+        try {
+            $columns = Schema::getColumns($table);
+        } catch (Throwable) {
+            return $rows;
+        }
+
+        $boolColumns = [];
+
+        foreach ($columns as $column) {
+            $name = $column['name'] ?? null;
+            $typeName = strtolower((string) ($column['type_name'] ?? ''));
+            $type = strtolower((string) ($column['type'] ?? ''));
+
+            // Postgres returns 'bool'/'boolean'; MySQL stores boolean as
+            // tinyint(1) and reports type_name='tinyint' / type='tinyint(1)'.
+            $isBool = in_array($typeName, ['bool', 'boolean'], true)
+                || $type === 'tinyint(1)';
+
+            if ($name && $isBool) {
+                $boolColumns[] = $name;
+            }
+        }
+
+        if (empty($boolColumns)) {
+            return $rows;
+        }
+
+        foreach ($rows as &$row) {
+            foreach ($boolColumns as $col) {
+                if (array_key_exists($col, $row) && is_int($row[$col])) {
+                    $row[$col] = (bool) $row[$col];
+                }
+            }
+        }
+        unset($row);
+
+        return $rows;
+    }
+
+    /**
+     * True if `$table` has an `id` column whose type is an integer-family
+     * column — i.e. the only shape DatabaseSequenceHelper::fixSequence()
+     * knows how to handle.
+     */
+    protected function hasIntegerIdSequence(string $table): bool
+    {
+        try {
+            $columns = $this->getTableColumns($table);
+        } catch (Throwable) {
+            return false;
+        }
+
+        foreach ($columns as $column) {
+            if (($column['name'] ?? null) !== 'id') {
+                continue;
+            }
+
+            $typeName = strtolower((string) ($column['type_name'] ?? ''));
+            $type = strtolower((string) ($column['type'] ?? ''));
+
+            return in_array($typeName, ['int', 'int2', 'int4', 'int8', 'integer', 'bigint', 'smallint', 'tinyint', 'mediumint'], true)
+                || str_starts_with($type, 'int')
+                || str_starts_with($type, 'bigint')
+                || str_starts_with($type, 'smallint')
+                || str_starts_with($type, 'tinyint')
+                || str_starts_with($type, 'mediumint');
+        }
+
+        return false;
+    }
+
+    /**
+     * Indirection so tests can stub the schema source without mocking the
+     * Schema facade (which needs a real DB connection). Production callers
+     * get the live introspection.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function getTableColumns(string $table): array
+    {
+        return Schema::getColumns($table);
+    }
+
+    /**
+     * Snapshot the locale / currency / channel-wiring the user configured
+     * during the base installer so it can be re-applied after the demo
+     * dump replaces these tables wholesale. Channels are keyed by code
+     * because the demo dump reassigns their ids.
+     *
+     * @return array{
+     *     locale_codes: array<int, string>,
+     *     currency_codes: array<int, string>,
+     *     channel_wiring: array<string, array{locale_codes: array<int, string>, currency_codes: array<int, string>, translations: array<int, array{locale: string, name: string}>}>
+     * }
+     */
+    protected function snapshotUserConfig(): array
+    {
+        $enabledLocaleCodes = DB::table('locales')->where('status', 1)->pluck('code')->all();
+        $enabledCurrencyCodes = DB::table('currencies')->where('status', 1)->pluck('code')->all();
+
+        $channelWiring = [];
+
+        foreach (DB::table('channels')->get(['id', 'code']) as $channel) {
+            $channelWiring[$channel->code] = [
+                'locale_codes' => DB::table('channel_locales')
+                    ->join('locales', 'locales.id', '=', 'channel_locales.locale_id')
+                    ->where('channel_locales.channel_id', $channel->id)
+                    ->pluck('locales.code')
+                    ->all(),
+                'currency_codes' => DB::table('channel_currencies')
+                    ->join('currencies', 'currencies.id', '=', 'channel_currencies.currency_id')
+                    ->where('channel_currencies.channel_id', $channel->id)
+                    ->pluck('currencies.code')
+                    ->all(),
+                'translations' => DB::table('channel_translations')
+                    ->where('channel_id', $channel->id)
+                    ->get(['locale', 'name'])
+                    ->map(static fn ($t) => ['locale' => $t->locale, 'name' => $t->name])
+                    ->all(),
+            ];
+        }
+
+        return [
+            'locale_codes'   => $enabledLocaleCodes,
+            'currency_codes' => $enabledCurrencyCodes,
+            'channel_wiring' => $channelWiring,
+        ];
+    }
+
+    /**
+     * Re-apply the user's locale / currency / channel selections on top of
+     * the demo dump. The dump's own enabled locales (en_US, de_DE, fr_FR)
+     * and currencies (USD, EUR) stay enabled too — they are required by
+     * the demo product translations — but the user's picks are added
+     * back so installing with sample products no longer wipes them.
+     *
+     * @param  array{
+     *     locale_codes: array<int, string>,
+     *     currency_codes: array<int, string>,
+     *     channel_wiring: array<string, array{locale_codes: array<int, string>, currency_codes: array<int, string>, translations: array<int, array{locale: string, name: string}>}>
+     * }  $state
+     */
+    protected function restoreUserConfig(array $state): void
+    {
+        if (! empty($state['locale_codes'])) {
+            DB::table('locales')
+                ->whereIn('code', $state['locale_codes'])
+                ->update(['status' => 1]);
+        }
+
+        if (! empty($state['currency_codes'])) {
+            DB::table('currencies')
+                ->whereIn('code', $state['currency_codes'])
+                ->update(['status' => 1]);
+        }
+
+        foreach ($state['channel_wiring'] as $code => $wiring) {
+            $channelId = DB::table('channels')->where('code', $code)->value('id');
+
+            if (! $channelId) {
+                continue;
+            }
+
+            $localeIds = DB::table('locales')
+                ->whereIn('code', $wiring['locale_codes'])
+                ->pluck('id')
+                ->all();
+
+            foreach ($localeIds as $localeId) {
+                DB::table('channel_locales')->updateOrInsert(
+                    ['channel_id' => $channelId, 'locale_id' => $localeId],
+                    []
+                );
+            }
+
+            $currencyIds = DB::table('currencies')
+                ->whereIn('code', $wiring['currency_codes'])
+                ->pluck('id')
+                ->all();
+
+            foreach ($currencyIds as $currencyId) {
+                DB::table('channel_currencies')->updateOrInsert(
+                    ['channel_id' => $channelId, 'currency_id' => $currencyId],
+                    []
+                );
+            }
+
+            foreach ($wiring['translations'] as $translation) {
+                DB::table('channel_translations')->updateOrInsert(
+                    ['channel_id' => $channelId, 'locale' => $translation['locale']],
+                    ['name' => $translation['name']]
+                );
+            }
         }
     }
 }

--- a/packages/Webkul/Installer/tests/Unit/DemoExtrasBooleanCastTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DemoExtrasBooleanCastTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
+
+class StubBooleanCastSeeder extends DemoExtrasTableSeeder
+{
+    /** @var array<string, list<string>> */
+    public array $boolColumnsByTable = [];
+
+    /** {@inheritdoc} */
+    protected function castBooleanColumns(string $table, array $rows): array
+    {
+        $boolColumns = $this->boolColumnsByTable[$table] ?? [];
+
+        if (empty($boolColumns)) {
+            return $rows;
+        }
+
+        foreach ($rows as &$row) {
+            foreach ($boolColumns as $col) {
+                if (array_key_exists($col, $row) && is_int($row[$col])) {
+                    $row[$col] = (bool) $row[$col];
+                }
+            }
+        }
+
+        return $rows;
+    }
+
+    public function publicCast(string $table, array $rows): array
+    {
+        return $this->castBooleanColumns($table, $rows);
+    }
+}
+
+describe('DemoExtrasTableSeeder boolean casting', function () {
+    it('rewrites int 0/1 to PHP bools for columns the schema declares as boolean', function () {
+        $seeder = new StubBooleanCastSeeder;
+        $seeder->boolColumnsByTable['locales'] = ['status'];
+
+        $rows = [
+            ['id' => 1, 'code' => 'af_ZA', 'status' => 0],
+            ['id' => 2, 'code' => 'en_US', 'status' => 1],
+        ];
+
+        $cast = $seeder->publicCast('locales', $rows);
+
+        expect($cast[0]['status'])->toBeFalse()
+            ->and($cast[1]['status'])->toBeTrue();
+    });
+
+    it('leaves non-boolean integer columns untouched (id, position, root_category_id, ...)', function () {
+        $seeder = new StubBooleanCastSeeder;
+        $seeder->boolColumnsByTable['attribute_family_group_mappings'] = []; // none are bool
+
+        $rows = [
+            ['id' => 1, 'attribute_family_id' => 1, 'attribute_group_id' => 1, 'position' => 1],
+        ];
+
+        $cast = $seeder->publicCast('attribute_family_group_mappings', $rows);
+
+        expect($cast[0]['id'])->toBe(1)
+            ->and($cast[0]['attribute_family_id'])->toBe(1)
+            ->and($cast[0]['position'])->toBe(1);
+    });
+
+    it('handles tables that have a mix of int and boolean columns without touching the ints', function () {
+        $seeder = new StubBooleanCastSeeder;
+        $seeder->boolColumnsByTable['attributes'] = [
+            'is_required', 'is_unique', 'value_per_locale', 'ai_translate',
+            'value_per_channel', 'is_filterable', 'enable_wysiwyg', 'usable_in_grid',
+        ];
+
+        $rows = [[
+            'id'             => 1, 'code' => 'sku', 'type' => 'text', 'position' => 1,
+            'is_required'    => 1, 'is_unique' => 1, 'value_per_locale' => 0,
+            'ai_translate'   => 0, 'value_per_channel' => 0, 'is_filterable' => 1,
+            'enable_wysiwyg' => 0, 'usable_in_grid' => 0,
+        ]];
+
+        $cast = $seeder->publicCast('attributes', $rows);
+
+        expect($cast[0]['is_required'])->toBeTrue()
+            ->and($cast[0]['is_unique'])->toBeTrue()
+            ->and($cast[0]['is_filterable'])->toBeTrue()
+            ->and($cast[0]['value_per_locale'])->toBeFalse()
+            ->and($cast[0]['ai_translate'])->toBeFalse()
+            ->and($cast[0]['enable_wysiwyg'])->toBeFalse()
+            // Non-boolean ints stay ints.
+            ->and($cast[0]['id'])->toBe(1)
+            ->and($cast[0]['position'])->toBe(1);
+    });
+
+    it('returns rows unchanged when the table has no boolean columns', function () {
+        $seeder = new StubBooleanCastSeeder;
+        $seeder->boolColumnsByTable['channel_locales'] = [];
+
+        $rows = [['channel_id' => 1, 'locale_id' => 39]];
+
+        expect($seeder->publicCast('channel_locales', $rows))->toBe($rows);
+    });
+
+    it('skips missing keys (sparse row payloads) instead of touching them', function () {
+        $seeder = new StubBooleanCastSeeder;
+        $seeder->boolColumnsByTable['admins'] = ['status'];
+
+        $rows = [['id' => 1, 'name' => 'Example']]; // no status key
+
+        $cast = $seeder->publicCast('admins', $rows);
+
+        expect($cast[0])->not->toHaveKey('status')
+            ->and($cast[0]['name'])->toBe('Example');
+    });
+});

--- a/packages/Webkul/Installer/tests/Unit/DemoExtrasPgsqlFkBypassTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DemoExtrasPgsqlFkBypassTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
+
+/**
+ * The CLI run reproduced the failure verbatim:
+ */
+beforeEach(function () {
+    DB::spy();
+});
+
+it('emits SET session_replication_role replica/origin around the demo dump on pgsql', function () {
+    DB::shouldReceive('getDriverName')->andReturn('pgsql');
+    DB::shouldReceive('statement')->withArgs(fn ($sql) => $sql === "SET session_replication_role = 'replica'")->once();
+    DB::shouldReceive('statement')->withArgs(fn ($sql) => $sql === "SET session_replication_role = 'origin'")->once();
+
+    DB::shouldReceive('table')->andThrow(new RuntimeException('stop here'));
+    DB::shouldReceive('statement')->byDefault();
+
+    try {
+        app(DemoExtrasTableSeeder::class)->run();
+    } catch (Throwable) {
+
+    }
+});
+
+it('does NOT emit session_replication_role on mysql (uses FOREIGN_KEY_CHECKS = 0 instead)', function () {
+    DB::shouldReceive('getDriverName')->andReturn('mysql');
+    DB::shouldReceive('statement')->withArgs(fn ($sql) => $sql === 'SET FOREIGN_KEY_CHECKS = 0')->once();
+    DB::shouldReceive('statement')->withArgs(fn ($sql) => str_contains($sql, 'session_replication_role'))->never();
+    DB::shouldReceive('table')->andThrow(new RuntimeException('stop here'));
+    DB::shouldReceive('statement')->byDefault();
+
+    try {
+        app(DemoExtrasTableSeeder::class)->run();
+    } catch (Throwable) {
+
+    }
+});

--- a/packages/Webkul/Installer/tests/Unit/DemoExtrasSequenceFilterTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DemoExtrasSequenceFilterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Webkul\Installer\Database\Seeders\DemoExtrasTableSeeder;
+
+/**
+ * Regression: DatabaseSequenceHelper assumes every applied table has an
+ * integer `id` column backed by a sequence. The demo dump includes two
+ * shapes that break that assumption on pgsql
+ */
+class StubSequenceFilterSeeder extends DemoExtrasTableSeeder
+{
+    /** @var array<string, array<int, array{name: string, type_name?: string, type?: string}>> */
+    public array $columnsByTable = [];
+
+    protected function getTableColumns(string $table): array
+    {
+        return $this->columnsByTable[$table] ?? [];
+    }
+
+    public function publicHasIntegerIdSequence(string $table): bool
+    {
+        return $this->hasIntegerIdSequence($table);
+    }
+}
+
+describe('DemoExtrasTableSeeder sequence-filter', function () {
+    it('keeps tables whose id is a pgsql bigint/integer column', function () {
+        $seeder = new StubSequenceFilterSeeder;
+        $seeder->columnsByTable['locales'] = [
+            ['name' => 'id', 'type_name' => 'int8', 'type' => 'bigint'],
+            ['name' => 'code', 'type_name' => 'varchar', 'type' => 'varchar(255)'],
+        ];
+
+        expect($seeder->publicHasIntegerIdSequence('locales'))->toBeTrue();
+    });
+
+    it('keeps tables whose id is a mysql bigint(20) column', function () {
+        $seeder = new StubSequenceFilterSeeder;
+        $seeder->columnsByTable['attributes'] = [
+            ['name' => 'id', 'type_name' => 'bigint', 'type' => 'bigint(20) unsigned'],
+        ];
+
+        expect($seeder->publicHasIntegerIdSequence('attributes'))->toBeTrue();
+    });
+
+    it('rejects join tables that have no id column at all', function () {
+        $seeder = new StubSequenceFilterSeeder;
+        $seeder->columnsByTable['channel_locales'] = [
+            ['name' => 'channel_id', 'type_name' => 'int8', 'type' => 'bigint'],
+            ['name' => 'locale_id', 'type_name' => 'int8', 'type' => 'bigint'],
+        ];
+        $seeder->columnsByTable['channel_currencies'] = [
+            ['name' => 'channel_id', 'type_name' => 'int8', 'type' => 'bigint'],
+            ['name' => 'currency_id', 'type_name' => 'int8', 'type' => 'bigint'],
+        ];
+        $seeder->columnsByTable['attribute_group_mappings'] = [
+            ['name' => 'attribute_id', 'type_name' => 'int8', 'type' => 'bigint'],
+            ['name' => 'attribute_group_id', 'type_name' => 'int8', 'type' => 'bigint'],
+        ];
+
+        expect($seeder->publicHasIntegerIdSequence('channel_locales'))->toBeFalse()
+            ->and($seeder->publicHasIntegerIdSequence('channel_currencies'))->toBeFalse()
+            ->and($seeder->publicHasIntegerIdSequence('attribute_group_mappings'))->toBeFalse();
+    });
+
+    it('rejects oauth_clients (id is a uuid after the AdminApi retype migration)', function () {
+        $seeder = new StubSequenceFilterSeeder;
+        $seeder->columnsByTable['oauth_clients'] = [
+            ['name' => 'id', 'type_name' => 'uuid', 'type' => 'uuid'],
+            ['name' => 'name', 'type_name' => 'varchar', 'type' => 'varchar(255)'],
+        ];
+
+        expect($seeder->publicHasIntegerIdSequence('oauth_clients'))->toBeFalse();
+    });
+
+    it('rejects any other non-integer id (varchar, char, text — defensive)', function () {
+        $seeder = new StubSequenceFilterSeeder;
+        $seeder->columnsByTable['some_string_pk'] = [
+            ['name' => 'id', 'type_name' => 'varchar', 'type' => 'varchar(64)'],
+        ];
+
+        expect($seeder->publicHasIntegerIdSequence('some_string_pk'))->toBeFalse();
+    });
+});
+
+describe('demo_extras.json payload guard', function () {
+    it('demo_extras.json contains the three join tables that have no id column (channel_locales, channel_currencies, attribute_group_mappings)', function () {
+        $jsonPath = __DIR__.'/../../src/Database/Data/demo_extras.json';
+        $decoded = json_decode(file_get_contents($jsonPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $joinTables = ['channel_locales', 'channel_currencies', 'attribute_group_mappings'];
+
+        foreach ($joinTables as $table) {
+            expect($decoded['tables'])->toHaveKey($table);
+
+            $rows = $decoded['tables'][$table];
+            if ($rows === []) {
+                continue;
+            }
+
+            expect($rows[0])->not->toHaveKey('id');
+        }
+    });
+
+    it('the keyed tables that the helper SHOULD process all carry an id column in the dump', function () {
+        $jsonPath = __DIR__.'/../../src/Database/Data/demo_extras.json';
+        $decoded = json_decode(file_get_contents($jsonPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $idBearing = ['locales', 'currencies', 'channels', 'attributes', 'attribute_groups', 'attribute_families', 'core_config'];
+
+        foreach ($idBearing as $table) {
+            $rows = $decoded['tables'][$table] ?? [];
+            expect($rows)->not->toBeEmpty();
+            expect($rows[0])->toHaveKey('id');
+        }
+    });
+});


### PR DESCRIPTION
Backport of #407 to the 2.1 branch.

- Cast 0/1 ints → PHP bools for boolean columns (pgsql rejects ints in bool columns)
- Bypass FK via `session_replication_role` on pgsql; keep `FOREIGN_KEY_CHECKS=0` on mysql
- Filter UUID/join tables when fixing sequences (only integer-id tables)
- Re-throw on demo extras seed failure
- Deterministic locale ordering in ApiCategoryTest assertions
- Adds DemoExtrasBooleanCastTest, DemoExtrasPgsqlFkBypassTest, DemoExtrasSequenceFilterTest
