### PR TITLE
Enforce ACL permission checks on state-changing admin routes (2.0 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v2.0.x
 
+## v2.0.2 - 2026-05-29
+
+### Improvements
+- Hardened **webhook URL handling** — webhook target URLs are now validated to ensure they resolve to a publicly reachable host before any request is made, applied both when saving the webhook settings and on each product-save dispatch. Outgoing webhook requests connect only to the validated address and no longer follow HTTP redirects ([#447](https://github.com/unopim/unopim/pull/447), [#451](https://github.com/unopim/unopim/pull/451)).
+
 ## v2.0.1 - 2026-05-25
 
 ### Security

--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -71,6 +71,41 @@ return [
         'route' => 'admin.catalog.products.mass_delete',
         'sort'  => 6,
     ], [
+        'key'   => 'catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.products.bulk-edit.save',
+        'sort'  => 3,
+    ], [
+        'key'   => 'catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.products.bulk-edit.save-media',
+        'sort'  => 3,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.products.bulkedit',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.bulkedit.attributes.fetch-all',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.products.bulkedit.filters',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.products.check-variant',
+        'sort'  => 1,
+    ], [
+        'key'   => 'catalog.products',
+        'name'  => 'admin::app.acl.products',
+        'route' => 'admin.catalog.categories.tree',
+        'sort'  => 1,
+    ], [
         'key'   => 'catalog.categories',
         'name'  => 'admin::app.acl.categories',
         'route' => 'admin.catalog.categories.index',
@@ -265,6 +300,21 @@ return [
         'name'  => 'admin::app.acl.copy',
         'route' => 'admin.catalog.families.copy',
         'sort'  => 4,
+    ], [
+        'key'   => 'catalog.families.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.families.completeness.edit',
+        'sort'  => 2,
+    ], [
+        'key'   => 'catalog.families.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.families.completeness.update',
+        'sort'  => 2,
+    ], [
+        'key'   => 'catalog.families.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.catalog.families.completeness.mass_update',
+        'sort'  => 2,
     ], [
         'key'   => 'history',
         'name'  => 'admin::app.acl.history',
@@ -566,6 +616,16 @@ return [
         'route'  => 'admin.configuration.integrations.index',
         'sort'   => 9,
     ], [
+        'key'    => 'configuration',
+        'name'   => 'admin::app.acl.configuration',
+        'route'  => 'admin.configuration.store',
+        'sort'   => 9,
+    ], [
+        'key'    => 'configuration',
+        'name'   => 'admin::app.acl.configuration',
+        'route'  => 'admin.configuration.download',
+        'sort'   => 9,
+    ], [
         'key'   => 'configuration.integrations',
         'name'  => 'admin::app.acl.integrations',
         'route' => 'admin.configuration.integrations.index',
@@ -576,9 +636,29 @@ return [
         'route' => 'admin.configuration.integrations.create',
         'sort'  => 1,
     ], [
+        'key'   => 'configuration.integrations.create',
+        'name'  => 'admin::app.acl.create',
+        'route' => 'admin.configuration.integrations.store',
+        'sort'  => 1,
+    ], [
         'key'   => 'configuration.integrations.edit',
         'name'  => 'admin::app.acl.edit',
         'route' => 'admin.configuration.integrations.edit',
+        'sort'  => 2,
+    ], [
+        'key'   => 'configuration.integrations.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.configuration.integrations.update',
+        'sort'  => 2,
+    ], [
+        'key'   => 'configuration.integrations.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.configuration.integrations.generate_key',
+        'sort'  => 2,
+    ], [
+        'key'   => 'configuration.integrations.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.configuration.integrations.re_generate_secret_key',
         'sort'  => 2,
     ], [
         'key'   => 'configuration.integrations.delete',

--- a/packages/Webkul/Admin/tests/Feature/Acl/WriteRouteBypassRegressionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/WriteRouteBypassRegressionTest.php
@@ -153,3 +153,81 @@ it('denies data_transfer.exports.update without export.edit permission', functio
     $this->put(route('admin.settings.data_transfer.exports.update', ['id' => 1]), [])
         ->assertStatus(401);
 });
+
+/**
+ * Integration / OAuth API key write routes. These create and issue credentials
+ * for a chosen admin account, so a restricted user must not be able to reach
+ * them by posting directly to the write verb. (Reported privilege escalation.)
+ */
+it('denies configuration.integrations.store without integrations.create permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.integrations.store'), [])
+        ->assertStatus(401);
+});
+
+it('denies configuration.integrations.update without integrations.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->put(route('admin.configuration.integrations.update', ['id' => 1]), [])
+        ->assertStatus(401);
+});
+
+it('denies configuration.integrations.generate_key without integrations.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.integrations.generate_key'), [])
+        ->assertStatus(401);
+});
+
+it('denies configuration.integrations.re_generate_secret_key without integrations.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.integrations.re_generate_secret_key'), [])
+        ->assertStatus(401);
+});
+
+/**
+ * Product bulk-edit save routes modify products and must require product edit.
+ */
+it('denies catalog.products.bulk-edit.save without products.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.products.bulk-edit.save'), [])
+        ->assertStatus(401);
+});
+
+it('denies catalog.products.bulk-edit.save-media without products.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.products.bulk-edit.save-media'), [])
+        ->assertStatus(401);
+});
+
+/**
+ * Family completeness settings write routes must require family edit.
+ */
+it('denies catalog.families.completeness.update without families.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.families.completeness.update'), [])
+        ->assertStatus(401);
+});
+
+it('denies catalog.families.completeness.mass_update without families.edit permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.catalog.families.completeness.mass_update'), [])
+        ->assertStatus(401);
+});
+
+/**
+ * Core configuration save must require the configuration permission so a
+ * restricted admin cannot persist global system settings.
+ */
+it('denies configuration.store without configuration permission', function () {
+    $this->loginWithPermissions(permissions: ['dashboard']);
+
+    $this->post(route('admin.configuration.store', ['slug' => 'general', 'slug2' => 'general']), [])
+        ->assertStatus(401);
+});

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -23,7 +23,7 @@ class Core
      *
      * @var string
      */
-    const VERSION = '2.0.1';
+    const VERSION = '2.0.2';
 
     /**
      * Current Channel.

--- a/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
+++ b/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
@@ -31,11 +31,11 @@ test('1.3 - Profile dropdown shows version string in format "Version : vX.X.X"',
   expect(versionText).toMatch(/Version\s*:\s*v\d+\.\d+\.\d+/);
 });
 
-test('1.4 - Version displays v2.0.1', async ({ adminPage }) => {
+test('1.4 - Version displays v2.0.2', async ({ adminPage }) => {
   const profileBtn = adminPage.locator('header').getByRole('button').last();
   await profileBtn.click();
 
-  await expect(adminPage.locator('#app').getByText(/Version\s*:\s*v2\.0\.1/)).toBeVisible();
+  await expect(adminPage.locator('#app').getByText(/Version\s*:\s*v2\.0\.2/)).toBeVisible();
 });
 
 test('1.5 - Profile dropdown shows UnoPim logo icon next to version', async ({ adminPage }) => {


### PR DESCRIPTION
Backport of #467 

The Bouncer middleware only enforces a permission when the route name is
present in the ACL map (`config/acl.php`). Several state-changing routes were
missing from that map, so they were reachable by any authenticated admin
regardless of role.

Adds the missing route -> permission mappings in `acl.php`:

- configuration.integrations store/update/generate_key/re_generate_secret_key
  -> configuration.integrations.create/.edit
- catalog.products.bulk-edit.save/.save-media -> catalog.products.edit
- catalog.products bulkedit/filters/fetch-attributes/check-variant and
  catalog.categories.tree -> catalog.products (read helpers, view level)
- catalog.families.completeness.edit/update/mass_update -> catalog.families.edit
- configuration.store/.download -> configuration

Note: on 2.0 the Bouncer denies with HTTP 401, so the regression-test
assertions use 401 (matching this branch's existing convention); the ACL
config change is identical to the 2.1/master fix.

Verified: Pint pass; Pest 30/30 regression + 29/29 positive; translations 224/224.
Run `php artisan optimize:clear` after deploy (ACL is cached config).
