### PR TITLE
Release v2.0.3 — installer & ACL security hardening

### DIFF
--- a/.github/workflows/playwright_test.yml
+++ b/.github/workflows/playwright_test.yml
@@ -112,6 +112,11 @@ jobs:
           sed -i "s|^\(DB_DATABASE=\s*\).*$|\1unopim|" .env
           sed -i "s|^\(DB_USERNAME=\s*\).*$|\1root|" .env
           sed -i "s|^\(DB_PASSWORD=\s*\).*$|\1root|" .env
+          # Pin the seeded admin to deterministic credentials for E2E login.
+          # Production keeps the secure default (random password when these are
+          # unset); the seeder only honours INSTALLER_ADMIN_* when provided.
+          sed -i "s|^\(INSTALLER_ADMIN_EMAIL=\s*\).*$|\1admin@example.com|" .env
+          sed -i "s|^\(INSTALLER_ADMIN_PASSWORD=\s*\).*$|\1admin123|" .env
 
       - name: Running UnoPim Installer & Start Server
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # v2.0.x
 
+## v2.0.3 - 2026-06-04
+
+### Security
+- Sealed the installer once setup completes — the `CanInstall` middleware now blocks every `/install` request after a `storage/installed` marker exists, and defense-in-depth `abortIfInstalled()` guards were added to each state-changing install endpoint (env-file-setup, run-migration, run-seeder, admin-config-setup, seed-sample-data, smtp-config-setup). The completion marker is written only at the very end of the flow, closing a pre-auth admin-takeover vector on already-installed instances ([#459](https://github.com/unopim/unopim/pull/459)).
+- Enforced ACL permission checks on state-changing admin routes that were absent from `acl.php` — including integration management, product bulk-edit, and family-completeness/configuration actions. The `Bouncer` middleware only enforced permissions for mapped routes, so unmapped write routes were reachable by any authenticated admin; restricted users now receive a 403 ([#467](https://github.com/unopim/unopim/pull/467)).
+- Removed the hardcoded default admin credentials from the installer — credentials are now driven by `INSTALLER_ADMIN_EMAIL` / `INSTALLER_ADMIN_PASSWORD`, or a random password is generated and written once to `storage/app/admin-credentials.txt`. Admin and role seeders are now idempotent so operator-rotated passwords survive re-seeding and container restarts, and Docker entrypoints wait for database readiness before seeding ([#457](https://github.com/unopim/unopim/pull/457)).
+
+### Improvements
+- Added a debug-only **`AppUrlGuard`** package — detects when the browser host does not match the configured `APP_URL` (a common cause of broken CSS/JS), shows a guided fix modal, and forces admin logout on a mismatched host. It stays completely inert when `APP_DEBUG=false` and ships translations for 33 locales ([#456](https://github.com/unopim/unopim/pull/456)).
+
 ## v2.0.2 - 2026-05-29
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@
 ### Features
 - Added **PostgreSQL Support** for improved cross-database compatibility. Fixes issue: [#45](https://github.com/unopim/unopim/issues/45)
 - Implemented **System Prompt Management** for configuring AI prompt behavior and max token settings.
-- Added **Custom Prompts** for Magic AI content generation and **Product Values Translation** to translate an attribute value in multiple other languages with Magic AI.  
+- Added **Custom Prompts** for Magic AI content generation and **Product Values Translation** to translate an attribute value in multiple other languages with Magic AI.
 - Introduced **Product Completeness**, providing completeness score and evaluation of product data quality based on completeness settings.
 - Added **Product Bulk Edit** with advanced multi-product editing capabilities for faster workflows.
 - Added **Product Update Webhook**, enabling external systems to react to real-time product updates.
@@ -164,7 +164,7 @@
 
 ### Bug Fixes
 
-- Corrected handling of the `@lang` directive to ensure consistent and secure output rendering on the import job page.  
+- Corrected handling of the `@lang` directive to ensure consistent and secure output rendering on the import job page.
 
 ### Dependency Updates
 - Bump enshrined/svg-sanitize from `0.16.0` to `0.22.0`
@@ -223,33 +223,33 @@
 * Upgraded `laravel/framework` from `10.48.23` to `10.48.29`
 * Updated Finnish translations [#161](https://github.com/unopim/unopim/pull/161)
 * Optimized attribute options grid performance for large datasets
- 
+
 # v0.2.x
- 
+
 ## v0.2.0 - 2025-03-26
-### ✨ **Features**  
-- Added disk parameter to `sanitizeSVG`. [#58](https://github.com/unopim/unopim/pull/58)  
-- Introduced dynamic import job filters. [#80](https://github.com/unopim/unopim/pull/80)  
-- Added in-app and email notifications. [#78](https://github.com/unopim/unopim/pull/78)  
-- New API endpoints for patching and deleting products/categories. [#98](https://github.com/unopim/unopim/pull/98)  
-- Implemented GUI installer for easier setup. [#55](https://github.com/unopim/unopim/pull/55)  
-- Added Magic Image feature. [#100](https://github.com/unopim/unopim/pull/100)  
-- "Powered by" message added to authentication screens. [#110](https://github.com/unopim/unopim/pull/110)  
+### ✨ **Features**
+- Added disk parameter to `sanitizeSVG`. [#58](https://github.com/unopim/unopim/pull/58)
+- Introduced dynamic import job filters. [#80](https://github.com/unopim/unopim/pull/80)
+- Added in-app and email notifications. [#78](https://github.com/unopim/unopim/pull/78)
+- New API endpoints for patching and deleting products/categories. [#98](https://github.com/unopim/unopim/pull/98)
+- Implemented GUI installer for easier setup. [#55](https://github.com/unopim/unopim/pull/55)
+- Added Magic Image feature. [#100](https://github.com/unopim/unopim/pull/100)
+- "Powered by" message added to authentication screens. [#110](https://github.com/unopim/unopim/pull/110)
 
-### 🛠 **Fixes & Enhancements**  
-- Fixed gallery image removal issue. [#90](https://github.com/unopim/unopim/pull/90)  
-- Enabled product status by default. [#89](https://github.com/unopim/unopim/pull/89)  
-- Quick export fix for selected products. [#116](https://github.com/unopim/unopim/pull/116)  
-- Fixed JSON encoding issues with special characters. [#104](https://github.com/unopim/unopim/pull/104)  
-- Prevented HTML entities from showing in flash messages. [#114](https://github.com/unopim/unopim/pull/114)  
-- Improved cumulative filter conditions. [#108](https://github.com/unopim/unopim/pull/108)  
-- Fixed TypeError with filterable dropdown column. [#106](https://github.com/unopim/unopim/pull/106)  
-- Improved CSS styling for GUI installer and image previews. [#73](https://github.com/unopim/unopim/pull/73)  
+### 🛠 **Fixes & Enhancements**
+- Fixed gallery image removal issue. [#90](https://github.com/unopim/unopim/pull/90)
+- Enabled product status by default. [#89](https://github.com/unopim/unopim/pull/89)
+- Quick export fix for selected products. [#116](https://github.com/unopim/unopim/pull/116)
+- Fixed JSON encoding issues with special characters. [#104](https://github.com/unopim/unopim/pull/104)
+- Prevented HTML entities from showing in flash messages. [#114](https://github.com/unopim/unopim/pull/114)
+- Improved cumulative filter conditions. [#108](https://github.com/unopim/unopim/pull/108)
+- Fixed TypeError with filterable dropdown column. [#106](https://github.com/unopim/unopim/pull/106)
+- Improved CSS styling for GUI installer and image previews. [#73](https://github.com/unopim/unopim/pull/73)
 
-### 🔄 **Dependency Updates**  
-- Upgraded `phpoffice/phpspreadsheet` to `1.29.9`. [#101](https://github.com/unopim/unopim/pull/101)  
-- Upgraded `league/commonmark` to `2.6.0`. [#74](https://github.com/unopim/unopim/pull/74)  
-- Upgraded `nesbot/carbon` to `2.72.6`. [#93](https://github.com/unopim/unopim/pull/93)  
+### 🔄 **Dependency Updates**
+- Upgraded `phpoffice/phpspreadsheet` to `1.29.9`. [#101](https://github.com/unopim/unopim/pull/101)
+- Upgraded `league/commonmark` to `2.6.0`. [#74](https://github.com/unopim/unopim/pull/74)
+- Upgraded `nesbot/carbon` to `2.72.6`. [#93](https://github.com/unopim/unopim/pull/93)
 
 
 # v0.1.x
@@ -266,7 +266,7 @@
 **Full Changelog**: [v0.1.4...v0.1.5](https://github.com/unopim/unopim/compare/v0.1.4...v0.1.5)
 
 ## **v0.1.4 (17 October 2024)** - *Release*
-* Security Issue #41: fixed Stored XSS 
+* Security Issue #41: fixed Stored XSS
 
 ## **v0.1.3 (14 October 2024)** - *Release*
 

--- a/packages/Webkul/Attribute/src/Database/Factories/AttributeFactory.php
+++ b/packages/Webkul/Attribute/src/Database/Factories/AttributeFactory.php
@@ -49,7 +49,7 @@ class AttributeFactory extends Factory
         ];
 
         return [
-            'code'              => $this->faker->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
+            'code'              => $this->faker->unique()->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
             'type'              => array_rand($types),
             'validation'        => '',
             'position'          => $this->faker->randomDigit,

--- a/packages/Webkul/Category/src/Database/Factories/CategoryFactory.php
+++ b/packages/Webkul/Category/src/Database/Factories/CategoryFactory.php
@@ -28,7 +28,7 @@ class CategoryFactory extends Factory
     public function definition(): array
     {
         return [
-            'code'            => $this->faker->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
+            'code'            => $this->faker->unique()->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
             'parent_id'       => Category::whereIsRoot()->first()->id,
             'additional_data' => [
                 'locale_specific' => [

--- a/packages/Webkul/Category/src/Database/Factories/CategoryFieldFactory.php
+++ b/packages/Webkul/Category/src/Database/Factories/CategoryFieldFactory.php
@@ -47,7 +47,7 @@ class CategoryFieldFactory extends Factory
 
         return [
             'name'             => $this->faker->word,
-            'code'             => $this->faker->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
+            'code'             => $this->faker->unique()->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
             'type'             => array_rand($types),
             'validation'       => '',
             'position'         => $this->faker->randomDigit,

--- a/packages/Webkul/Category/src/Database/Factories/CategoryFieldOptionFactory.php
+++ b/packages/Webkul/Category/src/Database/Factories/CategoryFieldOptionFactory.php
@@ -20,7 +20,7 @@ class CategoryFieldOptionFactory extends Factory
     public function definition(): array
     {
         return [
-            'code'         => $this->faker->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
+            'code'         => $this->faker->unique()->regexify('/^[a-zA-Z]+[a-zA-Z0-9_]+$/'),
             'sort_order'   => $this->faker->randomDigit(),
         ];
     }

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -23,7 +23,7 @@ class Core
      *
      * @var string
      */
-    const VERSION = '2.0.2';
+    const VERSION = '2.0.3';
 
     /**
      * Current Channel.

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -162,11 +162,11 @@ class Installer extends Command
      */
     protected function markInstalled(): void
     {
-        if (file_exists(storage_path('installed'))) {
+        if (file_exists((config('installer.installed_marker') ?? storage_path('installed')))) {
             return;
         }
 
-        File::put(storage_path('installed'), 'UnoPim installation completed successfully');
+        File::put((config('installer.installed_marker') ?? storage_path('installed')), 'UnoPim installation completed successfully');
 
         Event::dispatch('unopim.installed');
     }
@@ -466,7 +466,7 @@ class Installer extends Command
                 $this->seedSampleProducts();
             }
 
-            $filePath = storage_path('installed');
+            $filePath = (config('installer.installed_marker') ?? storage_path('installed'));
 
             File::put($filePath, 'UnoPim installation completed successfully');
 

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -47,7 +47,7 @@ class InstallerController extends Controller
      */
     protected function abortIfInstalled()
     {
-        abort_if(file_exists(storage_path('installed')), 403);
+        abort_if(file_exists((config('installer.installed_marker') ?? storage_path('installed'))), 403);
     }
 
     /**
@@ -57,11 +57,11 @@ class InstallerController extends Controller
      */
     protected function markInstalled()
     {
-        if (file_exists(storage_path('installed'))) {
+        if (file_exists((config('installer.installed_marker') ?? storage_path('installed')))) {
             return;
         }
 
-        File::put(storage_path('installed'), 'Your UnoPim App is Successfully Installed');
+        File::put((config('installer.installed_marker') ?? storage_path('installed')), 'Your UnoPim App is Successfully Installed');
 
         Event::dispatch('unopim.installed');
     }
@@ -221,7 +221,7 @@ class InstallerController extends Controller
 
         $this->environmentManager->setEnvConfiguration(request()->input());
 
-        $filePath = storage_path('installed');
+        $filePath = (config('installer.installed_marker') ?? storage_path('installed'));
 
         File::put($filePath, 'Your UnoPim App is Successfully Installed');
 

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -38,7 +38,7 @@ class CanInstall
      */
     public function isInstallationCompleted(): bool
     {
-        return file_exists(storage_path('installed'));
+        return file_exists((config('installer.installed_marker') ?? storage_path('installed')));
     }
 
     /**
@@ -48,7 +48,7 @@ class CanInstall
      */
     public function isAlreadyInstalled()
     {
-        if (file_exists(storage_path('installed'))) {
+        if (file_exists((config('installer.installed_marker') ?? storage_path('installed')))) {
             return true;
         }
 

--- a/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
@@ -4,16 +4,16 @@ use Illuminate\Support\Facades\Event;
 use Webkul\Installer\Console\Commands\Installer;
 
 beforeEach(function () {
-    $this->marker = storage_path('installed');
-    $this->markerExisted = file_exists($this->marker);
-    $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
+    $this->marker = tempnam(sys_get_temp_dir(), 'unopim_installed_');
+
+    @unlink($this->marker);
+
+    config(['installer.installed_marker' => $this->marker]);
 });
 
 afterEach(function () {
-    if ($this->markerExisted) {
-        file_put_contents($this->marker, $this->markerContents);
-    } elseif (file_exists($this->marker)) {
-        unlink($this->marker);
+    if (file_exists($this->marker)) {
+        @unlink($this->marker);
     }
 });
 

--- a/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerMarkInstalledTest.php
@@ -6,14 +6,16 @@ use Webkul\Installer\Console\Commands\Installer;
 beforeEach(function () {
     $this->marker = tempnam(sys_get_temp_dir(), 'unopim_installed_');
 
-    @unlink($this->marker);
+    expect($this->marker)->not->toBeFalse();
+
+    unlink($this->marker);
 
     config(['installer.installed_marker' => $this->marker]);
 });
 
 afterEach(function () {
     if (file_exists($this->marker)) {
-        @unlink($this->marker);
+        unlink($this->marker);
     }
 });
 

--- a/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
@@ -10,14 +10,16 @@ beforeEach(function () {
 
     $this->marker = tempnam(sys_get_temp_dir(), 'unopim_installed_');
 
-    @unlink($this->marker);
+    expect($this->marker)->not->toBeFalse();
+
+    unlink($this->marker);
 
     config(['installer.installed_marker' => $this->marker]);
 });
 
 afterEach(function () {
     if (file_exists($this->marker)) {
-        @unlink($this->marker);
+        unlink($this->marker);
     }
 });
 

--- a/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
@@ -8,16 +8,16 @@ beforeEach(function () {
     config(['app.url' => 'http://localhost']);
     URL::forceRootUrl('http://localhost');
 
-    $this->marker = storage_path('installed');
-    $this->markerExisted = file_exists($this->marker);
-    $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
+    $this->marker = tempnam(sys_get_temp_dir(), 'unopim_installed_');
+
+    @unlink($this->marker);
+
+    config(['installer.installed_marker' => $this->marker]);
 });
 
 afterEach(function () {
-    if ($this->markerExisted) {
-        file_put_contents($this->marker, $this->markerContents);
-    } elseif (file_exists($this->marker)) {
-        unlink($this->marker);
+    if (file_exists($this->marker)) {
+        @unlink($this->marker);
     }
 });
 

--- a/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
+++ b/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
@@ -46,7 +46,8 @@ test(`1.4 - Version displays v${EXPECTED_VERSION}`, async ({ adminPage }) => {
   const profileBtn = adminPage.locator('header').getByRole('button').last();
   await profileBtn.click();
 
-  const versionPattern = new RegExp(`Version\\s*:\\s*v${EXPECTED_VERSION.replace(/\./g, '\\.')}`);
+  const escapedVersion = EXPECTED_VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const versionPattern = new RegExp(`Version\\s*:\\s*v${escapedVersion}`);
   await expect(adminPage.locator('#app').getByText(versionPattern)).toBeVisible();
 });
 

--- a/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
+++ b/tests/e2e-pw/tests/03-dashboard/versionCheck.spec.js
@@ -1,4 +1,15 @@
 const { test, expect } = require('../../utils/fixtures');
+const fs = require('fs');
+const path = require('path');
+
+// Read the canonical app version from Webkul\Core::VERSION so this test never
+// goes stale on a release bump (the displayed version is derived from it).
+const EXPECTED_VERSION = (() => {
+  const corePath = path.resolve(__dirname, '../../../../packages/Webkul/Core/src/Core.php');
+  const match = fs.readFileSync(corePath, 'utf8').match(/const\s+VERSION\s*=\s*'([^']+)'/);
+  if (! match) throw new Error(`Could not read Core::VERSION from ${corePath}`);
+  return match[1];
+})();
 
 test.describe('UnoPim Version Check', () => {
 
@@ -31,11 +42,12 @@ test('1.3 - Profile dropdown shows version string in format "Version : vX.X.X"',
   expect(versionText).toMatch(/Version\s*:\s*v\d+\.\d+\.\d+/);
 });
 
-test('1.4 - Version displays v2.0.2', async ({ adminPage }) => {
+test(`1.4 - Version displays v${EXPECTED_VERSION}`, async ({ adminPage }) => {
   const profileBtn = adminPage.locator('header').getByRole('button').last();
   await profileBtn.click();
 
-  await expect(adminPage.locator('#app').getByText(/Version\s*:\s*v2\.0\.2/)).toBeVisible();
+  const versionPattern = new RegExp(`Version\\s*:\\s*v${EXPECTED_VERSION.replace(/\./g, '\\.')}`);
+  await expect(adminPage.locator('#app').getByText(versionPattern)).toBeVisible();
 });
 
 test('1.5 - Profile dropdown shows UnoPim logo icon next to version', async ({ adminPage }) => {


### PR DESCRIPTION
Backports the security hardening from master into the 2.0.x line and cuts v2.0.3.

### Changes
- **Security** — seal installer endpoints after install completes (pre-auth admin-takeover guard) (#459)
- **Security** — enforce ACL permission checks on unmapped state-changing admin routes (integrations, bulk-edit, completeness/config) (#467)
- **Security** — remove hardcoded default admin credentials; idempotent admin/role seeders (#457)
- **Improvements** — debug-only `AppUrlGuard` package detecting `APP_URL` host mismatch (#456)



