### PR TITLE
chore(release): v2.1.2  webhook SSRF security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v2.1.x
 
+## v2.1.2 - 2026-05-29
+
+### Improvements
+- Hardened **webhook URL handling** — webhook target URLs are now validated to ensure they resolve to a publicly reachable host before any request is made, applied both when saving the webhook settings and on each product-save dispatch. Outgoing webhook requests connect only to the validated address and no longer follow HTTP redirects ([#448](https://github.com/unopim/unopim/pull/448), [#450](https://github.com/unopim/unopim/pull/450)).
+
 ## v2.1.1 - 2026-05-26
 
 ### Security

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -23,7 +23,7 @@ class Core
      *
      * @var string
      */
-    const VERSION = '2.1.1';
+    const VERSION = '2.1.2';
 
     /**
      * Current Channel.


### PR DESCRIPTION
Release bump for the 2.1 line. Bumps Core::VERSION to 2.1.2 and adds a changelog entry for the webhook URL handling improvements already merged via #448 and #450 — webhook URLs are validated to resolve to a publicly reachable host before any request, redirects are no longer followed, and requests connect only to the validated address. Version + CHANGELOG only; no code change in this PR. Pint, translations (224/224), and the webhook Pest suite are green.