### PR TITLE
fix(installer): trim whitespace from DB inputs to prevent quoted .env values

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -279,13 +279,21 @@ class Installer extends Command
             'DB_HOST'       => text(
                 label: 'Please enter the database host',
                 default: env('DB_HOST') ?? '127.0.0.1',
-                required: true
+                required: true,
+                validate: fn (string $value) => preg_match('/\s/', trim($value))
+                    ? 'The database host cannot contain whitespace.'
+                    : null,
+                transform: trim(...),
             ),
 
             'DB_PORT'       => text(
                 label: 'Please enter the database port',
                 default: env('DB_PORT') ?? '3306',
-                required: true
+                required: true,
+                validate: fn (string $value) => ctype_digit(trim($value))
+                    ? null
+                    : 'The database port must be numeric.',
+                transform: trim(...),
             ),
 
             'DB_DATABASE' => text(
@@ -324,7 +332,11 @@ class Installer extends Command
             'DB_USERNAME' => text(
                 label: 'Please enter your database username',
                 default: env('DB_USERNAME') ?? '',
-                required: true
+                required: true,
+                validate: fn (string $value) => preg_match('/\s/', trim($value))
+                    ? 'The database username cannot contain whitespace.'
+                    : null,
+                transform: trim(...),
             ),
 
             'DB_PASSWORD' => password(
@@ -333,12 +345,14 @@ class Installer extends Command
             ),
         ];
 
-        $databaseDetails['DB_PREFIX'] = trim((string) ($databaseDetails['DB_PREFIX'] ?? ''));
+        foreach (['DB_HOST', 'DB_PORT', 'DB_DATABASE', 'DB_PREFIX', 'DB_USERNAME'] as $trimKey) {
+            $databaseDetails[$trimKey] = trim((string) ($databaseDetails[$trimKey] ?? ''));
+        }
 
         if (
-            ! $databaseDetails['DB_DATABASE']
-            || ! $databaseDetails['DB_USERNAME']
-            || ! $databaseDetails['DB_PASSWORD']
+            $databaseDetails['DB_DATABASE'] === ''
+            || $databaseDetails['DB_USERNAME'] === ''
+            || $databaseDetails['DB_PASSWORD'] === ''
         ) {
             return $this->error('Please enter the database credentials.');
         }
@@ -380,19 +394,22 @@ class Installer extends Command
         if ($connectionType === 'cloud') {
             $cloudId = text(
                 label: 'Please enter your Elasticsearch Cloud ID',
-                default: env('ELASTICSEARCH_CLOUD_ID') ?? ''
+                default: env('ELASTICSEARCH_CLOUD_ID') ?? '',
+                transform: trim(...),
             );
             $this->envUpdate('ELASTICSEARCH_CLOUD_ID', $cloudId);
         } else {
             $host = text(
                 label: 'Please enter the Elasticsearch host',
-                default: env('ELASTICSEARCH_HOST') ?? '127.0.0.1:9200'
+                default: env('ELASTICSEARCH_HOST') ?? '127.0.0.1:9200',
+                transform: trim(...),
             );
             $this->envUpdate('ELASTICSEARCH_HOST', $host);
 
             $user = text(
                 label: 'Please enter the Elasticsearch user',
-                default: env('ELASTICSEARCH_USER') ?? ''
+                default: env('ELASTICSEARCH_USER') ?? '',
+                transform: trim(...),
             );
             $this->envUpdate('ELASTICSEARCH_USER', $user);
 
@@ -404,7 +421,8 @@ class Installer extends Command
             if ($connectionType === 'api') {
                 $apiKey = text(
                     label: 'Please enter the Elasticsearch API key',
-                    default: env('ELASTICSEARCH_API_KEY') ?? ''
+                    default: env('ELASTICSEARCH_API_KEY') ?? '',
+                    transform: trim(...),
                 );
                 $this->envUpdate('ELASTICSEARCH_API_KEY', $apiKey);
             }
@@ -412,7 +430,8 @@ class Installer extends Command
 
         $indexPrefix = text(
             label: 'Please enter your Elasticsearch Index Prefix',
-            default: env('ELASTICSEARCH_INDEX_PREFIX') ?? ''
+            default: env('ELASTICSEARCH_INDEX_PREFIX') ?? '',
+            transform: trim(...),
         );
 
         $this->envUpdate('ELASTICSEARCH_INDEX_PREFIX', $indexPrefix);
@@ -428,17 +447,18 @@ class Installer extends Command
         $adminName = text(
             label: 'Set the Name for Administrator',
             default  : 'Example',
-            required: true
+            required: true,
+            transform: trim(...),
         );
 
         $adminEmail = text(
             label: 'Provide Email of Administrator',
             default  : 'admin@example.com',
             validate: fn (string $value) => match (true) {
-                ! filter_var($value, FILTER_VALIDATE_EMAIL) => 'The email address you entered is not valid please try again.',
-                ! filter_var($value, FILTER_VALIDATE_EMAIL) => 'The provided email is invalid, kindly enter a valid email address.',
-                default                                     => null
-            }
+                ! filter_var(trim($value), FILTER_VALIDATE_EMAIL) => 'The email address you entered is not valid please try again.',
+                default                                           => null
+            },
+            transform: trim(...),
         );
 
         $adminPassword = password(
@@ -589,10 +609,11 @@ class Installer extends Command
         $input = text(
             label: $question,
             default: $defaultValue,
-            required: true
+            required: true,
+            transform: trim(...),
         );
 
-        $this->envUpdate($key, $input ?: $defaultValue);
+        $this->envUpdate($key, $input === '' ? $defaultValue : $input);
     }
 
     /**

--- a/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
+++ b/packages/Webkul/Installer/tests/Feature/DatabaseInputTrimTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use Webkul\Installer\Console\Commands\Installer;
+
+function bindInstallerCapturingDbEnvUpdate(array &$captured): Closure
+{
+    return function () use (&$captured) {
+        return new class($captured) extends Installer
+        {
+            private array $captured;
+
+            public function __construct(array &$captured)
+            {
+                parent::__construct();
+                $this->captured = &$captured;
+            }
+
+            public function call($command, array $arguments = [], $output = null)
+            {
+                return 0;
+            }
+
+            protected function envUpdate(string $key, string $value): void
+            {
+                $this->captured[$key] = $value;
+            }
+
+            public function handle()
+            {
+                $this->askForDatabaseDetails();
+
+                return 0;
+            }
+        };
+    };
+}
+
+it('trims trailing whitespace on DB_HOST so quote-wrapping in .env never breaks DNS resolution', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1     ')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_HOST'])->toBe('127.0.0.1');
+});
+
+it('rejects DB_HOST containing internal whitespace ', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0 .1')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_HOST');
+});
+
+it('trims surrounding whitespace on DB_PORT', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '  3306  ')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_PORT'])->toBe('3306');
+});
+
+it('rejects a non-numeric DB_PORT so the connection cannot be written with garbage', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '33a06')
+        ->assertExitCode(1);
+
+    expect($captured)->not->toHaveKey('DB_PORT');
+});
+
+it('trims surrounding whitespace on DB_DATABASE so the schema lookup uses the bare name ', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim    ')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_DATABASE'])->toBe('unopim');
+});
+
+it('trims surrounding whitespace on DB_USERNAME so PDO auth uses the bare name ', function () {
+    $captured = [];
+    $this->app->extend(Installer::class, bindInstallerCapturingDbEnvUpdate($captured));
+
+    $this->artisan('unopim:install', ['--skip-admin-creation' => true])
+        ->expectsQuestion('Please select the database connection', 'mysql')
+        ->expectsQuestion('Please enter the database host', '127.0.0.1')
+        ->expectsQuestion('Please enter the database port', '3306')
+        ->expectsQuestion('Please enter the database name', 'unopim')
+        ->expectsQuestion('Please enter the database prefix', '')
+        ->expectsQuestion('Please enter your database username', 'root  ')
+        ->expectsQuestion('Please enter your database password', 'root')
+        ->assertExitCode(0);
+
+    expect($captured['DB_USERNAME'])->toBe('root');
+});


### PR DESCRIPTION
Backport of #404 to the 2.1 branch.

- Trim whitespace from DB_* inputs in the installer to prevent quoted .env values
- Adds DatabaseInputTrimTest
