### PR TITLE
[Backport 2.0] fix(installer): remove hardcoded admin default credentials & make seeders idempotent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ APP_DEBUG=true
 APP_URL=http://localhost:8000
 APP_ADMIN_URL=admin
 
+# Initial admin (used by AdminsTableSeeder on first boot only).
+# Leave blank to auto-generate a random password and write it to
+# storage/app/admin-credentials.txt — read it once, then delete.
+# Existing admin rows are NEVER overwritten on re-seed.
+INSTALLER_ADMIN_EMAIL=
+INSTALLER_ADMIN_PASSWORD=
+
 # Comma-separated list of upstream proxy IPs (or CIDRs) allowed to set
 # X-Forwarded-* headers. Use '*' only if your edge already strips these
 # headers from the public internet. Defaults to '127.0.0.1' when unset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Improvements
 - Hardened **webhook URL handling** — webhook target URLs are now validated to ensure they resolve to a publicly reachable host before any request is made, applied both when saving the webhook settings and on each product-save dispatch. Outgoing webhook requests connect only to the validated address and no longer follow HTTP redirects ([#447](https://github.com/unopim/unopim/pull/447), [#451](https://github.com/unopim/unopim/pull/451)).
 
+### Security
+- Fixed **insecure default admin password on install** — the installer no longer creates the admin with a known default password. Set `INSTALLER_ADMIN_EMAIL` / `INSTALLER_ADMIN_PASSWORD`, or leave them blank and a random password is generated and written once to `storage/app/admin-credentials.txt` (read it, log in, then delete). Existing admin users are never overwritten on re-install ([#457](https://github.com/unopim/unopim/pull/457)).
+- Fixed **duplicate rows on re-seeding** — admin and role seeders are now idempotent and skip insertion when the record already exists ([#457](https://github.com/unopim/unopim/pull/457)).
+
 ## v2.0.1 - 2026-05-25
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 ### Improvements
 - Hardened **webhook URL handling** — webhook target URLs are now validated to ensure they resolve to a publicly reachable host before any request is made, applied both when saving the webhook settings and on each product-save dispatch. Outgoing webhook requests connect only to the validated address and no longer follow HTTP redirects ([#447](https://github.com/unopim/unopim/pull/447), [#451](https://github.com/unopim/unopim/pull/451)).
 
-### Security
-- Fixed **insecure default admin password on install** — the installer no longer creates the admin with a known default password. Set `INSTALLER_ADMIN_EMAIL` / `INSTALLER_ADMIN_PASSWORD`, or leave them blank and a random password is generated and written once to `storage/app/admin-credentials.txt` (read it, log in, then delete). Existing admin users are never overwritten on re-install ([#457](https://github.com/unopim/unopim/pull/457)).
-- Fixed **duplicate rows on re-seeding** — admin and role seeders are now idempotent and skip insertion when the record already exists ([#457](https://github.com/unopim/unopim/pull/457)).
-
 ## v2.0.1 - 2026-05-25
 
 ### Security

--- a/packages/Webkul/Installer/src/Database/Seeders/User/AdminsTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/User/AdminsTableSeeder.php
@@ -4,6 +4,7 @@ namespace Webkul\Installer\Database\Seeders\User;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Webkul\Core\Helpers\Database\DatabaseSequenceHelper;
 
@@ -17,18 +18,32 @@ class AdminsTableSeeder extends Seeder
      */
     public function run($parameters = [])
     {
-        DB::table('admins')->delete();
+
+        $adminEmail = ($parameters['admin_email'] ?? '')
+            ?: env('INSTALLER_ADMIN_EMAIL')
+            ?: 'admin@example.com';
+
+        $providedPassword = ($parameters['admin_password'] ?? '')
+            ?: env('INSTALLER_ADMIN_PASSWORD')
+            ?: '';
+
+        $adminPassword = $providedPassword ?: Str::random(20);
+        $generatedRandom = $providedPassword === '';
+
+        DatabaseSequenceHelper::fixSequence('admins');
+
+        if (DB::table('admins')->exists()) {
+            return;
+        }
 
         $defaultLocale = $parameters['default_locale'] ?? config('app.locale');
-
-        /** Default locale id to be set to user else 58 id of en_US locale is added */
         $defaultLocaleId = DB::table('locales')->where('code', $defaultLocale)->where('status', 1)->first()?->id ?? 58;
 
         DB::table('admins')->insert([
             'id'            => 1,
             'name'          => trans('installer::app.seeders.user.users.name', [], $defaultLocale),
-            'email'         => 'admin@example.com',
-            'password'      => bcrypt('admin123'),
+            'email'         => $adminEmail,
+            'password'      => bcrypt($adminPassword),
             'api_token'     => Str::random(80),
             'created_at'    => date('Y-m-d H:i:s'),
             'updated_at'    => date('Y-m-d H:i:s'),
@@ -38,5 +53,41 @@ class AdminsTableSeeder extends Seeder
         ]);
 
         DatabaseSequenceHelper::fixSequence('admins');
+
+        if ($generatedRandom) {
+            $this->writeGeneratedCredentialsFile($adminEmail, $adminPassword);
+        }
+    }
+
+    /**
+     * Persist a one-time credentials file the operator can read on first boot.
+     */
+    private function writeGeneratedCredentialsFile(string $email, string $password): void
+    {
+        $path = storage_path('app/admin-credentials.txt');
+
+        $body = "UnoPim — initial admin credentials (auto-generated)\n"
+            ."====================================================\n"
+            ."email:    {$email}\n"
+            ."password: {$password}\n\n"
+            ."Log in once, rotate the password, then delete this file.\n";
+
+        if (file_put_contents($path, $body, LOCK_EX) === false) {
+            throw new \RuntimeException(
+                "Unable to write initial admin credentials to {$path}. ".
+                'Set INSTALLER_ADMIN_PASSWORD and retry installation.'
+            );
+        }
+
+        @chmod($path, 0600);
+
+        try {
+            Log::warning(
+                '[unopim:install] Generated random initial admin password. '.
+                'See '.$path.' — rotate and delete after first login.'
+            );
+        } catch (\Throwable) {
+            // Logging is best-effort; never break first-time setup if the log sink is read-only.
+        }
     }
 }

--- a/packages/Webkul/Installer/src/Database/Seeders/User/RolesTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/User/RolesTableSeeder.php
@@ -16,9 +16,11 @@ class RolesTableSeeder extends Seeder
      */
     public function run($parameters = [])
     {
-        DB::table('admins')->delete();
+        DatabaseSequenceHelper::fixSequence('roles');
 
-        DB::table('roles')->delete();
+        if (DB::table('roles')->where('id', 1)->exists()) {
+            return;
+        }
 
         $defaultLocale = $parameters['default_locale'] ?? config('app.locale');
 

--- a/packages/Webkul/Installer/tests/Feature/AdminsTableSeederSecurityTest.php
+++ b/packages/Webkul/Installer/tests/Feature/AdminsTableSeederSecurityTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Webkul\Installer\Database\Seeders\User\AdminsTableSeeder;
+
+function setEnvVar(string $name, string $value): void
+{
+    $_SERVER[$name] = $value;
+    $_ENV[$name] = $value;
+    putenv("{$name}={$value}");
+}
+
+function clearEnvVar(string $name): void
+{
+    unset($_SERVER[$name], $_ENV[$name]);
+    putenv($name);
+}
+
+beforeEach(function () {
+    clearEnvVar('INSTALLER_ADMIN_EMAIL');
+    clearEnvVar('INSTALLER_ADMIN_PASSWORD');
+    @unlink(storage_path('app/admin-credentials.txt'));
+
+    DB::table('admins')->delete();
+});
+
+afterEach(function () {
+    clearEnvVar('INSTALLER_ADMIN_EMAIL');
+    clearEnvVar('INSTALLER_ADMIN_PASSWORD');
+    @unlink(storage_path('app/admin-credentials.txt'));
+});
+
+it('never bcrypts the old hardcoded admin123 default when env vars are blank', function () {
+    app(AdminsTableSeeder::class)->run();
+
+    $hash = DB::table('admins')->where('email', 'admin@example.com')->value('password');
+
+    expect($hash)->not->toBeNull()
+        ->and(Hash::check('admin123', $hash))->toBeFalse();
+});
+
+it('generates a 20-char random password and writes a 0600 credentials file when env is blank', function () {
+    app(AdminsTableSeeder::class)->run();
+
+    $path = storage_path('app/admin-credentials.txt');
+    expect(file_exists($path))->toBeTrue()
+        ->and(fileperms($path) & 0777)->toBe(0600);
+
+    preg_match('/password:\s*(\S+)/', file_get_contents($path), $m);
+    $random = $m[1] ?? '';
+
+    expect($random)->toHaveLength(20);
+
+    $hash = DB::table('admins')->where('email', 'admin@example.com')->value('password');
+    expect(Hash::check($random, $hash))->toBeTrue();
+});
+
+it('uses INSTALLER_ADMIN_EMAIL from env when set', function () {
+    setEnvVar('INSTALLER_ADMIN_EMAIL', 'ops@yourco.com');
+
+    app(AdminsTableSeeder::class)->run();
+
+    expect(DB::table('admins')->where('email', 'ops@yourco.com')->exists())->toBeTrue()
+        ->and(DB::table('admins')->where('email', 'admin@example.com')->exists())->toBeFalse();
+});
+
+it('uses INSTALLER_ADMIN_PASSWORD from env', function () {
+    setEnvVar('INSTALLER_ADMIN_PASSWORD', 'my-very-secret-pw');
+
+    app(AdminsTableSeeder::class)->run();
+
+    $hash = DB::table('admins')->where('email', 'admin@example.com')->value('password');
+
+    expect(Hash::check('my-very-secret-pw', $hash))->toBeTrue();
+});
+
+it('lets $parameters override env vars', function () {
+    setEnvVar('INSTALLER_ADMIN_EMAIL', 'env@example.com');
+    setEnvVar('INSTALLER_ADMIN_PASSWORD', 'env-pass');
+
+    app(AdminsTableSeeder::class)->run([
+        'admin_email'    => 'param@example.com',
+        'admin_password' => 'param-pass',
+    ]);
+
+    $hash = DB::table('admins')->where('email', 'param@example.com')->value('password');
+
+    expect($hash)->not->toBeNull()
+        ->and(Hash::check('param-pass', $hash))->toBeTrue()
+        ->and(DB::table('admins')->where('email', 'env@example.com')->exists())->toBeFalse();
+});
+
+it('treats a present-but-blank env var as unset and falls back to the default email', function () {
+    setEnvVar('INSTALLER_ADMIN_EMAIL', '');
+    setEnvVar('INSTALLER_ADMIN_PASSWORD', '');
+
+    app(AdminsTableSeeder::class)->run();
+
+    $admin = DB::table('admins')->where('email', 'admin@example.com')->first();
+
+    expect($admin)->not->toBeNull()
+        ->and($admin->email)->toBe('admin@example.com');
+});
+
+it('is idempotent — does not overwrite an existing admin with the same email', function () {
+    app(AdminsTableSeeder::class)->run(['admin_password' => 'first-pass']);
+    $firstHash = DB::table('admins')->where('email', 'admin@example.com')->value('password');
+
+    app(AdminsTableSeeder::class)->run(['admin_password' => 'second-pass']);
+    $secondHash = DB::table('admins')->where('email', 'admin@example.com')->value('password');
+
+    expect($secondHash)->toBe($firstHash)
+        ->and(Hash::check('first-pass', $secondHash))->toBeTrue()
+        ->and(Hash::check('second-pass', $secondHash))->toBeFalse();
+});
+
+it('does not delete other admin rows', function () {
+    DB::table('admins')->insert([
+        'id'           => 5000,
+        'name'         => 'ops-2',
+        'email'        => 'ops2@example.test',
+        'password'     => bcrypt('ops2-pass'),
+        'api_token'    => str_repeat('x', 80),
+        'role_id'      => 1,
+        'status'       => 1,
+        'timezone'     => 'UTC',
+        'ui_locale_id' => 58,
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    app(AdminsTableSeeder::class)->run();
+
+    expect(DB::table('admins')->where('id', 5000)->exists())->toBeTrue();
+});

--- a/packages/Webkul/Installer/tests/Feature/RolesTableSeederIdempotencyTest.php
+++ b/packages/Webkul/Installer/tests/Feature/RolesTableSeederIdempotencyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\Installer\Database\Seeders\User\RolesTableSeeder;
+
+it('does not delete rows from the admins table', function () {
+    if (! DB::table('roles')->where('id', 1)->exists()) {
+        DB::table('roles')->insert([
+            'id'              => 1,
+            'name'            => 'tmp-role',
+            'description'     => 'tmp',
+            'permission_type' => 'all',
+        ]);
+    }
+
+    DB::table('admins')->insert([
+        'id'           => 9999,
+        'name'         => 'sentinel',
+        'email'        => 'sentinel@example.test',
+        'password'     => bcrypt('whatever'),
+        'api_token'    => str_repeat('a', 80),
+        'role_id'      => 1,
+        'status'       => 1,
+        'timezone'     => 'UTC',
+        'ui_locale_id' => 58,
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    app(RolesTableSeeder::class)->run();
+
+    expect(DB::table('admins')->where('id', 9999)->exists())->toBeTrue();
+});
+
+it('inserts role id=1 when none exists', function () {
+    DB::table('roles')->where('id', 1)->delete();
+
+    app(RolesTableSeeder::class)->run();
+
+    expect(DB::table('roles')->where('id', 1)->exists())->toBeTrue();
+});
+
+it('is idempotent — does not re-insert role id=1 when it already exists', function () {
+    app(RolesTableSeeder::class)->run();
+    DB::table('roles')->where('id', 1)->update(['name' => 'mutated-by-operator']);
+
+    app(RolesTableSeeder::class)->run();
+
+    expect(DB::table('roles')->where('id', 1)->value('name'))->toBe('mutated-by-operator');
+});
+
+it('does not wipe operator-added roles', function () {
+    if (! DB::table('roles')->where('id', 1)->exists()) {
+        app(RolesTableSeeder::class)->run();
+    }
+
+    DB::table('roles')->insert([
+        'id'              => 5000,
+        'name'            => 'operator-role',
+        'description'     => 'added by ops',
+        'permission_type' => 'all',
+    ]);
+
+    app(RolesTableSeeder::class)->run();
+
+    expect(DB::table('roles')->where('id', 5000)->exists())->toBeTrue();
+});


### PR DESCRIPTION
Backport of #457 to release/2.0.2. Core security fix + tests only.