### PR TITLE
fix: reject special characters in DB_DATABASE to prevent reinstall failure

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -291,7 +291,17 @@ class Installer extends Command
             'DB_DATABASE' => text(
                 label: 'Please enter the database name',
                 default: env('DB_DATABASE') ?? '',
-                required: true
+                required: true,
+                validate: function (string $value): ?string {
+                    $trimmed = trim($value);
+
+                    return match (true) {
+                        $trimmed === ''                                 => 'The database name is required.',
+                        (bool) preg_match('/[^A-Za-z0-9_]/', $trimmed)  => 'The database name can only contain letters, numbers, and underscores. Characters like dots, dashes, and spaces are not allowed because they break SQL identifier quoting.',
+                        default                                         => null,
+                    };
+                },
+                transform: trim(...),
             ),
 
             'DB_PREFIX' => text(

--- a/packages/Webkul/Installer/tests/Feature/DatabaseNameValidationTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabaseNameValidationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Webkul\Installer\Console\Commands\Installer;
+
+function bindInstallerCapturingDbNameEnvUpdate(array &$captured): Closure
+{
+    return function () use (&$captured) {
+        return new class($captured) extends Installer
+        {
+            private array $captured;
+
+            public function __construct(array &$captured)
+            {
+                parent::__construct();
+                $this->captured = &$captured;
+            }
+
+            public function call($command, array $arguments = [], $output = null)
+            {
+                return 0;
+            }
+
+            protected function envUpdate(string $key, string $value): void
+            {
+                $this->captured[$key] = $value;
+            }
+
+            public function handle()
+            {
+                $this->askForDatabaseDetails();
+
+                return 0;
+            }
+        };
+    };
+}
+
+it('rejects DB_DATABASE containing a dot so DROP TABLE wk_db.table cannot be parsed as a multi-segment identifier', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbNameEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', '1.2.3')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_DATABASE');
+});
+
+it('rejects DB_DATABASE containing a dash', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbNameEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'my-db')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_DATABASE');
+});
+
+it('accepts valid alphanumeric DB_DATABASE ', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbNameEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim_v2')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_DATABASE'])->toBe('unopim_v2');
+});


### PR DESCRIPTION
Backport of #405 to the 2.1 branch.

- Reject special characters in DB_DATABASE (only letters, numbers, underscores allowed)
- Trim whitespace via Prompts `transform` option
- Adds DatabaseNameValidationTest
