### PR TITLE
Enforce ACL permission checks on state-changing admin routes

### DIFF
--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -596,9 +596,29 @@ return [
         'route' => 'admin.configuration.integrations.create',
         'sort'  => 1,
     ], [
+        'key'   => 'configuration.integrations.create',
+        'name'  => 'admin::app.acl.create',
+        'route' => 'admin.configuration.integrations.store',
+        'sort'  => 1,
+    ], [
         'key'   => 'configuration.integrations.edit',
         'name'  => 'admin::app.acl.edit',
         'route' => 'admin.configuration.integrations.edit',
+        'sort'  => 2,
+    ], [
+        'key'   => 'configuration.integrations.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.configuration.integrations.update',
+        'sort'  => 2,
+    ], [
+        'key'   => 'configuration.integrations.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.configuration.integrations.generate_key',
+        'sort'  => 2,
+    ], [
+        'key'   => 'configuration.integrations.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.configuration.integrations.re_generate_secret_key',
         'sort'  => 2,
     ], [
         'key'   => 'configuration.integrations.delete',

--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -71,6 +71,41 @@ return [
         'route' => 'admin.catalog.products.mass_delete',
         'sort'  => 6,
     ], [
+        'key'   => 'catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.products.bulk-edit.save',
+        'sort'  => 3,
+    ], [
+        'key'   => 'catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.products.bulk-edit.save-media',
+        'sort'  => 3,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.products.bulkedit',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.bulkedit.attributes.fetch-all',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.products.bulkedit.filters',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.products.check-variant',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.categories.tree',
+        'sort'  => 1,
+    ], [
         'key'   => 'catalog.categories',
         'name'  => 'admin::app.acl.categories',
         'route' => 'admin.catalog.categories.index',
@@ -265,6 +300,21 @@ return [
         'name'  => 'admin::app.acl.copy',
         'route' => 'admin.catalog.families.copy',
         'sort'  => 4,
+    ], [
+        'key'   => 'catalog.families.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.families.completeness.edit',
+        'sort'  => 2,
+    ], [
+        'key'   => 'catalog.families.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.families.completeness.update',
+        'sort'  => 2,
+    ], [
+        'key'   => 'catalog.families.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.families.completeness.mass_update',
+        'sort'  => 2,
     ], [
         'key'   => 'history',
         'name'  => 'admin::app.acl.history',
@@ -584,6 +634,16 @@ return [
         'key'    => 'configuration',
         'name'   => 'admin::app.acl.configuration',
         'route'  => 'admin.configuration.integrations.index',
+        'sort'   => 9,
+    ], [
+        'key'    => 'configuration',
+        'name'   => 'admin::app.acl.configuration',
+        'route'  => 'admin.configuration.store',
+        'sort'   => 9,
+    ], [
+        'key'    => 'configuration',
+        'name'   => 'admin::app.acl.configuration',
+        'route'  => 'admin.configuration.download',
         'sort'   => 9,
     ], [
         'key'   => 'configuration.integrations',

--- a/packages/Webkul/Admin/tests/Feature/Acl/WriteRouteBypassRegressionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/WriteRouteBypassRegressionTest.php
@@ -153,3 +153,81 @@ it('denies data_transfer.exports.update without export.edit permission', functio
     $this->put(route('admin.settings.data_transfer.exports.update', ['id' => 1]), [])
         ->assertStatus(403);
 });
+
+/**
+ * Integration / OAuth API key write routes. These create and issue credentials
+ * for a chosen admin account, so a restricted user must not be able to reach
+ * them by posting directly to the write verb. (Reported privilege escalation.)
+ */
+it('denies configuration.integrations.store without integrations.create permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.integrations.store'), [])
+        ->assertStatus(403);
+});
+
+it('denies configuration.integrations.update without integrations.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->put(route('admin.configuration.integrations.update', ['id' => 1]), [])
+        ->assertStatus(403);
+});
+
+it('denies configuration.integrations.generate_key without integrations.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.integrations.generate_key'), [])
+        ->assertStatus(403);
+});
+
+it('denies configuration.integrations.re_generate_secret_key without integrations.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.integrations.re_generate_secret_key'), [])
+        ->assertStatus(403);
+});
+
+/**
+ * Product bulk-edit save routes modify products and must require product edit.
+ */
+it('denies catalog.products.bulk-edit.save without products.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.products.bulk-edit.save'), [])
+        ->assertStatus(403);
+});
+
+it('denies catalog.products.bulk-edit.save-media without products.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.products.bulk-edit.save-media'), [])
+        ->assertStatus(403);
+});
+
+/**
+ * Family completeness settings write routes must require family edit.
+ */
+it('denies catalog.families.completeness.update without families.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.families.completeness.update'), [])
+        ->assertStatus(403);
+});
+
+it('denies catalog.families.completeness.mass_update without families.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.families.completeness.mass_update'), [])
+        ->assertStatus(403);
+});
+
+/**
+ * Core configuration save must require the configuration permission so a
+ * restricted admin cannot persist global system settings.
+ */
+it('denies configuration.store without configuration permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.store', ['slug' => 'general', 'slug2' => 'general']), [])
+        ->assertStatus(403);
+});


### PR DESCRIPTION
## Summary

The Bouncer middleware only enforces a permission when the current route
name exists in the ACL map (`config/acl.php` → `$acl->roles[]`). Several
state-changing routes were missing from that map, so they were not covered
by any permission check — they were reachable by any authenticated admin
regardless of their assigned role.

This PR adds the missing route → permission mappings so these routes are
gated consistently with the rest of the codebase.

## Root cause

`hasPermission()` is an exact route→key lookup; routes absent from
`config/acl.php` skip `bouncer()->allow()` entirely, and the affected
controllers have no inline `bouncer()` fallback.

## Changes

Added the missing route → permission mappings in `acl.php`:

| Route(s) | Mapped permission |
|---|---|
| `configuration.integrations.store` / `.update` / `.generate_key` / `.re_generate_secret_key` | `configuration.integrations.create` / `.edit` |
| `catalog.products.bulk-edit.save` / `.save-media` | `catalog.products.edit` |
| `catalog.families.completeness.edit` / `.update` / `.mass_update` | `catalog.families.edit` |
| `configuration.store` / `.download` | `configuration` |
| `catalog.products.bulkedit` / `.bulkedit.filters` / `bulkedit.attributes.fetch-all` / `products.check-variant` / `categories.tree` | `catalog.products` (view) |

Mappings were chosen against the exact-match permission model and the
permission tree's ancestor auto-select behaviour, so **legitimate users keep
their existing access** — read-only views and per-user actions (e.g.
`notification.read_all`) are intentionally left unchanged.

## Tests

Extended `WriteRouteBypassRegressionTest` with cases asserting a restricted
(dashboard-only) user receives **403** on each newly mapped write route.

- Pint: ✅ passed
- Pest: ✅ 30/30 regression + 36/36 positive-path (Integration,
  IntegrationSection, ProductBulkEdit, CompletenessSettings)
- Translations: ✅ 224/224 locales (existing keys reused, none added)
- Playwright: unaffected — e2e runs as superadmin (`permission_type=all`),
  which bypasses Bouncer; no UI/string changes

