### PR TITLE
Fix fail-open API scope bypass on configurable-product routes

### DIFF
--- a/packages/Webkul/AdminApi/src/Config/api-acl.php
+++ b/packages/Webkul/AdminApi/src/Config/api-acl.php
@@ -89,6 +89,34 @@ return [
     [
         'key'   => 'api.catalog.products',
         'name'  => 'admin::app.acl.products',
+        'route' => 'admin.api.configurable_products.index',
+        'sort'  => 1,
+    ], [
+        'key'   => 'api.catalog.products.create',
+        'name'  => 'admin::app.acl.create',
+        'route' => 'admin.api.configurable_products.store',
+        'sort'  => 1,
+    ], [
+        'key'   => 'api.catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.api.configurable_products.update',
+        'sort'  => 2,
+    ], [
+        'key'   => 'api.catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.api.configurable_products.patch',
+        'sort'  => 2,
+    ], [
+        'key'   => 'api.catalog.products.delete',
+        'name'  => 'admin::app.acl.delete',
+        'route' => 'admin.api.configurable_products.delete',
+        'sort'  => 3,
+    ],
+
+    // Legacy "configrable_products" (typo) prefix — kept for backward compatibility.
+    [
+        'key'   => 'api.catalog.products',
+        'name'  => 'admin::app.acl.products',
         'route' => 'admin.api.configrable_products.index',
         'sort'  => 1,
     ], [
@@ -106,6 +134,11 @@ return [
         'name'  => 'admin::app.acl.edit',
         'route' => 'admin.api.configrable_products.patch',
         'sort'  => 2,
+    ], [
+        'key'   => 'api.catalog.products.delete',
+        'name'  => 'admin::app.acl.delete',
+        'route' => 'admin.api.configrable_products.delete',
+        'sort'  => 3,
     ],
 
     // Product media uploads — require edit permission

--- a/packages/Webkul/AdminApi/src/Http/Middleware/ScopeMiddleware.php
+++ b/packages/Webkul/AdminApi/src/Http/Middleware/ScopeMiddleware.php
@@ -15,11 +15,26 @@ class ScopeMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($this->getAclForCurrentRoute() && ! $this->hasPermission($this->getAclForCurrentRoute())) {
+        $acl = $this->getAclForCurrentRoute();
+
+        if ($acl) {
+            if (! $this->hasPermission($acl)) {
+                return response()->json(['error' => 'This action is unauthorized'], 403);
+            }
+        } elseif ($this->isMutatingRequest($request)) {
+
             return response()->json(['error' => 'This action is unauthorized'], 403);
         }
 
         return $next($request);
+    }
+
+    /**
+     * Determine whether the request uses a state-changing HTTP method.
+     */
+    protected function isMutatingRequest(Request $request): bool
+    {
+        return in_array($request->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
     }
 
     /**

--- a/packages/Webkul/AdminApi/tests/Feature/Acl/ConfigurableProductScopeBypassTest.php
+++ b/packages/Webkul/AdminApi/tests/Feature/Acl/ConfigurableProductScopeBypassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Regression coverage for the fail-open API scope bypass.
+ *
+ * The configurable-product mutating routes were registered but absent from
+ * api-acl.php, so ScopeMiddleware short-circuited and allowed them with no
+ * scope. The fix maps every configurable-product route (both the correct
+ * "configurable_products" prefix and the legacy "configrable_products" typo)
+ * and makes ScopeMiddleware fail closed for any unmapped state-changing route.
+ */
+it('maps every mutating API scope route in api-acl so no write route fails open', function () {
+    $roles = app('api-acl')->roles;
+
+    $unmapped = [];
+
+    foreach (Route::getRoutes() as $route) {
+        $name = $route->getName();
+
+        if (! $name || ! str_starts_with($name, 'admin.api.')) {
+            continue;
+        }
+
+        $hasScope = collect($route->gatherMiddleware())
+            ->contains(fn ($m) => str_contains($m, 'ScopeMiddleware') || $m === 'api.scope');
+
+        $isWrite = (bool) array_intersect($route->methods(), ['POST', 'PUT', 'PATCH', 'DELETE']);
+
+        if ($hasScope && $isWrite && ! isset($roles[str_replace('.get', '.index', $name)])) {
+            $unmapped[] = $name;
+        }
+    }
+
+    expect($unmapped)->toBe([]);
+});
+
+dataset('configurable write routes', [
+    'store (correct prefix)'  => ['POST', 'admin.api.configurable_products.store', null],
+    'update (correct prefix)' => ['PUT', 'admin.api.configurable_products.update', 'sku-x'],
+    'patch (correct prefix)'  => ['PATCH', 'admin.api.configurable_products.patch', 'sku-x'],
+    'delete (correct prefix)' => ['DELETE', 'admin.api.configurable_products.delete', 'sku-x'],
+    'delete (legacy typo)'    => ['DELETE', 'admin.api.configrable_products.delete', 'sku-x'],
+    'store (legacy typo)'     => ['POST', 'admin.api.configrable_products.store', null],
+]);
+
+it('forbids configurable-product writes for a key without the product scope', function (string $method, string $routeName, ?string $param) {
+    $headers = $this->getAuthenticationHeaders('custom', ['api.settings.locales']);
+
+    $url = $param ? route($routeName, $param) : route($routeName);
+
+    $this->withHeaders($headers)->json($method, $url)->assertForbidden();
+})->with('configurable write routes');
+
+it('allows a configurable-product write past the scope check when the key holds the product scope', function () {
+    $headers = $this->getAuthenticationHeaders('custom', ['api.catalog.products.create']);
+
+    $response = $this->withHeaders($headers)->json('POST', route('admin.api.configurable_products.store'), []);
+
+    expect($response->getStatusCode())->not->toBe(403);
+});


### PR DESCRIPTION

## Issue Reference
Fixes High finding :  API authorization bypass (fail-open scope), configurable products.

## Description
`ScopeMiddleware` enforced a scope only when the route name was mapped in `api-acl.php`; the configurable-product write routes (`store`/`update`/`patch`/`delete`, both the `configurable_products` and legacy `configrable_products` prefixes) were unmapped, so the check short-circuited and any low-scope API key could create/update/delete configurable products (authorization bypass).

**Changes:**
- `api-acl.php`: map every configurable-product route for both prefixes, incl. the missing `.delete`.
- `ScopeMiddleware`: fail **closed** for POST/PUT/PATCH/DELETE — any unmapped write route now returns 403 (fixes the root cause for all future write routes).
- Add `ConfigurableProductScopeBypassTest` (real OAuth tokens; 403 on all write routes; invariant test that no write route is left unmapped; positive control).

## How To Test This?
- A low-scope key calling `DELETE /api/v1/rest/configurable-products/{sku}` (and store/update/patch) now returns **403** instead of bypassing the scope check.
- `vendor/bin/pest packages/Webkul/AdminApi/tests/Feature/Acl/ConfigurableProductScopeBypassTest.php` → 8 passed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.1

## Pint
- [x] All Pint checks pass.

## Tailwind Reordering
- [x] N/A — no Blade/Tailwind changes.

## Tests
- Pint ✅
- New test: 8 passed ✅
- Existing AdminApi Acl + Catalog suites: 270 passed / 1455 assertions / 0 failures ✅
