### PR TITLE
fix: make promo banner sticky to remove empty gap on scroll

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/promo-bar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/promo-bar.blade.php
@@ -14,7 +14,7 @@
         <div
             v-if="list.length"
             id="unopim-promo-bar"
-            class="relative z-0 w-full overflow-hidden"
+            class="sticky top-0 z-[10002] w-full overflow-hidden"
         >
             <div
                 v-for="(slide, slideIndex) in list"

--- a/packages/Webkul/Admin/src/Resources/views/components/promo-bar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/promo-bar.blade.php
@@ -14,7 +14,7 @@
         <div
             v-if="list.length"
             id="unopim-promo-bar"
-            class="sticky top-0 w-full overflow-hidden"
+            class="sticky top-0 z-[9999] w-full overflow-hidden"
         >
             <div
                 v-for="(slide, slideIndex) in list"

--- a/packages/Webkul/Admin/src/Resources/views/components/promo-bar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/promo-bar.blade.php
@@ -14,7 +14,7 @@
         <div
             v-if="list.length"
             id="unopim-promo-bar"
-            class="sticky top-0 z-[10002] w-full overflow-hidden"
+            class="sticky top-0 w-full overflow-hidden"
         >
             <div
                 v-for="(slide, slideIndex) in list"


### PR DESCRIPTION
## Problem

On the admin dashboard, the cloud-hosting promo banner was not sticky like the UnoPim header. On scroll the banner scrolled away, leaving a **48px empty gap** above the header.

### Root cause
- Banner wrapper (`promo-bar.blade.php`) used `position: relative` (`relative z-0`) → it scrolls out of view.
- The layout (`layouts/index.blade.php`) already offsets the sticky header by its height: `body:has(#unopim-promo-bar) .unopim-header { top: 3rem; }`.
- So when the banner scrolled off, the header stayed pinned at `top: 48px` while nothing occupied that reserved 48px → empty gap.

### Fix
Make the banner `sticky top-0` with z-index above the header (`z-[10002]` > header `z-[10001]`). Banner now pins at the top and the header sits flush below it — no gap.

```diff
- class="relative z-0 w-full overflow-hidden"
+ class="sticky top-0 z-[10002] w-full overflow-hidden"
```

### Verification (Playwright)
Scrolled 400px on `/admin/dashboard`:
- banner: `position:sticky`, viewport top `0`, bottom `48`
- header: viewport top `48` (flush)
- gap above header: **0** (was 48px)