### PR TITLE
chore(release): v2.0.2  webhook SSRF security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v2.0.x
 
+## v2.0.2 - 2026-05-29
+
+### Improvements
+- Hardened **webhook URL handling** — webhook target URLs are now validated to ensure they resolve to a publicly reachable host before any request is made, applied both when saving the webhook settings and on each product-save dispatch. Outgoing webhook requests connect only to the validated address and no longer follow HTTP redirects ([#447](https://github.com/unopim/unopim/pull/447), [#451](https://github.com/unopim/unopim/pull/451)).
+
 ## v2.0.1 - 2026-05-25
 
 ### Security

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -23,7 +23,7 @@ class Core
      *
      * @var string
      */
-    const VERSION = '2.0.1';
+    const VERSION = '2.0.2';
 
     /**
      * Current Channel.


### PR DESCRIPTION
Release bump for the 2.0 LTS line. Bumps Core::VERSION to 2.0.2 and adds a changelog entry for the webhook URL handling improvements already merged via #447 and #451 (same hardening as 2.1). Version + CHANGELOG only. Pint, translations (224/224), and the webhook Pest suite are green.