### PR TITLE
chore(webhook): harden webhook URL validation and dispatch [v2.0 LTS]

### DIFF
--- a/.github/workflows/playwright_test.yml
+++ b/.github/workflows/playwright_test.yml
@@ -42,6 +42,11 @@ jobs:
       ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
       INVALID_ADMIN_EMAIL: ${{ secrets.INVALID_ADMIN_EMAIL }}
       INVALID_ADMIN_PASSWORD: ${{ secrets.INVALID_ADMIN_PASSWORD }}
+      # E2E only: lets webhook-delivery.spec.js point UnoPim at a localhost
+      # catcher (127.0.0.1:<port>). SafeWebhookUrl blocks loopback by default
+      # in prod; this flag re-allows loopback ONLY — private / link-local /
+      # multicast / reserved IP ranges stay blocked.
+      WEBHOOK_ALLOW_LOOPBACK: 'true'
 
     steps:
       - name: Checkout

--- a/packages/Webkul/Admin/tests/Feature/Webhook/WebhookSettingsValidationTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Webhook/WebhookSettingsValidationTest.php
@@ -61,14 +61,14 @@ it('saves a valid https webhook URL when the probe succeeds', function () {
 
     $response = storeWebhookSettings([
         'webhook_active' => 1,
-        'webhook_url'    => 'https://wh58b8f638f57c37d003.free.beeceptor.com',
+        'webhook_url'    => 'https://1.1.1.1',
     ]);
 
     $payload = json_decode($response->getContent(), true);
     expect($payload['success'] ?? null)->toBeTrue();
 
     $stored = DB::table('webhook_settings')->where('field', 'webhook_url')->value('value');
-    expect($stored)->toBe('https://wh58b8f638f57c37d003.free.beeceptor.com');
+    expect($stored)->toBe('https://1.1.1.1');
 });
 
 it('rejects the save when the probe returns a non-2xx response', function () {
@@ -78,7 +78,7 @@ it('rejects the save when the probe returns a non-2xx response', function () {
 
     $response = storeWebhookSettings([
         'webhook_active' => 1,
-        'webhook_url'    => 'https://example.test/not-a-hook',
+        'webhook_url'    => 'https://1.1.1.1/not-a-hook',
     ]);
 
     expect($response->getStatusCode())->toBe(422);
@@ -98,7 +98,7 @@ it('rejects the save when the probe cannot reach the host', function () {
 
     $response = storeWebhookSettings([
         'webhook_active' => 1,
-        'webhook_url'    => 'https://does-not-exist.invalid/hook',
+        'webhook_url'    => 'https://1.1.1.1/hook',
     ]);
 
     expect($response->getStatusCode())->toBe(422);

--- a/packages/Webkul/Admin/tests/Feature/Webhook/WebhookStatusTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Webhook/WebhookStatusTest.php
@@ -20,7 +20,7 @@ beforeEach(function () {
 
     DB::table('webhook_settings')->updateOrInsert(
         ['field' => 'webhook_url'],
-        ['value' => 'https://example.test/hook', 'updated_at' => now(), 'created_at' => now()]
+        ['value' => 'https://1.1.1.1/hook', 'updated_at' => now(), 'created_at' => now()]
     );
     DB::table('webhook_settings')->updateOrInsert(
         ['field' => 'webhook_active'],
@@ -37,7 +37,7 @@ afterEach(function () {
 
 it('logs status=1 with HTTP 200 in extra when the endpoint succeeds', function () {
     Http::fake([
-        'example.test/*' => Http::response(['ok' => true], 200),
+        '1.1.1.1/*' => Http::response(['ok' => true], 200),
     ]);
 
     $product = Product::factory()->create();
@@ -55,7 +55,7 @@ it('logs status=1 with HTTP 200 in extra when the endpoint succeeds', function (
 
 it('logs status=0 when the endpoint returns 404', function () {
     Http::fake([
-        'example.test/*' => Http::response(['error' => 'not found'], 404),
+        '1.1.1.1/*' => Http::response(['error' => 'not found'], 404),
     ]);
 
     $product = Product::factory()->create();
@@ -73,7 +73,7 @@ it('logs status=0 when the endpoint returns 404', function () {
 
 it('logs status=0 when the endpoint returns 500', function () {
     Http::fake([
-        'example.test/*' => Http::response(['error' => 'server'], 500),
+        '1.1.1.1/*' => Http::response(['error' => 'server'], 500),
     ]);
 
     $product = Product::factory()->create();

--- a/packages/Webkul/Webhook/src/Http/Controllers/WebhookSettingsController.php
+++ b/packages/Webkul/Webhook/src/Http/Controllers/WebhookSettingsController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\View\View;
 use Webkul\Webhook\Models\WebhookSetting;
 use Webkul\Webhook\Repositories\SettingsRepository;
+use Webkul\Webhook\Validators\SafeWebhookUrl;
 
 class WebhookSettingsController
 {
@@ -50,10 +51,28 @@ class WebhookSettingsController
             'webhook_url.regex'       => trans('webhook::app.configuration.webhook.settings.index.webhook_url.scheme'),
         ]);
 
-        $active = (int) $request->input('webhook_active', '0');
+        // Cast 'true'/'false' strings + 0/1 alike — (int) 'true' === 0 would
+        // silently disarm the activation path and skip the SSRF probe below.
+        $active = filter_var($request->input('webhook_active', false), FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
         $url = $request->filled('webhook_url') ? $request->webhook_url : null;
 
         if ($active === 1 && ! empty($url)) {
+            // SSRF guard (CWE-918): reject URLs that resolve to loopback,
+            // private, link-local, multicast or otherwise reserved address
+            // space — including cloud metadata 169.254.169.254 — BEFORE the
+            // synchronous test POST is fired against the supplied host.
+            $safety = SafeWebhookUrl::validate($url);
+
+            if (! $safety['valid']) {
+                return response()->json([
+                    'success' => false,
+                    'message' => trans('webhook::app.configuration.webhook.settings.index.webhook_url.unsafe'),
+                    'errors'  => [
+                        'webhook_url' => [trans('webhook::app.configuration.webhook.settings.index.webhook_url.unsafe')],
+                    ],
+                ], 422);
+            }
+
             $testResult = $this->testWebhookUrl($url);
 
             if (! $testResult['success']) {
@@ -117,7 +136,12 @@ class WebhookSettingsController
         ];
 
         try {
-            $response = Http::timeout(self::TEST_REQUEST_TIMEOUT)->post($url, $payload);
+            // Pin the request to the validated IP (CURLOPT_RESOLVE) and
+            // disable redirect-following — closes the DNS-rebinding TOCTOU
+            // gap and the redirect-chain bypass.
+            $response = Http::withOptions(SafeWebhookUrl::httpOptions($url))
+                ->timeout(self::TEST_REQUEST_TIMEOUT)
+                ->post($url, $payload);
         } catch (\Throwable $e) {
             return [
                 'success' => false,

--- a/packages/Webkul/Webhook/src/Resources/lang/ar_AE/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/ar_AE/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'يجب أن يبدأ رابط Webhook بـ http:// أو https://.',
                         'connection_failed' => 'لا يمكن الوصول إلى رابط Webhook. يرجى التحقق من الرابط.',
                         'unreachable'       => 'رابط Webhook غير صالح (HTTP :code).',
+                        'unsafe'            => 'يشير رابط Webhook إلى عنوان خاص أو محلي أو داخلي وغير مسموح به.',
                     ],
                     'success'    => 'تم حفظ إعدادات Webhook بنجاح',
                     'logs-title' => 'السجلات',

--- a/packages/Webkul/Webhook/src/Resources/lang/ca_ES/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/ca_ES/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'L\'URL del Webhook ha de començar amb http:// o https://.',
                         'connection_failed' => 'No s\'ha pogut accedir a l\'URL del Webhook. Verifiqueu l\'URL.',
                         'unreachable'       => 'L\'URL del Webhook no és vàlid (HTTP :code).',
+                        'unsafe'            => 'L\'URL del webhook apunta a una adreça privada, de loopback o interna i no està permès.',
                     ],
                     'success'    => 'La configuració del Webhook s\'ha desat correctament',
                     'logs-title' => 'Registres',

--- a/packages/Webkul/Webhook/src/Resources/lang/da_DK/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/da_DK/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook-URL\'en skal starte med http:// eller https://.',
                         'connection_failed' => 'Webhook-URL\'en kunne ikke nås. Tjek venligst URL\'en.',
                         'unreachable'       => 'Webhook-URL\'en er ikke gyldig (HTTP :code).',
+                        'unsafe'            => 'Webhook-URL\'en peger på en privat, loopback eller intern adresse og er ikke tilladt.',
                     ],
                     'success'    => 'Webhook-indstillinger blev gemt',
                     'logs-title' => 'Logfiler',

--- a/packages/Webkul/Webhook/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/de_DE/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Die Webhook-URL muss mit http:// oder https:// beginnen.',
                         'connection_failed' => 'Die Webhook-URL konnte nicht erreicht werden. Bitte überprüfen Sie die URL.',
                         'unreachable'       => 'Die Webhook-URL ist ungültig (HTTP :code).',
+                        'unsafe'            => 'Die Webhook-URL verweist auf eine private, Loopback- oder interne Adresse und ist nicht erlaubt.',
                     ],
                     'success'    => 'Webhook-Einstellungen erfolgreich gespeichert',
                     'logs-title' => 'Protokolle',

--- a/packages/Webkul/Webhook/src/Resources/lang/en_AU/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/en_AU/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'The Webhook URL must start with http:// or https://.',
                         'connection_failed' => 'The Webhook URL could not be reached. Please check the URL.',
                         'unreachable'       => 'The Webhook URL is not valid (HTTP :code).',
+                        'unsafe'            => 'The Webhook URL points at a private, loopback or internal address and is not allowed.',
                     ],
                     'success'    => 'Webhook settings saved successfully',
                     'logs-title' => 'Logs',

--- a/packages/Webkul/Webhook/src/Resources/lang/en_GB/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/en_GB/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'The Webhook URL must start with http:// or https://.',
                         'connection_failed' => 'The Webhook URL could not be reached. Please check the URL.',
                         'unreachable'       => 'The Webhook URL is not valid (HTTP :code).',
+                        'unsafe'            => 'The Webhook URL points at a private, loopback or internal address and is not allowed.',
                     ],
                     'success'    => 'Webhook settings saved successfully',
                     'logs-title' => 'Logs',

--- a/packages/Webkul/Webhook/src/Resources/lang/en_NZ/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/en_NZ/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'The Webhook URL must start with http:// or https://.',
                         'connection_failed' => 'The Webhook URL could not be reached. Please check the URL.',
                         'unreachable'       => 'The Webhook URL is not valid (HTTP :code).',
+                        'unsafe'            => 'The Webhook URL points at a private, loopback or internal address and is not allowed.',
                     ],
                     'success'    => 'Webhook settings saved successfully',
                     'logs-title' => 'Logs',

--- a/packages/Webkul/Webhook/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/en_US/app.php
@@ -48,6 +48,7 @@ return [
                         'scheme'            => 'The Webhook URL must start with http:// or https://.',
                         'connection_failed' => 'The Webhook URL could not be reached. Please check the URL.',
                         'unreachable'       => 'The Webhook URL is not valid (HTTP :code).',
+                        'unsafe'            => 'The Webhook URL points at a private, loopback or internal address and is not allowed.',
                     ],
                     'success'    => 'Webhook settings saved successfully',
                     'title'      => 'Webhook Settings',

--- a/packages/Webkul/Webhook/src/Resources/lang/es_ES/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/es_ES/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'La URL del Webhook debe comenzar con http:// o https://.',
                         'connection_failed' => 'No se pudo acceder a la URL del Webhook. Verifique la URL.',
                         'unreachable'       => 'La URL del Webhook no es válida (HTTP :code).',
+                        'unsafe'            => 'La URL del webhook apunta a una dirección privada, de loopback o interna y no está permitida.',
                     ],
                     'success'    => 'Configuración del Webhook guardada correctamente',
                     'logs-title' => 'Registros',

--- a/packages/Webkul/Webhook/src/Resources/lang/es_VE/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/es_VE/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'La URL del Webhook debe comenzar con http:// o https://.',
                         'connection_failed' => 'No se pudo acceder a la URL del Webhook. Verifique la URL.',
                         'unreachable'       => 'La URL del Webhook no es válida (HTTP :code).',
+                        'unsafe'            => 'La URL del webhook apunta a una dirección privada, de loopback o interna y no está permitida.',
                     ],
                     'success'    => 'Configuración del Webhook guardada exitosamente',
                     'logs-title' => 'Registros',

--- a/packages/Webkul/Webhook/src/Resources/lang/fi_FI/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/fi_FI/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook-URL:n on alettava http:// tai https://.',
                         'connection_failed' => 'Webhook-URL-osoitteeseen ei saatu yhteyttä. Tarkista URL-osoite.',
                         'unreachable'       => 'Webhook-URL ei kelpaa (HTTP :code).',
+                        'unsafe'            => 'Webhook-URL osoittaa yksityiseen, loopback- tai sisäiseen osoitteeseen, eikä sitä sallita.',
                     ],
                     'success'    => 'Webhook-asetukset tallennettu onnistuneesti',
                     'logs-title' => 'Lokit',

--- a/packages/Webkul/Webhook/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/fr_FR/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'L\'URL du Webhook doit commencer par http:// ou https://.',
                         'connection_failed' => 'L\'URL du Webhook n\'a pas pu être atteinte. Veuillez vérifier l\'URL.',
                         'unreachable'       => 'L\'URL du Webhook n\'est pas valide (HTTP :code).',
+                        'unsafe'            => 'L\'URL du webhook pointe vers une adresse privée, loopback ou interne et n\'est pas autorisée.',
                     ],
                     'success'    => 'Paramètres du Webhook enregistrés avec succès',
                     'logs-title' => 'Journaux',

--- a/packages/Webkul/Webhook/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/hi_IN/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL http:// या https:// से शुरू होना चाहिए।',
                         'connection_failed' => 'Webhook URL तक नहीं पहुँचा जा सका। कृपया URL जाँचें।',
                         'unreachable'       => 'Webhook URL मान्य नहीं है (HTTP :code)।',
+                        'unsafe'            => 'Webhook URL एक प्राइवेट, लूपबैक या आंतरिक पते की ओर इशारा करता है और इसकी अनुमति नहीं है।',
                     ],
                     'success'    => 'Webhook सेटिंग्स सफलतापूर्वक सहेजी गईं',
                     'logs-title' => 'लॉग',

--- a/packages/Webkul/Webhook/src/Resources/lang/hr_HR/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/hr_HR/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL mora počinjati s http:// ili https://.',
                         'connection_failed' => 'Nije moguće pristupiti Webhook URL-u. Provjerite URL.',
                         'unreachable'       => 'Webhook URL nije ispravan (HTTP :code).',
+                        'unsafe'            => 'Webhook URL upućuje na privatnu, loopback ili internu adresu i nije dopušten.',
                     ],
                     'success'    => 'Postavke Webhooka uspješno spremljene',
                     'logs-title' => 'Zapisi',

--- a/packages/Webkul/Webhook/src/Resources/lang/id_ID/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/id_ID/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'URL Webhook harus dimulai dengan http:// atau https://.',
                         'connection_failed' => 'URL Webhook tidak dapat dijangkau. Silakan periksa URL.',
                         'unreachable'       => 'URL Webhook tidak valid (HTTP :code).',
+                        'unsafe'            => 'URL Webhook menunjuk ke alamat pribadi, loopback, atau internal dan tidak diizinkan.',
                     ],
                     'success'    => 'Pengaturan Webhook berhasil disimpan',
                     'logs-title' => 'Log',

--- a/packages/Webkul/Webhook/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/it_IT/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'L\'URL del Webhook deve iniziare con http:// o https://.',
                         'connection_failed' => 'Impossibile raggiungere l\'URL del Webhook. Verifica l\'URL.',
                         'unreachable'       => 'L\'URL del Webhook non è valido (HTTP :code).',
+                        'unsafe'            => 'L\'URL del webhook punta a un indirizzo privato, di loopback o interno e non è consentito.',
                     ],
                     'success'    => 'Impostazioni Webhook salvate con successo',
                     'logs-title' => 'Registri',

--- a/packages/Webkul/Webhook/src/Resources/lang/ja_JP/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/ja_JP/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL は http:// または https:// で始まる必要があります。',
                         'connection_failed' => 'Webhook URL に到達できませんでした。URL を確認してください。',
                         'unreachable'       => 'Webhook URL が無効です (HTTP :code)。',
+                        'unsafe'            => 'Webhook URL がプライベート、ループバック、または内部アドレスを指しているため許可されていません。',
                     ],
                     'success'    => 'Webhook設定が正常に保存されました',
                     'logs-title' => 'ログ',

--- a/packages/Webkul/Webhook/src/Resources/lang/ko_KR/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/ko_KR/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL은 http:// 또는 https://로 시작해야 합니다.',
                         'connection_failed' => 'Webhook URL에 연결할 수 없습니다. URL을 확인해 주세요.',
                         'unreachable'       => 'Webhook URL이 유효하지 않습니다 (HTTP :code).',
+                        'unsafe'            => '웹훅 URL이 비공개, 루프백 또는 내부 주소를 가리키므로 허용되지 않습니다.',
                     ],
                     'success'    => 'Webhook 설정이 성공적으로 저장되었습니다',
                     'logs-title' => '로그',

--- a/packages/Webkul/Webhook/src/Resources/lang/mn_MN/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/mn_MN/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL нь http:// эсвэл https:// гэж эхэлсэн байх ёстой.',
                         'connection_failed' => 'Webhook URL-д хүрэх боломжгүй байна. URL-аа шалгана уу.',
                         'unreachable'       => 'Webhook URL хүчингүй байна (HTTP :code).',
+                        'unsafe'            => 'Webhook URL хувийн, эргэлтийн буюу дотоод хаяг руу зааж байгаа тул зөвшөөрөгдөөгүй.',
                     ],
                     'success'    => 'Webhook тохиргоо амжилттай хадгалагдлаа',
                     'logs-title' => 'Логууд',

--- a/packages/Webkul/Webhook/src/Resources/lang/nl_NL/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/nl_NL/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'De Webhook-URL moet beginnen met http:// of https://.',
                         'connection_failed' => 'De Webhook-URL kon niet worden bereikt. Controleer de URL.',
                         'unreachable'       => 'De Webhook-URL is niet geldig (HTTP :code).',
+                        'unsafe'            => 'De Webhook-URL verwijst naar een privé-, loopback- of intern adres en is niet toegestaan.',
                     ],
                     'success'    => 'Webhook-instellingen succesvol opgeslagen',
                     'logs-title' => 'Logboeken',

--- a/packages/Webkul/Webhook/src/Resources/lang/no_NO/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/no_NO/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook-URL-en må begynne med http:// eller https://.',
                         'connection_failed' => 'Webhook-URL-en kunne ikke nås. Sjekk URL-en.',
                         'unreachable'       => 'Webhook-URL-en er ikke gyldig (HTTP :code).',
+                        'unsafe'            => 'Webhook-URL-en peker til en privat, loopback- eller intern adresse og er ikke tillatt.',
                     ],
                     'success'    => 'Webhook-innstillinger lagret',
                     'logs-title' => 'Logger',

--- a/packages/Webkul/Webhook/src/Resources/lang/pl_PL/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/pl_PL/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Adres URL Webhooka musi zaczynać się od http:// lub https://.',
                         'connection_failed' => 'Nie można połączyć się z adresem URL Webhooka. Sprawdź adres URL.',
                         'unreachable'       => 'Adres URL Webhooka jest nieprawidłowy (HTTP :code).',
+                        'unsafe'            => 'Adres URL webhooka wskazuje na adres prywatny, loopback lub wewnętrzny i nie jest dozwolony.',
                     ],
                     'success'    => 'Ustawienia Webhooka zostały pomyślnie zapisane',
                     'logs-title' => 'Logi',

--- a/packages/Webkul/Webhook/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/pt_BR/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'A URL do Webhook deve começar com http:// ou https://.',
                         'connection_failed' => 'Não foi possível acessar a URL do Webhook. Verifique a URL.',
                         'unreachable'       => 'A URL do Webhook não é válida (HTTP :code).',
+                        'unsafe'            => 'A URL do webhook aponta para um endereço privado, de loopback ou interno e não é permitida.',
                     ],
                     'success'    => 'Configurações do Webhook salvas com sucesso',
                     'logs-title' => 'Registros',

--- a/packages/Webkul/Webhook/src/Resources/lang/pt_PT/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/pt_PT/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'O URL do Webhook deve começar com http:// ou https://.',
                         'connection_failed' => 'Não foi possível aceder ao URL do Webhook. Verifique o URL.',
                         'unreachable'       => 'O URL do Webhook não é válido (HTTP :code).',
+                        'unsafe'            => 'O URL do webhook aponta para um endereço privado, de loopback ou interno e não é permitido.',
                     ],
                     'success'    => 'Definições do Webhook guardadas com sucesso',
                     'logs-title' => 'Registos',

--- a/packages/Webkul/Webhook/src/Resources/lang/ro_RO/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/ro_RO/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'URL-ul Webhook trebuie să înceapă cu http:// sau https://.',
                         'connection_failed' => 'URL-ul Webhook nu a putut fi accesat. Verificați URL-ul.',
                         'unreachable'       => 'URL-ul Webhook nu este valid (HTTP :code).',
+                        'unsafe'            => 'URL-ul webhook indică o adresă privată, loopback sau internă și nu este permis.',
                     ],
                     'success'    => 'Setările Webhook au fost salvate cu succes',
                     'logs-title' => 'Jurnale',

--- a/packages/Webkul/Webhook/src/Resources/lang/ru_RU/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/ru_RU/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'URL Webhook должен начинаться с http:// или https://.',
                         'connection_failed' => 'Не удалось подключиться к URL Webhook. Пожалуйста, проверьте URL.',
                         'unreachable'       => 'URL Webhook недействителен (HTTP :code).',
+                        'unsafe'            => 'URL вебхука указывает на частный, петлевой или внутренний адрес и не разрешён.',
                     ],
                     'success'    => 'Настройки Webhook успешно сохранены',
                     'logs-title' => 'Журналы',

--- a/packages/Webkul/Webhook/src/Resources/lang/sv_SE/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/sv_SE/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook-URL:en måste börja med http:// eller https://.',
                         'connection_failed' => 'Webhook-URL:en kunde inte nås. Kontrollera URL:en.',
                         'unreachable'       => 'Webhook-URL:en är inte giltig (HTTP :code).',
+                        'unsafe'            => 'Webhook-URL:en pekar på en privat, loopback- eller intern adress och är inte tillåten.',
                     ],
                     'success'    => 'Webhook-inställningar sparades framgångsrikt',
                     'logs-title' => 'Loggar',

--- a/packages/Webkul/Webhook/src/Resources/lang/tl_PH/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/tl_PH/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Ang Webhook URL ay dapat magsimula sa http:// o https://.',
                         'connection_failed' => 'Hindi maabot ang Webhook URL. Pakisuri ang URL.',
                         'unreachable'       => 'Hindi wasto ang Webhook URL (HTTP :code).',
+                        'unsafe'            => 'Ang Webhook URL ay tumuturo sa pribado, loopback, o panloob na address at hindi pinapayagan.',
                     ],
                     'success'    => 'Matagumpay na na-save ang mga setting ng Webhook',
                     'logs-title' => 'Mga Log',

--- a/packages/Webkul/Webhook/src/Resources/lang/tr_TR/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/tr_TR/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL\'si http:// veya https:// ile başlamalıdır.',
                         'connection_failed' => 'Webhook URL\'sine erişilemedi. Lütfen URL\'yi kontrol edin.',
                         'unreachable'       => 'Webhook URL geçerli değil (HTTP :code).',
+                        'unsafe'            => 'Webhook URL\'si özel, geri döngü veya dahili bir adrese işaret ediyor ve izin verilmiyor.',
                     ],
                     'success'    => 'Webhook ayarları başarıyla kaydedildi',
                     'logs-title' => 'Günlükler',

--- a/packages/Webkul/Webhook/src/Resources/lang/uk_UA/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/uk_UA/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'URL Webhook повинен починатися з http:// або https://.',
                         'connection_failed' => 'Не вдалося підключитися до URL Webhook. Будь ласка, перевірте URL.',
                         'unreachable'       => 'URL Webhook недійсний (HTTP :code).',
+                        'unsafe'            => 'URL вебхука вказує на приватну, петлеву або внутрішню адресу і не дозволений.',
                     ],
                     'success'    => 'Налаштування Webhook успішно збережено',
                     'logs-title' => 'Журнали',

--- a/packages/Webkul/Webhook/src/Resources/lang/vi_VN/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/vi_VN/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'URL Webhook phải bắt đầu bằng http:// hoặc https://.',
                         'connection_failed' => 'Không thể truy cập URL Webhook. Vui lòng kiểm tra URL.',
                         'unreachable'       => 'URL Webhook không hợp lệ (HTTP :code).',
+                        'unsafe'            => 'URL Webhook trỏ đến địa chỉ riêng tư, loopback hoặc nội bộ và không được phép.',
                     ],
                     'success'    => 'Cài đặt Webhook đã được lưu thành công',
                     'logs-title' => 'Nhật ký',

--- a/packages/Webkul/Webhook/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/zh_CN/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL 必须以 http:// 或 https:// 开头。',
                         'connection_failed' => '无法访问 Webhook URL。请检查 URL。',
                         'unreachable'       => 'Webhook URL 无效 (HTTP :code)。',
+                        'unsafe'            => 'Webhook URL 指向私有、回环或内部地址,不被允许。',
                     ],
                     'success'    => 'Webhook 设置已成功保存',
                     'logs-title' => '日志',

--- a/packages/Webkul/Webhook/src/Resources/lang/zh_TW/app.php
+++ b/packages/Webkul/Webhook/src/Resources/lang/zh_TW/app.php
@@ -47,6 +47,7 @@ return [
                         'scheme'            => 'Webhook URL 必須以 http:// 或 https:// 開頭。',
                         'connection_failed' => '無法存取 Webhook URL。請檢查 URL。',
                         'unreachable'       => 'Webhook URL 無效 (HTTP :code)。',
+                        'unsafe'            => 'Webhook URL 指向私有、回環或內部地址,不被允許。',
                     ],
                     'success'    => 'Webhook 設定已成功儲存',
                     'logs-title' => '日誌',

--- a/packages/Webkul/Webhook/src/Services/WebhookService.php
+++ b/packages/Webkul/Webhook/src/Services/WebhookService.php
@@ -4,11 +4,13 @@ namespace Webkul\Webhook\Services;
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Webkul\Product\Contracts\Product;
 use Webkul\Product\Repositories\ProductRepository;
 use Webkul\Webhook\Helpers\ProductComparer;
 use Webkul\Webhook\Repositories\LogsRepository;
 use Webkul\Webhook\Repositories\SettingsRepository;
+use Webkul\Webhook\Validators\SafeWebhookUrl;
 
 /**
  * Service responsible for sending product data to an external webhook and storing logs.
@@ -53,7 +55,17 @@ class WebhookService
         ];
 
         try {
-            $response = Http::post($webhookUrl, $webhookData);
+            $safety = SafeWebhookUrl::validate($webhookUrl);
+            if (! $safety['valid']) {
+                Log::warning('Webhook dispatch blocked — unsafe URL', [
+                    'reason' => $safety['reason'],
+                    'ip'     => $safety['ip'] ?? null,
+                ]);
+
+                return null;
+            }
+
+            $response = Http::withOptions(SafeWebhookUrl::httpOptions($webhookUrl))->post($webhookUrl, $webhookData);
         } catch (\Exception $e) {
             $response = null;
 
@@ -99,7 +111,17 @@ class WebhookService
         ];
 
         try {
-            $response = Http::post($webhookUrl, $webhookData);
+            $safety = SafeWebhookUrl::validate($webhookUrl);
+            if (! $safety['valid']) {
+                Log::warning('Webhook dispatch blocked — unsafe URL', [
+                    'reason' => $safety['reason'],
+                    'ip'     => $safety['ip'] ?? null,
+                ]);
+
+                return null;
+            }
+
+            $response = Http::withOptions(SafeWebhookUrl::httpOptions($webhookUrl))->post($webhookUrl, $webhookData);
         } catch (\Exception $e) {
             $response = null;
 
@@ -167,7 +189,17 @@ class WebhookService
         ];
 
         try {
-            $response = Http::post($webhookUrl, $normalized);
+            $safety = SafeWebhookUrl::validate($webhookUrl);
+            if (! $safety['valid']) {
+                Log::warning('Webhook dispatch blocked — unsafe URL', [
+                    'reason' => $safety['reason'],
+                    'ip'     => $safety['ip'] ?? null,
+                ]);
+
+                return null;
+            }
+
+            $response = Http::withOptions(SafeWebhookUrl::httpOptions($webhookUrl))->post($webhookUrl, $normalized);
         } catch (\Exception $e) {
             $response = null;
 

--- a/packages/Webkul/Webhook/src/Validators/SafeWebhookUrl.php
+++ b/packages/Webkul/Webhook/src/Validators/SafeWebhookUrl.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Webkul\Webhook\Validators;
+
+/**
+ * Validate that a webhook URL is safe to call from the server side.
+ *
+ * Rejects URLs that resolve (A + AAAA) to loopback / private / link-local /
+ * multicast / reserved address space — including the cloud metadata
+ * 169.254.169.254 covered by FILTER_FLAG_NO_RES_RANGE.
+ *
+ * Applied at every Http::post() sink that takes user-supplied URLs:
+ *  - WebhookSettingsController::store + testWebhookUrl
+ *  - WebhookService::sendDataToWebhook / sendCreatedToWebhook / sendBatch
+ *
+ * DNS-rebinding (TOCTOU) defense: callers pair validate() with
+ * httpOptions($url), which returns a CURLOPT_RESOLVE entry pinning the
+ * hostname to the validated IP so the connection cannot re-resolve to an
+ * internal address between check and use. HTTP redirects are also disabled.
+ *
+ * Test-env opt-in: setting WEBHOOK_ALLOW_LOOPBACK=true (default false) lets
+ * the loopback range pass so Playwright E2E can spin up a localhost catcher
+ * to verify end-to-end webhook delivery. Private / link-local / multicast /
+ * reserved are still blocked even with the flag on.
+ */
+class SafeWebhookUrl
+{
+    /**
+     * @return array{valid: bool, reason: string, ip?: string}
+     */
+    public static function validate(?string $url): array
+    {
+        if ($url === null || $url === '') {
+            return ['valid' => false, 'reason' => 'empty_url'];
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false) {
+            return ['valid' => false, 'reason' => 'invalid_url'];
+        }
+
+        if (empty($parts['scheme']) || ! in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            return ['valid' => false, 'reason' => 'invalid_scheme'];
+        }
+
+        if (empty($parts['host'])) {
+            return ['valid' => false, 'reason' => 'invalid_url'];
+        }
+
+        $host = $parts['host'];
+
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $host = substr($host, 1, -1);
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $ips = [$host];
+        } else {
+            $ips = self::resolveHost($host);
+
+            if ($ips === []) {
+                return ['valid' => false, 'reason' => 'dns_lookup_failed'];
+            }
+        }
+
+        foreach ($ips as $ip) {
+            if (! self::isAllowedIp($ip)) {
+                return ['valid' => false, 'reason' => 'restricted_ip', 'ip' => $ip];
+            }
+        }
+
+        return ['valid' => true, 'reason' => '', 'ip' => $ips[0]];
+    }
+
+    /**
+     * Build the Http::withOptions() payload used at every dispatch sink.
+     *
+     * Returns an array always carrying `allow_redirects: false` and, when the
+     * URL resolves to a validated public IP, a CURLOPT_RESOLVE entry pinning
+     * `host:port` to that IP. Pinning closes the DNS-rebinding TOCTOU window:
+     * the connection bypasses the resolver and goes straight to the IP that
+     * was already checked against the reserved-range allowlist. SNI / Host
+     * header still carry the original hostname, so TLS certificate validation
+     * is unaffected.
+     *
+     * Returns redirect-blocking options only when the URL fails validation —
+     * the dispatch site MUST guard with validate() first, but this fallback
+     * stops the request from following 30x chains in the failure path.
+     *
+     * @return array<string, mixed>
+     */
+    public static function httpOptions(string $url): array
+    {
+        $options = ['allow_redirects' => false];
+
+        $check = self::validate($url);
+
+        if (! ($check['valid'] ?? false) || empty($check['ip'])) {
+            return $options;
+        }
+
+        $parts = parse_url($url);
+        $host = $parts['host'] ?? '';
+
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $host = substr($host, 1, -1);
+        }
+
+        $port = $parts['port'] ?? (strtolower($parts['scheme'] ?? '') === 'https' ? 443 : 80);
+
+        // CURLOPT_RESOLVE wants the literal IPv6 wrapped in brackets so the
+        // resolver entry parses correctly.
+        $ip = $check['ip'];
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            $ip = "[{$ip}]";
+        }
+
+        $options['curl'] = [
+            CURLOPT_RESOLVE => ["{$host}:{$port}:{$ip}"],
+        ];
+
+        return $options;
+    }
+
+    /**
+     * Resolve hostname to all A + AAAA records.
+     *
+     * @return array<int, string>
+     */
+    protected static function resolveHost(string $host): array
+    {
+        $ipv4 = @gethostbynamel($host) ?: [];
+
+        $ipv6 = [];
+        $aaaa = @dns_get_record($host, DNS_AAAA) ?: [];
+
+        foreach ($aaaa as $record) {
+            if (! empty($record['ipv6'])) {
+                $ipv6[] = $record['ipv6'];
+            }
+        }
+
+        return array_values(array_unique(array_merge($ipv4, $ipv6)));
+    }
+
+    /**
+     * Accept only public unicast IPs.
+     *
+     * filter_var with FILTER_FLAG_NO_PRIV_RANGE blocks RFC1918 (10/8,
+     * 172.16/12, 192.168/16) and IPv6 unique-local (fc00::/7).
+     * FILTER_FLAG_NO_RES_RANGE blocks 0.0.0.0/8, 127.0.0.0/8 (loopback),
+     * 169.254.0.0/16 (link-local incl. 169.254.169.254 cloud-metadata),
+     * 192.0.0.0/24, 192.0.2.0/24, 198.18.0.0/15, 198.51.100.0/24,
+     * 203.0.113.0/24, 240.0.0.0/4 (reserved), and IPv6 ::/128, ::1/128,
+     * ::ffff:0:0/96, fe80::/10. Multicast (IPv4 224/4, IPv6 ff00::/8) is
+     * NOT covered by the flag, so it is checked separately via inet_pton.
+     */
+    protected static function isAllowedIp(string $ip): bool
+    {
+        // Loopback opt-in for Playwright E2E delivery test (env var, not
+        // app env — explicit allowlist, off in production by default).
+        $loopbackAllowed = filter_var(
+            getenv('WEBHOOK_ALLOW_LOOPBACK') ?: env('WEBHOOK_ALLOW_LOOPBACK', false),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        $bin = @inet_pton($ip);
+
+        if ($bin === false) {
+            return false;
+        }
+
+        // IPv4 multicast 224.0.0.0/4 — first nibble 0xe (0xe0..0xef).
+        if (strlen($bin) === 4 && (ord($bin[0]) & 0xF0) === 0xE0) {
+            return false;
+        }
+
+        // IPv6 multicast ff00::/8 — first byte 0xff.
+        if (strlen($bin) === 16 && ord($bin[0]) === 0xFF) {
+            return false;
+        }
+
+        $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+
+        if ($loopbackAllowed) {
+            // Re-allow ONLY the loopback ranges (127/8, ::1) while keeping
+            // every other reserved/private/link-local/multicast block intact.
+            if (strlen($bin) === 4 && ord($bin[0]) === 127) {
+                return true;
+            }
+            if (strlen($bin) === 16 && $ip === '::1') {
+                return true;
+            }
+        }
+
+        return (bool) filter_var($ip, FILTER_VALIDATE_IP, $flags);
+    }
+}

--- a/packages/Webkul/Webhook/tests/Unit/SafeWebhookUrlTest.php
+++ b/packages/Webkul/Webhook/tests/Unit/SafeWebhookUrlTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use Webkul\Webhook\Validators\SafeWebhookUrl;
+
+it('accepts a normal public https URL', function () {
+    // Public IP literal — bypasses DNS so the test is deterministic in
+    // network-restricted CI. 1.1.1.1 is in public unicast space.
+    $result = SafeWebhookUrl::validate('https://1.1.1.1/inbound');
+
+    expect($result['valid'])->toBeTrue();
+    expect($result['reason'])->toBe('');
+    expect($result['ip'])->toBe('1.1.1.1');
+});
+
+it('pins the resolved IP in httpOptions to close DNS-rebinding TOCTOU', function () {
+    $options = SafeWebhookUrl::httpOptions('https://1.1.1.1/inbound');
+
+    expect($options['allow_redirects'])->toBeFalse();
+    expect($options['curl'][CURLOPT_RESOLVE])->toBe(['1.1.1.1:443:1.1.1.1']);
+});
+
+it('omits the pin and falls back to redirect-disable when validation fails', function () {
+    $options = SafeWebhookUrl::httpOptions('http://127.0.0.1/hook');
+
+    expect($options['allow_redirects'])->toBeFalse();
+    expect($options)->not->toHaveKey('curl');
+});
+
+it('rejects loopback IPv4 literal', function () {
+    $result = SafeWebhookUrl::validate('http://127.0.0.1:9999/probe');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects 0.0.0.0 unspecified address', function () {
+    $result = SafeWebhookUrl::validate('http://0.0.0.0:8080/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects IPv6 loopback literal', function () {
+    $result = SafeWebhookUrl::validate('http://[::1]:8080/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects AWS cloud metadata IP 169.254.169.254', function () {
+    $result = SafeWebhookUrl::validate('http://169.254.169.254/latest/meta-data/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+    expect($result['ip'])->toBe('169.254.169.254');
+});
+
+it('rejects IPv4 RFC1918 private range 10.0.0.0/8', function () {
+    $result = SafeWebhookUrl::validate('http://10.0.0.1/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects IPv4 RFC1918 private range 172.16.0.0/12', function () {
+    $result = SafeWebhookUrl::validate('http://172.16.5.10/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects IPv4 RFC1918 private range 192.168.0.0/16', function () {
+    $result = SafeWebhookUrl::validate('http://192.168.1.1/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects multicast range 224.0.0.0/4', function () {
+    $result = SafeWebhookUrl::validate('http://224.0.0.1/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('restricted_ip');
+});
+
+it('rejects file:// scheme', function () {
+    $result = SafeWebhookUrl::validate('file:///etc/passwd');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('invalid_scheme');
+});
+
+it('rejects gopher:// scheme', function () {
+    $result = SafeWebhookUrl::validate('gopher://attacker.com/');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('invalid_scheme');
+});
+
+it('rejects ftp:// scheme', function () {
+    $result = SafeWebhookUrl::validate('ftp://attacker.com/payload');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('invalid_scheme');
+});
+
+it('rejects empty url', function () {
+    $result = SafeWebhookUrl::validate('');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('empty_url');
+});
+
+it('rejects null url', function () {
+    $result = SafeWebhookUrl::validate(null);
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('empty_url');
+});
+
+it('rejects garbage url with no host', function () {
+    $result = SafeWebhookUrl::validate('http://');
+
+    expect($result['valid'])->toBeFalse();
+    expect($result['reason'])->toBe('invalid_url');
+});
+
+it('allows loopback only when WEBHOOK_ALLOW_LOOPBACK opt-in is set', function () {
+    putenv('WEBHOOK_ALLOW_LOOPBACK=true');
+
+    try {
+        // Loopback now allowed.
+        $loopback = SafeWebhookUrl::validate('http://127.0.0.1:9999/probe');
+        expect($loopback['valid'])->toBeTrue();
+
+        $loopback6 = SafeWebhookUrl::validate('http://[::1]:9999/probe');
+        expect($loopback6['valid'])->toBeTrue();
+
+        // Private / link-local / multicast must STILL be blocked.
+        $private = SafeWebhookUrl::validate('http://10.0.0.1/');
+        expect($private['valid'])->toBeFalse();
+        expect($private['reason'])->toBe('restricted_ip');
+
+        $metadata = SafeWebhookUrl::validate('http://169.254.169.254/');
+        expect($metadata['valid'])->toBeFalse();
+        expect($metadata['reason'])->toBe('restricted_ip');
+
+        $multicast = SafeWebhookUrl::validate('http://224.0.0.1/');
+        expect($multicast['valid'])->toBeFalse();
+        expect($multicast['reason'])->toBe('restricted_ip');
+    } finally {
+        putenv('WEBHOOK_ALLOW_LOOPBACK');
+    }
+});


### PR DESCRIPTION
## Summary
Hardens webhook URL validation and dispatch behaviour:
- Tighter URL format validation (scheme allow-list, length cap, required-if active)
- Outbound request safety improvements in the webhook dispatcher
- HTTP redirect handling tightened on outbound calls
- Defense-in-depth checks applied at every relevant call site

## Tests
- New unit tests covering URL validation edge cases
- Existing webhook test fixtures updated to use resolvable test domains

## Verified Locally
- composer install + optimize:clear + pint --test → pass
- php artisan unopim:translations:check → 224/224 locales pass
- vendor/bin/pest full suite green on this branch

## Test plan
- [ ] Manual: save a valid public webhook URL → success
- [ ] Manual: edit a product → webhook fires successfully
- [ ] CI: pest + playwright green