### PR TITLE
fix(ci): remove empty ${{ }} breaking Docker Publish on 2.1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          # Pick raw tag from env (not inline ${{ }}) to avoid shell injection
+          # Pick raw tag from env (not inline GitHub expressions) to avoid shell injection
           # via a tag name containing shell metacharacters.
           if [ "$EVENT_NAME" = "release" ]; then
             RAW_TAG="$RELEASE_TAG"


### PR DESCRIPTION
## Problem

The `release: published` event has not been dispatching **Docker Publish** since v2.1.0. Every release on the 2.1 line (v2.1.1, **v2.1.2**, v2.0.x, v1.0.1) produced **zero** release-event runs — only an instant 0-second *"workflow file issue"* failure on the tag commit. No Docker image was built/pushed and the demo never updated.

## Root cause

```
# Pick raw tag from env (not inline ${{ }}) to avoid shell injection
```

That literal **`${{ }}`** is an *empty GitHub expression*. GitHub evaluates `${{ }}` everywhere in a workflow (including inside `run:` blocks), hits empty braces, and rejects the file:

> Invalid workflow file: .github/workflows/docker-publish.yml — **"An expression was expected"** (L50)

Invalid file ⇒ startup_failure ⇒ the `release` event can't dispatch the job. Introduced in #426; `master` was already fixed, this backports the fix to the **2.1 default branch**.

## Fix

Reword the comment to plain text. One line, no behavior change.

## Impact

Without this, the upcoming **v2.1.3** release will also silently fail to publish.

## Notes

- v2.1.2's missing Docker image is being backfilled separately via `workflow_dispatch` (builds the existing v2.1.2 tag — no tag/release re-creation).
- Verified: `grep -rn '${{[[:space:]]*}}' .github/workflows/` → clean.