### PR TITLE
Fix MagicAI Platform authorization bypass: update & set-default reachable without permission

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php
@@ -3,7 +3,7 @@
 use Webkul\MagicAI\Models\MagicAIPlatform;
 
 /**
- * Regression coverage for the MagicAI platform authorization bypass (audit finding #4).
+ * Regression coverage for the MagicAI platform authorization bypass.
  *
  * `admin.magic_ai.platform.update` (PUT) and `admin.magic_ai.platform.set_default`
  * (POST) were registered but absent from AiAgent/Config/acl.php, so the fail-open

--- a/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Webkul\MagicAI\Models\MagicAIPlatform;
+
+/**
+ * Regression coverage for the MagicAI platform authorization bypass (audit finding #4).
+ *
+ * `admin.magic_ai.platform.update` (PUT) and `admin.magic_ai.platform.set_default`
+ * (POST) were registered but absent from AiAgent/Config/acl.php, so the fail-open
+ * Bouncer middleware skipped the permission check and any authenticated admin could
+ * repoint a platform's api_url/api_key or swap the default. The fix maps both routes
+ * to `ai-agent.platform.edit`.
+ */
+function makeMagicAiPlatform(array $overrides = []): MagicAIPlatform
+{
+    return MagicAIPlatform::create(array_merge([
+        'label'      => 'Primary',
+        'provider'   => 'openai',
+        'api_url'    => 'https://api.openai.com/v1',
+        'models'     => 'gpt-4o',
+        'is_default' => true,
+        'status'     => true,
+    ], $overrides));
+}
+
+describe('MagicAI platform authorization', function () {
+    it('forbids a low-privilege admin from updating a platform', function () {
+        $platform = makeMagicAiPlatform();
+
+        $this->loginWithPermissions('custom', ['dashboard']);
+
+        $this->putJson(route('admin.magic_ai.platform.update', $platform->id), [
+            'label'    => 'x',
+            'provider' => 'openai',
+            'models'   => 'gpt-4o',
+            'api_url'  => 'https://evil.tld',
+            'api_key'  => 'stolen',
+        ])->assertForbidden();
+    });
+
+    it('forbids a low-privilege admin from changing the default platform', function () {
+        makeMagicAiPlatform(['label' => 'A']);
+        $other = makeMagicAiPlatform(['label' => 'B', 'is_default' => false]);
+
+        $this->loginWithPermissions('custom', ['dashboard']);
+
+        $this->postJson(route('admin.magic_ai.platform.set_default', $other->id))
+            ->assertForbidden();
+    });
+
+    it('allows an admin holding the platform-edit permission to update', function () {
+        $platform = makeMagicAiPlatform();
+
+        $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.platform', 'ai-agent.platform.edit']);
+
+        $this->putJson(route('admin.magic_ai.platform.update', $platform->id), [
+            'label'      => 'Updated',
+            'provider'   => 'openai',
+            'models'     => 'gpt-4o',
+            'status'     => true,
+            'is_default' => true,
+        ])->assertOk();
+    });
+});

--- a/packages/Webkul/AiAgent/Config/acl.php
+++ b/packages/Webkul/AiAgent/Config/acl.php
@@ -29,6 +29,16 @@ return [
         'name'   => 'ai-agent::app.acl.delete',
         'route'  => 'admin.magic_ai.platform.delete',
         'sort'   => 3,
+    ], [
+        'key'    => 'ai-agent.platform.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.platform.update',
+        'sort'   => 2,
+    ], [
+        'key'    => 'ai-agent.platform.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.platform.set_default',
+        'sort'   => 2,
     ],
     [
         'key'    => 'ai-agent.general',


### PR DESCRIPTION

## Issue Reference
Fixes High finding  MagicAI Platform authorization bypass.

## Description
The Bouncer middleware enforces a permission only when the current route name exists in the merged `acl.php` map (`User/Http/Middleware/Bouncer.php:96`); unmapped routes fail open. `AiAgent/Config/acl.php` mapped `platform.store/.edit/.delete` but omitted:
- `admin.magic_ai.platform.update` (PUT)
- `admin.magic_ai.platform.set_default` (POST)

`MagicAIPlatformController::update()` / `setDefault()` have no inline guard, so any authenticated admin — even a minimal `dashboard`-only role — could repoint a platform's `api_url`/`api_key` (exfiltrating future AI traffic and the provider key) or swap the default platform.

**Changes:**
- `AiAgent/Config/acl.php`: map `platform.update` and `platform.set_default` to `ai-agent.platform.edit`.
- Add `MagicAIPlatformAclBypassTest`.

## How To Test This?
- A low-privilege admin (e.g. only `dashboard`) calling `PUT /admin/magic-ai/platform/{id}` or `POST /admin/magic-ai/platform/{id}/default` now receives **403**.
- An admin with `ai-agent.platform.edit` can still update / set default.
- `vendor/bin/pest packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php` → 3 passed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.1

## Pint
- [x] All Pint checks pass.

## Tailwind Reordering
- [x] N/A — no Blade/Tailwind changes.

## Tests
- Pint ✅
- New test: 3 passed ✅
- Existing MagicAI suites: 112 passed / 0 failures ✅
- Translations: 256/256 (no new key introduced) ✅
