### PR TITLE
fix(aiagent): respect attribute type when attaching images (gallery support)

### DIFF
--- a/packages/Webkul/AiAgent/src/Chat/Tools/AttachImage.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/AttachImage.php
@@ -4,11 +4,13 @@ namespace Webkul\AiAgent\Chat\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Http\File;
+use Illuminate\Support\Facades\DB;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Webkul\AiAgent\Chat\ChatContext;
 use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
+use Webkul\Attribute\Models\Attribute;
 use Webkul\Core\Filesystem\FileStorer;
 
 class AttachImage implements PimTool
@@ -26,13 +28,14 @@ class AttachImage implements PimTool
 
             public function description(): string
             {
-                return 'Attach an uploaded image to a product by SKU.';
+                return 'Attach an uploaded image to a product. Pass attribute code (default "image"). For gallery attributes (type=gallery) the image is APPENDED to the existing list; for single-image attributes it REPLACES the current value. Use the product family\'s actual attribute code (e.g. "image", "gallery", "media_gallery").';
             }
 
             public function schema(JsonSchema $schema): array
             {
                 return [
-                    'sku' => $schema->string()->description('Product SKU to attach the image to'),
+                    'sku'       => $schema->string()->description('Product SKU to attach the image to'),
+                    'attribute' => $schema->string()->description('Target attribute code on the product. Defaults to "image". For multiple/gallery images, pass the gallery attribute code (e.g. "gallery").'),
                 ];
             }
 
@@ -47,12 +50,34 @@ class AttachImage implements PimTool
                 }
 
                 $sku = $request->string('sku')->toString();
+                $attributeCode = $request->string('attribute')->toString() ?: 'image';
 
                 $repo = app('Webkul\Product\Repositories\ProductRepository');
                 $product = $repo->findOneByField('sku', $sku);
 
                 if (! $product) {
                     return json_encode(['error' => "Product not found: {$sku}"]);
+                }
+
+                $attribute = Attribute::where('code', $attributeCode)->first();
+
+                if (! $attribute) {
+                    return json_encode(['error' => "Attribute '{$attributeCode}' not found in this UnoPim instance."]);
+                }
+
+                if (! in_array($attribute->type, ['image', 'gallery'])) {
+                    return json_encode(['error' => "Attribute '{$attributeCode}' is type '{$attribute->type}', not an image/gallery attribute."]);
+                }
+
+                // Verify attribute is on the product's family
+                $familyHasAttribute = DB::table('attribute_family_groups_mappings as afgm')
+                    ->join('attribute_group_mappings as agm', 'agm.attribute_group_id', '=', 'afgm.attribute_group_id')
+                    ->where('afgm.attribute_family_id', $product->attribute_family_id)
+                    ->where('agm.attribute_id', $attribute->id)
+                    ->exists();
+
+                if (! $familyHasAttribute) {
+                    return json_encode(['error' => "Attribute '{$attributeCode}' is not assigned to this product's attribute family. Add it to the family first."]);
                 }
 
                 $imagePath = $this->context->firstImagePath();
@@ -63,7 +88,7 @@ class AttachImage implements PimTool
 
                 try {
                     $fileStorer = app(FileStorer::class);
-                    $storagePath = 'product'.DIRECTORY_SEPARATOR.$product->id.DIRECTORY_SEPARATOR.'image';
+                    $storagePath = 'product'.DIRECTORY_SEPARATOR.$product->id.DIRECTORY_SEPARATOR.$attribute->code;
 
                     $storedPath = $fileStorer->store(
                         $storagePath,
@@ -75,22 +100,61 @@ class AttachImage implements PimTool
                         return json_encode(['error' => 'Failed to store image.']);
                     }
 
+                    $scope = $this->resolveScope($attribute);
                     $values = $product->values ?? [];
-                    $values['common']['image'] = $storedPath;
+                    $channelCode = core()->getRequestedChannelCode();
+                    $localeCode = core()->getRequestedLocaleCode();
+
+                    if ($attribute->type === 'gallery') {
+                        // Append to existing gallery instead of overwriting.
+                        $currentValue = $attribute->getValueFromProductValues($values, $channelCode, $localeCode);
+                        $images = is_array($currentValue) ? $currentValue : ($currentValue ? explode(',', $currentValue) : []);
+                        $images = array_values(array_filter($images));
+                        $images[] = $storedPath;
+                        $newValue = $images;
+                    } else {
+                        $newValue = $storedPath;
+                    }
+
+                    match ($scope) {
+                        'channel_locale_specific' => $values['channel_locale_specific'][$channelCode][$localeCode][$attribute->code] = $newValue,
+                        'channel_specific'        => $values['channel_specific'][$channelCode][$attribute->code] = $newValue,
+                        'locale_specific'         => $values['locale_specific'][$localeCode][$attribute->code] = $newValue,
+                        default                   => $values['common'][$attribute->code] = $newValue,
+                    };
 
                     $repo->updateWithValues(['values' => $values], $product->id);
 
                     return json_encode([
                         'result' => [
-                            'attached' => true,
-                            'sku'      => $sku,
-                            'image'    => $storedPath,
+                            'attached'  => true,
+                            'sku'       => $sku,
+                            'attribute' => $attribute->code,
+                            'type'      => $attribute->type,
+                            'image'     => $storedPath,
                         ],
                         'product_url' => route('admin.catalog.products.edit', $product->id),
                     ]);
                 } catch (\Throwable $e) {
                     return json_encode(['error' => 'Failed to attach image: '.$e->getMessage()]);
                 }
+            }
+
+            private function resolveScope(Attribute $attribute): string
+            {
+                if ($attribute->isLocaleAndChannelBasedAttribute()) {
+                    return 'channel_locale_specific';
+                }
+
+                if ($attribute->isChannelBasedAttribute()) {
+                    return 'channel_specific';
+                }
+
+                if ($attribute->isLocaleBasedAttribute()) {
+                    return 'locale_specific';
+                }
+
+                return 'common';
             }
         };
     }

--- a/packages/Webkul/AiAgent/src/Chat/Tools/GenerateImage.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/GenerateImage.php
@@ -4,6 +4,7 @@ namespace Webkul\AiAgent\Chat\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Http\File;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Image;
@@ -11,6 +12,7 @@ use Laravel\Ai\Tools\Request;
 use Webkul\AiAgent\Chat\ChatContext;
 use Webkul\AiAgent\Chat\Concerns\ChecksPermission;
 use Webkul\AiAgent\Chat\Contracts\PimTool;
+use Webkul\Attribute\Models\Attribute;
 use Webkul\Core\Filesystem\FileStorer;
 use Webkul\MagicAI\Enums\AiProvider;
 
@@ -42,9 +44,10 @@ class GenerateImage implements PimTool
             public function schema(JsonSchema $schema): array
             {
                 return [
-                    'prompt' => $schema->string()->description('Detailed description of the image to generate (e.g. "Professional product photo of a red leather handbag on white background")'),
-                    'sku'    => $schema->string()->description('Optional: Product SKU to attach the generated image to'),
-                    'size'   => $schema->string()->enum(['1024x1024', '1024x1792', '1792x1024'])->description('Image size/aspect ratio'),
+                    'prompt'    => $schema->string()->description('Detailed description of the image to generate (e.g. "Professional product photo of a red leather handbag on white background")'),
+                    'sku'       => $schema->string()->description('Optional: Product SKU to attach the generated image to'),
+                    'attribute' => $schema->string()->description('Optional: target attribute code on the product (default "image"). For multiple/gallery images pass the gallery attribute code (e.g. "gallery") — gallery images are APPENDED, single-image attributes are REPLACED.'),
+                    'size'      => $schema->string()->enum(['1024x1024', '1024x1792', '1792x1024'])->description('Image size/aspect ratio'),
                 ];
             }
 
@@ -56,6 +59,7 @@ class GenerateImage implements PimTool
 
                 $prompt = $request->string('prompt')->toString();
                 $sku = $request->string('sku')->toString() ?: null;
+                $attributeCode = $request->string('attribute')->toString() ?: 'image';
                 $size = $request->string('size')->toString() ?: '1024x1024';
 
                 $aiProvider = AiProvider::from($this->context->platform->provider);
@@ -131,26 +135,66 @@ class GenerateImage implements PimTool
                         $repo = app('Webkul\Product\Repositories\ProductRepository');
                         $product = $repo->findOneByField('sku', $sku);
 
-                        if ($product) {
-                            $fileStorer = app(FileStorer::class);
-                            $targetPath = 'product'.DIRECTORY_SEPARATOR.$product->id.DIRECTORY_SEPARATOR.'image';
-
-                            $storedImage = $fileStorer->store(
-                                $targetPath,
-                                new File($fullPath),
-                                [FileStorer::HASHED_FOLDER_NAME_KEY => true],
-                            );
-
-                            if ($storedImage) {
-                                $values = $product->values ?? [];
-                                $values['common']['image'] = $storedImage;
-                                $repo->updateWithValues(['values' => $values], $product->id);
-
-                                $result['attached_to'] = $sku;
-                                $result['product_url'] = route('admin.catalog.products.edit', $product->id);
-                            }
-                        } else {
+                        if (! $product) {
                             $result['warning'] = "Product SKU '{$sku}' not found. Image generated but not attached.";
+                        } else {
+                            $attribute = Attribute::where('code', $attributeCode)->first();
+
+                            if (! $attribute) {
+                                $result['warning'] = "Attribute '{$attributeCode}' not found. Image generated but not attached.";
+                            } elseif (! in_array($attribute->type, ['image', 'gallery'])) {
+                                $result['warning'] = "Attribute '{$attributeCode}' is type '{$attribute->type}', not image/gallery. Image generated but not attached.";
+                            } else {
+                                $familyHasAttribute = DB::table('attribute_family_groups_mappings as afgm')
+                                    ->join('attribute_group_mappings as agm', 'agm.attribute_group_id', '=', 'afgm.attribute_group_id')
+                                    ->where('afgm.attribute_family_id', $product->attribute_family_id)
+                                    ->where('agm.attribute_id', $attribute->id)
+                                    ->exists();
+
+                                if (! $familyHasAttribute) {
+                                    $result['warning'] = "Attribute '{$attributeCode}' is not assigned to this product's family. Image generated but not attached.";
+                                } else {
+                                    $fileStorer = app(FileStorer::class);
+                                    $targetPath = 'product'.DIRECTORY_SEPARATOR.$product->id.DIRECTORY_SEPARATOR.$attribute->code;
+
+                                    $storedImage = $fileStorer->store(
+                                        $targetPath,
+                                        new File($fullPath),
+                                        [FileStorer::HASHED_FOLDER_NAME_KEY => true],
+                                    );
+
+                                    if ($storedImage) {
+                                        $scope = $this->outer->resolveScope($attribute);
+                                        $values = $product->values ?? [];
+                                        $channelCode = core()->getRequestedChannelCode();
+                                        $localeCode = core()->getRequestedLocaleCode();
+
+                                        if ($attribute->type === 'gallery') {
+                                            $currentValue = $attribute->getValueFromProductValues($values, $channelCode, $localeCode);
+                                            $images = is_array($currentValue) ? $currentValue : ($currentValue ? explode(',', $currentValue) : []);
+                                            $images = array_values(array_filter($images));
+                                            $images[] = $storedImage;
+                                            $newValue = $images;
+                                        } else {
+                                            $newValue = $storedImage;
+                                        }
+
+                                        match ($scope) {
+                                            'channel_locale_specific' => $values['channel_locale_specific'][$channelCode][$localeCode][$attribute->code] = $newValue,
+                                            'channel_specific'        => $values['channel_specific'][$channelCode][$attribute->code] = $newValue,
+                                            'locale_specific'         => $values['locale_specific'][$localeCode][$attribute->code] = $newValue,
+                                            default                   => $values['common'][$attribute->code] = $newValue,
+                                        };
+
+                                        $repo->updateWithValues(['values' => $values], $product->id);
+
+                                        $result['attached_to'] = $sku;
+                                        $result['attribute'] = $attribute->code;
+                                        $result['attribute_type'] = $attribute->type;
+                                        $result['product_url'] = route('admin.catalog.products.edit', $product->id);
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -164,6 +208,27 @@ class GenerateImage implements PimTool
                 }
             }
         };
+    }
+
+    /**
+     * Resolve which scope key to write a value under, based on whether the
+     * attribute is per-channel and/or per-locale.
+     */
+    public function resolveScope(Attribute $attribute): string
+    {
+        if ($attribute->isLocaleAndChannelBasedAttribute()) {
+            return 'channel_locale_specific';
+        }
+
+        if ($attribute->isChannelBasedAttribute()) {
+            return 'channel_specific';
+        }
+
+        if ($attribute->isLocaleBasedAttribute()) {
+            return 'locale_specific';
+        }
+
+        return 'common';
     }
 
     /**


### PR DESCRIPTION
## Summary
- Both `AttachImage` and `GenerateImage` tools hardcoded `$values['common']['image'] = ...`, so:
  - Calling either tool N times overwrote the single `image` attribute instead of populating a gallery — the agent reported "5 images added" but only the last one persisted, and a real `gallery` attribute on the family was never touched.
  - Gallery-, channel-, and locale-scoped attributes silently never received values.
  - Wrong-family attribute codes failed silently with apparent success.

## Changes
- Both tools accept an `attribute` parameter (default `"image"`).
- Tool descriptions document gallery vs single-image semantics so the agent picks the right one.
- Resolve `Attribute` model, validate type ∈ {`image`, `gallery`}, and verify the attribute is mapped onto the product's attribute family (`attribute_family_groups_mappings` + `attribute_group_mappings`) before storing — fail-fast with a clear error when it isn't.
- Gallery type APPENDS to existing list; single-image type REPLACES (same pattern as `EditImage::saveToProduct()`).
- Honour the attribute's scope (`common` / `locale_specific` / `channel_specific` / `channel_locale_specific`) instead of always writing to `common`.
- Return the resolved attribute code + type in the tool result so the agent surfaces accurate confirmation messages.
- Storage path now uses `$attribute->code` instead of literal `'image'` so gallery files land under `product/{id}/{gallery_code}/`.

## Dependency
Targets #435 (laravel/ai migration) because both files were refactored in that PR. **Rebase onto master after #435 merges.**

## Test plan
- [ ] Upload an image, ask agent to "attach to product X as gallery image" — verify it appends to the `gallery` attribute on the family, not the `image` attribute.
- [ ] Generate 5 images and attach to a gallery — verify all 5 land in the list (not just the last).
- [ ] Attach to a product whose family has NO `gallery` attribute — verify clear error message instead of silent success.
- [ ] Attach to a single-image attribute — verify REPLACE behaviour preserved.
- [ ] Attach to a locale-scoped or channel-scoped image attribute — verify it writes under the correct scope key in `values`.