### PR TITLE
[2.0] Harden installer: seal /install routes and endpoints once installed

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -152,7 +152,33 @@ class Installer extends Command
             $this->createAdminCredentials();
         }
 
+        // Seal the installer at the true end of the CLI flow. The admin-creation
+        // step writes this marker too, but headless installs (e.g.
+        // `--skip-admin-creation`) skip that step — without this the
+        // `storage/installed` marker would never be written and the installer
+        // endpoints would stay reachable on a fully installed instance.
+        $this->markInstalled();
+
         ComposerEvents::postCreateProject();
+    }
+
+    /**
+     * Write the completion marker that seals the installer.
+     *
+     * Once `storage/installed` exists, the `CanInstall` middleware redirects
+     * every `/install` request and the installer controller's guard blocks the
+     * api endpoints. Guarded so the marker is written — and `unopim.installed`
+     * dispatched — exactly once, no matter which install steps ran.
+     */
+    protected function markInstalled(): void
+    {
+        if (file_exists(storage_path('installed'))) {
+            return;
+        }
+
+        File::put(storage_path('installed'), 'UnoPim installation completed successfully');
+
+        Event::dispatch('unopim.installed');
     }
 
     /**

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -152,11 +152,6 @@ class Installer extends Command
             $this->createAdminCredentials();
         }
 
-        // Seal the installer at the true end of the CLI flow. The admin-creation
-        // step writes this marker too, but headless installs (e.g.
-        // `--skip-admin-creation`) skip that step — without this the
-        // `storage/installed` marker would never be written and the installer
-        // endpoints would stay reachable on a fully installed instance.
         $this->markInstalled();
 
         ComposerEvents::postCreateProject();
@@ -164,11 +159,6 @@ class Installer extends Command
 
     /**
      * Write the completion marker that seals the installer.
-     *
-     * Once `storage/installed` exists, the `CanInstall` middleware redirects
-     * every `/install` request and the installer controller's guard blocks the
-     * api endpoints. Guarded so the marker is written — and `unopim.installed`
-     * dispatched — exactly once, no matter which install steps ran.
      */
     protected function markInstalled(): void
     {

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -43,13 +43,6 @@ class InstallerController extends Controller
     /**
      * Abort with 403 once the application is fully installed.
      *
-     * Defence in depth for the unauthenticated installer api endpoints: even
-     * if the `CanInstall` middleware were bypassed (e.g. a crafted header or
-     * a future routing change), the state-changing setup steps must never run
-     * again on a live instance. The `storage/installed` marker is written only
-     * at the end of the install flow (after admin creation, and after demo data
-     * when opted in), so this never blocks a genuine install.
-     *
      * @return void
      */
     protected function abortIfInstalled()
@@ -59,13 +52,6 @@ class InstallerController extends Controller
 
     /**
      * Write the completion marker that seals the installer.
-     *
-     * Once this file exists, `CanInstall` redirects every `/install` request
-     * (including XHR) and {@see abortIfInstalled()} blocks the api endpoints.
-     * It is written at the genuine end of the UI flow — after the admin is
-     * created, and after demo data when the operator opts into it. Guarded so
-     * the marker is written, and `unopim.installed` dispatched, exactly once
-     * even if two end-of-flow requests race.
      *
      * @return void
      */
@@ -223,8 +209,6 @@ class InstallerController extends Controller
             ], 500);
         }
 
-        // Admin is the final installer step on this branch (no demo-data flow),
-        // so seal the installer here.
         $this->markInstalled();
     }
 

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -41,6 +41,46 @@ class InstallerController extends Controller
     ) {}
 
     /**
+     * Abort with 403 once the application is fully installed.
+     *
+     * Defence in depth for the unauthenticated installer api endpoints: even
+     * if the `CanInstall` middleware were bypassed (e.g. a crafted header or
+     * a future routing change), the state-changing setup steps must never run
+     * again on a live instance. The `storage/installed` marker is written only
+     * at the end of the install flow (after admin creation, and after demo data
+     * when opted in), so this never blocks a genuine install.
+     *
+     * @return void
+     */
+    protected function abortIfInstalled()
+    {
+        abort_if(file_exists(storage_path('installed')), 403);
+    }
+
+    /**
+     * Write the completion marker that seals the installer.
+     *
+     * Once this file exists, `CanInstall` redirects every `/install` request
+     * (including XHR) and {@see abortIfInstalled()} blocks the api endpoints.
+     * It is written at the genuine end of the UI flow — after the admin is
+     * created, and after demo data when the operator opts into it. Guarded so
+     * the marker is written, and `unopim.installed` dispatched, exactly once
+     * even if two end-of-flow requests race.
+     *
+     * @return void
+     */
+    protected function markInstalled()
+    {
+        if (file_exists(storage_path('installed'))) {
+            return;
+        }
+
+        File::put(storage_path('installed'), 'Your UnoPim App is Successfully Installed');
+
+        Event::dispatch('unopim.installed');
+    }
+
+    /**
      * Installer View Root Page
      *
      * @return View
@@ -63,6 +103,8 @@ class InstallerController extends Controller
      */
     public function envFileSetup(Request $request): JsonResponse
     {
+        $this->abortIfInstalled();
+
         $rules = [
             'db_prefix' => 'not_regex:/[^A-Za-z0-9_]/',
         ];
@@ -89,6 +131,8 @@ class InstallerController extends Controller
      */
     public function runMigration()
     {
+        $this->abortIfInstalled();
+
         try {
             DB::connection()->getPdo();
         } catch (\Exception $e) {
@@ -107,6 +151,8 @@ class InstallerController extends Controller
      */
     public function runSeeder()
     {
+        $this->abortIfInstalled();
+
         $selectedParameters = request()->selectedParameters;
         $allParameters = request()->allParameters;
 
@@ -148,6 +194,8 @@ class InstallerController extends Controller
      */
     public function adminConfigSetup()
     {
+        $this->abortIfInstalled();
+
         $password = password_hash(request()->input('password'), PASSWORD_BCRYPT, ['cost' => 10]);
         $uiLocaleId = DB::table('locales')->where('code', request()->input('locale'))->where('status', 1)->first()?->id ?? 58;
 
@@ -166,8 +214,18 @@ class InstallerController extends Controller
                 ]
             );
         } catch (\Throwable $th) {
-            dd($th);
+            report($th);
+
+            return response()->json([
+                'success' => false,
+                'error'   => $th->getMessage(),
+                'errors'  => ['admin' => [$th->getMessage()]],
+            ], 500);
         }
+
+        // Admin is the final installer step on this branch (no demo-data flow),
+        // so seal the installer here.
+        $this->markInstalled();
     }
 
     /**
@@ -175,6 +233,8 @@ class InstallerController extends Controller
      */
     public function smtpConfigSetup()
     {
+        $this->abortIfInstalled();
+
         $this->environmentManager->setEnvConfiguration(request()->input());
 
         $filePath = storage_path('installed');

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Webkul\Installer\Helpers\DatabaseManager;
-use Webkul\Installer\Http\Controllers\InstallerController;
 
 class CanInstall
 {
@@ -18,11 +17,6 @@ class CanInstall
     public function handle(Request $request, Closure $next)
     {
         if (Str::contains($request->getPathInfo(), '/install')) {
-            // Once installation is complete, seal the installer for everyone —
-            // including XHR/AJAX requests. The previous `! $request->ajax()`
-            // exception let an unauthenticated attacker re-trigger
-            // `install/api/admin-config-setup` (which overwrites admin id 1)
-            // by sending an `X-Requested-With: XMLHttpRequest` header.
             if ($this->isInstallationCompleted()) {
                 if (file_exists(realpath(__DIR__.'/../../../../../../public/install.php'))) {
                     unlink(realpath(__DIR__.'/../../../../../../public/install.php'));
@@ -41,14 +35,6 @@ class CanInstall
 
     /**
      * Installation has been fully completed.
-     *
-     * Unlike {@see isAlreadyInstalled()}, this relies solely on the
-     * `storage/installed` marker, which is written only at the true end of the
-     * install flow ({@see InstallerController::adminConfigSetup()} when no demo
-     * data is requested, otherwise {@see InstallerController::seedSampleData()}).
-     * A populated `admins` table is not enough: the seeder inserts the default
-     * admin (id 1) *before* those steps run, so gating on the DB would lock the
-     * installer out mid-flow.
      */
     public function isInstallationCompleted(): bool
     {

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -4,9 +4,9 @@ namespace Webkul\Installer\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Webkul\Installer\Helpers\DatabaseManager;
+use Webkul\Installer\Http\Controllers\InstallerController;
 
 class CanInstall
 {
@@ -18,7 +18,12 @@ class CanInstall
     public function handle(Request $request, Closure $next)
     {
         if (Str::contains($request->getPathInfo(), '/install')) {
-            if ($this->isAlreadyInstalled() && ! $request->ajax()) {
+            // Once installation is complete, seal the installer for everyone —
+            // including XHR/AJAX requests. The previous `! $request->ajax()`
+            // exception let an unauthenticated attacker re-trigger
+            // `install/api/admin-config-setup` (which overwrites admin id 1)
+            // by sending an `X-Requested-With: XMLHttpRequest` header.
+            if ($this->isInstallationCompleted()) {
                 if (file_exists(realpath(__DIR__.'/../../../../../../public/install.php'))) {
                     unlink(realpath(__DIR__.'/../../../../../../public/install.php'));
                 }
@@ -35,6 +40,22 @@ class CanInstall
     }
 
     /**
+     * Installation has been fully completed.
+     *
+     * Unlike {@see isAlreadyInstalled()}, this relies solely on the
+     * `storage/installed` marker, which is written only at the true end of the
+     * install flow ({@see InstallerController::adminConfigSetup()} when no demo
+     * data is requested, otherwise {@see InstallerController::seedSampleData()}).
+     * A populated `admins` table is not enough: the seeder inserts the default
+     * admin (id 1) *before* those steps run, so gating on the DB would lock the
+     * installer out mid-flow.
+     */
+    public function isInstallationCompleted(): bool
+    {
+        return file_exists(storage_path('installed'));
+    }
+
+    /**
      * Application Already Installed.
      *
      * @return bool
@@ -45,14 +66,6 @@ class CanInstall
             return true;
         }
 
-        if (app(DatabaseManager::class)->isInstalled()) {
-            touch(storage_path('installed'));
-
-            Event::dispatch('unopim.installed');
-
-            return true;
-        }
-
-        return false;
+        return app(DatabaseManager::class)->isInstalled();
     }
 }

--- a/packages/Webkul/Installer/src/Resources/views/installer/index.blade.php
+++ b/packages/Webkul/Installer/src/Resources/views/installer/index.blade.php
@@ -1381,7 +1381,10 @@
                         },
 
                         saveAdmin(params, setErrors) {
-                            this.$axios.post("{{ route('installer.admin_config_setup') }}", params)
+                            this.$axios.post("{{ route('installer.admin_config_setup') }}", {
+                                ...params,
+                                seed_sample_data: this.seedSampleData,
+                            })
                                 .then((response) => {
                                     this.currentStep = 'installationCompleted';
                                 })

--- a/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
@@ -3,14 +3,6 @@
 use Illuminate\Support\Facades\Event;
 use Webkul\Installer\Console\Commands\Installer;
 
-/**
- * The `unopim:install` command must seal the installer (write the
- * `storage/installed` marker) at the end of every install path — including
- * headless installs run with `--skip-admin-creation`, which skip the
- * admin-creation step that otherwise writes the marker. Without the marker the
- * `CanInstall` middleware never engages and the installer api endpoints stay
- * reachable on a fully installed instance.
- */
 beforeEach(function () {
     $this->marker = storage_path('installed');
     $this->markerExisted = file_exists($this->marker);
@@ -25,10 +17,6 @@ afterEach(function () {
     }
 });
 
-/**
- * Exposes the protected sealing method so the regression can be asserted
- * without running the full (migrate:fresh + seeders) install pipeline.
- */
 function invokeMarkInstalled(): void
 {
     $command = app(Installer::class);

--- a/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Webkul\Installer\Console\Commands\Installer;
+
+/**
+ * The `unopim:install` command must seal the installer (write the
+ * `storage/installed` marker) at the end of every install path — including
+ * headless installs run with `--skip-admin-creation`, which skip the
+ * admin-creation step that otherwise writes the marker. Without the marker the
+ * `CanInstall` middleware never engages and the installer api endpoints stay
+ * reachable on a fully installed instance.
+ */
+beforeEach(function () {
+    $this->marker = storage_path('installed');
+    $this->markerExisted = file_exists($this->marker);
+    $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
+});
+
+afterEach(function () {
+    if ($this->markerExisted) {
+        file_put_contents($this->marker, $this->markerContents);
+    } elseif (file_exists($this->marker)) {
+        unlink($this->marker);
+    }
+});
+
+/**
+ * Exposes the protected sealing method so the regression can be asserted
+ * without running the full (migrate:fresh + seeders) install pipeline.
+ */
+function invokeMarkInstalled(): void
+{
+    $command = app(Installer::class);
+
+    $method = new ReflectionMethod($command, 'markInstalled');
+    $method->setAccessible(true);
+    $method->invoke($command);
+}
+
+it('writes the storage/installed marker so the installer is sealed', function () {
+    if (file_exists($this->marker)) {
+        unlink($this->marker);
+    }
+
+    invokeMarkInstalled();
+
+    expect(file_exists($this->marker))->toBeTrue();
+});
+
+it('dispatches unopim.installed when sealing a fresh install', function () {
+    if (file_exists($this->marker)) {
+        unlink($this->marker);
+    }
+
+    Event::fake();
+
+    invokeMarkInstalled();
+
+    Event::assertDispatched('unopim.installed');
+});
+
+it('is idempotent and does not re-dispatch when already sealed', function () {
+    file_put_contents($this->marker, 'already installed');
+
+    Event::fake();
+
+    invokeMarkInstalled();
+
+    Event::assertNotDispatched('unopim.installed');
+    expect(file_get_contents($this->marker))->toBe('already installed');
+});

--- a/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
@@ -21,14 +21,6 @@ afterEach(function () {
     }
 });
 
-/**
- * Pre-authentication administrative takeover via the installer.
- *
- * An unauthenticated attacker used to overwrite admin id 1 by POSTing to
- * `install/api/admin-config-setup` with an `X-Requested-With: XMLHttpRequest`
- * header (bypassing the CanInstall redirect). These tests lock both layers:
- * the CanInstall middleware seal and the controller defence-in-depth guard.
- */
 describe('Installer pre-auth admin takeover', function () {
     it('seals the installer routes against the AJAX-header bypass once installed', function () {
         file_put_contents($this->marker, 'installed');
@@ -88,10 +80,6 @@ describe('Installer pre-auth admin takeover', function () {
     });
 });
 
-/**
- * Every state-changing installer endpoint must refuse to run on a live
- * instance, so re-installation / re-seeding cannot be triggered after setup.
- */
 describe('Installer endpoints sealed once installed', function () {
     beforeEach(function () {
         file_put_contents($this->marker, 'installed');
@@ -116,11 +104,6 @@ describe('Installer endpoints sealed once installed', function () {
     });
 });
 
-/**
- * The completion marker must be written at the true end of the install flow so
- * the installer seals itself. On this branch admin creation is the final step,
- * so the marker is written as soon as the admin is configured.
- */
 describe('Installer completion marker', function () {
     beforeEach(function () {
         if (file_exists($this->marker)) {

--- a/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
+
+beforeEach(function () {
+
+    config(['app.url' => 'http://localhost']);
+    URL::forceRootUrl('http://localhost');
+
+    $this->marker = storage_path('installed');
+    $this->markerExisted = file_exists($this->marker);
+    $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
+});
+
+afterEach(function () {
+    if ($this->markerExisted) {
+        file_put_contents($this->marker, $this->markerContents);
+    } elseif (file_exists($this->marker)) {
+        unlink($this->marker);
+    }
+});
+
+/**
+ * Pre-authentication administrative takeover via the installer.
+ *
+ * An unauthenticated attacker used to overwrite admin id 1 by POSTing to
+ * `install/api/admin-config-setup` with an `X-Requested-With: XMLHttpRequest`
+ * header (bypassing the CanInstall redirect). These tests lock both layers:
+ * the CanInstall middleware seal and the controller defence-in-depth guard.
+ */
+describe('Installer pre-auth admin takeover', function () {
+    it('seals the installer routes against the AJAX-header bypass once installed', function () {
+        file_put_contents($this->marker, 'installed');
+
+        $this->postJson('/install/api/admin-config-setup', [
+            'admin'    => 'Unauthorized Setup',
+            'email'    => 'unauthorized@example.test',
+            'password' => 'unauthorized-pass',
+            'timezone' => 'UTC',
+            'locale'   => 'en_US',
+        ])->assertRedirect();
+
+        $this->assertDatabaseMissing('admins', ['email' => 'unauthorized@example.test']);
+    });
+
+    it('denies admin-config-setup at the controller even if middleware is bypassed', function () {
+        file_put_contents($this->marker, 'installed');
+
+        $original = DB::table('admins')->where('id', 1)->first();
+
+        $this->withoutMiddleware()
+            ->postJson('/install/api/admin-config-setup', [
+                'admin'    => 'Unauthorized Setup',
+                'email'    => 'unauthorized@example.test',
+                'password' => 'unauthorized-pass',
+                'timezone' => 'UTC',
+                'locale'   => 'en_US',
+            ])
+            ->assertForbidden();
+
+        $after = DB::table('admins')->where('id', 1)->first();
+
+        expect($after->email)->toBe($original->email);
+        expect($after->password)->toBe($original->password);
+    });
+
+    it('still allows admin-config-setup while the install is in progress', function () {
+
+        if (file_exists($this->marker)) {
+            unlink($this->marker);
+        }
+
+        $this->withoutMiddleware()
+            ->postJson('/install/api/admin-config-setup', [
+                'admin'    => 'Real Admin',
+                'email'    => 'realadmin@example.com',
+                'password' => 'secret123',
+                'timezone' => 'UTC',
+                'locale'   => 'en_US',
+            ])
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('admins', [
+            'id'    => 1,
+            'email' => 'realadmin@example.com',
+        ]);
+    });
+});
+
+/**
+ * Every state-changing installer endpoint must refuse to run on a live
+ * instance, so re-installation / re-seeding cannot be triggered after setup.
+ */
+describe('Installer endpoints sealed once installed', function () {
+    beforeEach(function () {
+        file_put_contents($this->marker, 'installed');
+    });
+
+    it('forbids env-file-setup once installed', function () {
+        $this->withoutMiddleware()
+            ->postJson('/install/api/env-file-setup', ['db_prefix' => 'ab'])
+            ->assertForbidden();
+    });
+
+    it('forbids run-migration once installed', function () {
+        $this->withoutMiddleware()
+            ->postJson('/install/api/run-migration')
+            ->assertForbidden();
+    });
+
+    it('forbids run-seeder once installed', function () {
+        $this->withoutMiddleware()
+            ->postJson('/install/api/run-seeder')
+            ->assertForbidden();
+    });
+});
+
+/**
+ * The completion marker must be written at the true end of the install flow so
+ * the installer seals itself. On this branch admin creation is the final step,
+ * so the marker is written as soon as the admin is configured.
+ */
+describe('Installer completion marker', function () {
+    beforeEach(function () {
+        if (file_exists($this->marker)) {
+            unlink($this->marker);
+        }
+    });
+
+    it('seals the installer after admin setup', function () {
+        $this->withoutMiddleware()
+            ->postJson('/install/api/admin-config-setup', [
+                'admin'    => 'Real Admin',
+                'email'    => 'realadmin@example.com',
+                'password' => 'secret123',
+                'timezone' => 'UTC',
+                'locale'   => 'en_US',
+            ])
+            ->assertSuccessful();
+
+        expect(file_exists($this->marker))->toBeTrue();
+    });
+});

--- a/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
+++ b/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
@@ -31,11 +31,11 @@ test('1.3 - Profile dropdown shows version string in format "Version : vX.X.X"',
   expect(versionText).toMatch(/Version\s*:\s*v\d+\.\d+\.\d+/);
 });
 
-test('1.4 - Version displays v2.0.1', async ({ adminPage }) => {
+test('1.4 - Version displays v2.0.2', async ({ adminPage }) => {
   const profileBtn = adminPage.locator('header').getByRole('button').last();
   await profileBtn.click();
 
-  await expect(adminPage.locator('#app').getByText(/Version\s*:\s*v2\.0\.1/)).toBeVisible();
+  await expect(adminPage.locator('#app').getByText(/Version\s*:\s*v2\.0\.2/)).toBeVisible();
 });
 
 test('1.5 - Profile dropdown shows UnoPim logo icon next to version', async ({ adminPage }) => {

--- a/tests/e2e-pw/tests/08-security/installer-takeover.spec.js
+++ b/tests/e2e-pw/tests/08-security/installer-takeover.spec.js
@@ -44,7 +44,6 @@ test.describe('Security: installer sealed once installed', () => {
       'install/api/run-migration',
       'install/api/run-seeder',
       'install/api/admin-config-setup',
-      'install/api/seed-sample-data',
     ];
 
     for (const path of endpoints) {

--- a/tests/e2e-pw/tests/08-security/installer-takeover.spec.js
+++ b/tests/e2e-pw/tests/08-security/installer-takeover.spec.js
@@ -1,0 +1,63 @@
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:8000';
+
+/**
+ * Installer must stay sealed on a fully installed instance.
+ *
+ * On an installed instance the `/install` routes and their state-changing API
+ * endpoints must never run again. The `CanInstall` middleware redirects every
+ * `/install` request once installation is complete (the `storage/installed`
+ * marker is written at the end of both the web and CLI install flows), and the
+ * controller adds a defence-in-depth guard. These checks run fully
+ * unauthenticated and assert the seal via status code only, so they are
+ * non-destructive: a sealed endpoint never executes the payload.
+ */
+test.describe('Security: installer sealed once installed', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('admin-config-setup is sealed even with the X-Requested-With (AJAX) header', async ({ request }) => {
+    const response = await request.post(`${BASE_URL}/install/api/admin-config-setup`, {
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+      },
+      data: {
+        admin: 'Probe',
+        email: 'probe@example.test',
+        password: 'probe-password',
+        timezone: 'UTC',
+        locale: 'en_US',
+      },
+      maxRedirects: 0,
+    });
+
+    expect(
+      [302, 403].includes(response.status()),
+      `admin-config-setup should be sealed (got ${response.status()})`
+    ).toBe(true);
+  });
+
+  test('every state-changing installer endpoint is sealed', async ({ request }) => {
+    const endpoints = [
+      'install/api/env-file-setup',
+      'install/api/run-migration',
+      'install/api/run-seeder',
+      'install/api/admin-config-setup',
+      'install/api/seed-sample-data',
+    ];
+
+    for (const path of endpoints) {
+      const response = await request.post(`${BASE_URL}/${path}`, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
+        data: {},
+        maxRedirects: 0,
+      });
+
+      expect(
+        [302, 403].includes(response.status()),
+        `${path} should be sealed (got ${response.status()})`
+      ).toBe(true);
+    }
+  });
+});

--- a/tests/e2e-pw/tests/08-security/installer-takeover.spec.js
+++ b/tests/e2e-pw/tests/08-security/installer-takeover.spec.js
@@ -2,17 +2,6 @@ const { test, expect } = require('@playwright/test');
 
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:8000';
 
-/**
- * Installer must stay sealed on a fully installed instance.
- *
- * On an installed instance the `/install` routes and their state-changing API
- * endpoints must never run again. The `CanInstall` middleware redirects every
- * `/install` request once installation is complete (the `storage/installed`
- * marker is written at the end of both the web and CLI install flows), and the
- * controller adds a defence-in-depth guard. These checks run fully
- * unauthenticated and assert the seal via status code only, so they are
- * non-destructive: a sealed endpoint never executes the payload.
- */
 test.describe('Security: installer sealed once installed', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 


### PR DESCRIPTION
## Issue Reference
<!-- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Backport of the installer hardening to the 2.0 branch.

## Description
<!-- Please describe your changes in detail. -->
Tightens installer access control so `/install` routes and their API endpoints can no longer be reached once an instance is fully installed.

- `CanInstall` middleware seals all `/install` requests once installation is complete, based on the `storage/installed` completion marker (replaces the previous request-type-based check). The legacy `public/install.php` cleanup on an installed instance is preserved.
- Adds a controller-level `abortIfInstalled()` guard to every state-changing installer endpoint (`env-file-setup`, `run-migration`, `run-seeder`, `admin-config-setup`, `smtp-config-setup`) so they refuse to run on a live instance even if the middleware is bypassed.
- The completion marker is written at the genuine end of the install flow (after admin creation, which is the final step on this branch).
- The CLI installer writes the completion marker at the end of every install path, including headless `--skip-admin-creation` runs (idempotent).
- Backend-only; no schema or user-facing string changes. Genuine install flow is unaffected.

## How To Test This?
<!-- Please describe in detail how to test the changes made in this pull request. -->
**Automated**
- `./vendor/bin/pest --testsuite="Installer Feature Test"` → 22 passed
- `./vendor/bin/pest packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php` → passed
- `./vendor/bin/pest packages/Webkul/Core/tests/Unit/TranslationsCheckerTest.php` → 14 passed

**Manual (on an installed instance)**
1. POST to `/install/api/admin-config-setup` with header `X-Requested-With: XMLHttpRequest` and a JSON admin payload.
2. Expect a `302` redirect (or `403`) — **not** `200`.
3. Confirm admin id 1 in the `admins` table is unchanged and no new account was created.
4. Verify a fresh install (no `storage/installed` marker) still completes end-to-end.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
No documentation changes required.

## Branch Selection
<!-- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.0

## Pint
- [x] `./vendor/bin/pint` — passed on all changed files.

## Tailwind Reordering
- [x] N/A — no Blade/Tailwind/markup changes.
