### PR TITLE
docs(agents): update AI agent instructions from Laravel 11 to Laravel 12 / PHP 8.3

### DIFF
--- a/.github/code-generation-instructions.md
+++ b/.github/code-generation-instructions.md
@@ -1,13 +1,13 @@
 # Unopim Connector — Code Generation Instructions
 
-Follow these guidelines when generating code for **Laravel 11 + Unopim** connector and plugin packages.
+Follow these guidelines when generating code for **Laravel 12 + Unopim** connector and plugin packages.
 Applies to all AI coding agents: Kilo Code, GitHub Copilot, Claude Code, Codex, Cursor.
 
 
 
 ## 1. Documentation Standards
 
-- Use Laravel 11 PHPDoc block comments (`/** */`) — not inline `//` comments
+- Use Laravel 12 PHPDoc block comments (`/** */`) — not inline `//` comments
 - Document method **intent** only; skip obvious implementation details
 - Remove unnecessary comments and dead code
 - Use `@return`, `@param` in PHPDoc when types are complex or non-obvious

--- a/.github/code-review-instructions.md
+++ b/.github/code-review-instructions.md
@@ -1,6 +1,6 @@
 # Unopim Connector — Code Review Instructions
 
-Use this checklist when reviewing Laravel 11 + Unopim connector/plugin code.
+Use this checklist when reviewing Laravel 12 + Unopim connector/plugin code.
 Applies to all AI coding agents: Kilo Code, GitHub Copilot, Claude Code, Codex, Cursor.
 
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,14 +1,14 @@
 # GitHub Copilot Workspace Instructions: Unopim Connector Development
 
 This workspace contains agent skills for building **Unopim third-party connector
-modules**. Unopim is a Webkul Laravel 11 PIM — it is NOT Bagisto.
+modules**. Unopim is a Webkul Laravel 12 PIM — it is NOT Bagisto.
 
 ---
 
 ## Framework
 
 - **Platform:** Unopim (not Bagisto, not Magento, not Akeneo)
-- **Language:** PHP 8.1+ / Laravel 11
+- **Language:** PHP 8.3+ / Laravel 12
 - **Module base:** `packages/Webkul/{ModuleName}/src/`
 - **Reference:** `packages/Webkul/WooCommerce/` is the ground-truth connector
 
@@ -16,19 +16,23 @@ modules**. Unopim is a Webkul Laravel 11 PIM — it is NOT Bagisto.
 
 ## Non-negotiable Conventions
 
-### 1. Table names always start with `wk_`
+### 1. Table names use unprefixed names; Laravel adds the `DB_PREFIX`
+Unopim models declare `$table` **without** the `wk_` prefix. The framework prepends the configured `DB_PREFIX` (default `wk_`) automatically, so hardcoding it produces `wk_wk_*` tables in production.
 ```php
 // Correct
+protected $table = 'woocommerce_credentials';
+DB::table('shopify_products')
+
+// Wrong — do not hardcode the prefix
 protected $table = 'wk_woocommerce_credentials';
 DB::table('wk_shopify_products')
-
-// Wrong
-protected $table = 'woocommerce_credentials';
 ```
+This matches the reference connectors (`packages/Webkul/Core/src/Models/Channel.php` uses `channels`, `CoreConfig.php` uses `core_config`) and is the convention enforced by `AGENTS.md`.
 
 ### 2. Migration folder: `Database/Migration/` (no 's')
 ```
-Database/Migration/2025_01_01_000000_wk_module_credentials.php
+Database/Migration/2025_01_01_000000_module_credentials.php
+```
 ```
 
 ### 3. ServiceProvider: routes via `Route::middleware('web')->group()`
@@ -116,7 +120,7 @@ class CredentialDataGrid extends DataGrid
      */
     public function prepareQueryBuilder()     // no PHP return type hint
     {
-        return DB::table('wk_module_credentials')->select(...);
+        return DB::table('module_credentials')->select(...);
     }
 
     public function prepareColumns()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Copilot, Claude, Kilo Code, Cursor, etc.).
 
 ## Framework Context
 
-- **Platform:** Unopim (Webkul) — Laravel 11 modular PIM system
+- **Platform:** Unopim (Webkul) — Laravel 12 modular PIM system
 - **Not Bagisto** — Unopim and Bagisto are different products. Do NOT use Bagisto patterns.
 - **Package location:** `packages/Webkul/{ModuleName}/src/`
 - **Reference implementation:** `packages/Webkul/WooCommerce/` (production reference)

--- a/code-generation-instructions.md
+++ b/code-generation-instructions.md
@@ -1,13 +1,13 @@
 # Unopim Connector — Code Generation Instructions
 
-Follow these guidelines when generating code for **Laravel 11 + Unopim** connector and plugin packages.
+Follow these guidelines when generating code for **Laravel 12 + Unopim** connector and plugin packages.
 Applies to all AI coding agents: Kilo Code, GitHub Copilot, Claude Code, Codex, Cursor.
 
 ---
 
 ## 1. Documentation Standards
 
-- Use Laravel 11 PHPDoc block comments (`/** */`) — not inline `//` comments
+- Use Laravel 12 PHPDoc block comments (`/** */`) — not inline `//` comments
 - Document method **intent** only; skip obvious implementation details
 - Remove unnecessary comments and dead code
 - Use `@return`, `@param` in PHPDoc when types are complex or non-obvious

--- a/code-review-instructions.md
+++ b/code-review-instructions.md
@@ -1,6 +1,6 @@
 # Unopim Connector — Code Review Instructions
 
-Use this checklist when reviewing Laravel 11 + Unopim connector/plugin code.
+Use this checklist when reviewing Laravel 12 + Unopim connector/plugin code.
 Applies to all AI coding agents: Kilo Code, GitHub Copilot, Claude Code, Codex, Cursor.
 
 ---


### PR DESCRIPTION
Updates six agent-instruction files (read by Copilot, Kilo Code, Claude Code, Cursor, and Codex at session start) to match the project's actual framework version.

composer.json requires:
  - "php": "^8.3"
  - "laravel/framework": "^12.0"

But these docs still say Laravel 11 and PHP 8.1+. AI agents applying Laravel 11 idioms and targeting the wrong PHP version is a real risk for new contributors.

In addition, `.github/copilot-instructions.md` Section 1 actively told agents to hardcode the `wk_` table prefix — this contradicts `AGENTS.md` ("Never hardcode `wk_` in table names — it causes `wk_wk_` double prefix issues") and the actual production code (`packages/Webkul/Core/src/Models/Channel.php` uses `channels`, `CoreConfig.php` uses `core_config`). The section has been rewritten to point at the real unprefixed convention.

Files updated:
- AGENTS.md
- code-generation-instructions.md (root)
- code-review-instructions.md     (root)
- .github/code-generation-instructions.md
- .github/code-review-instructions.md
- .github/copilot-instructions.md