### PR TITLE
[Security] Fix ORDER BY SQL injection via sort order in Product DataGrid 

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -523,7 +523,7 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
     public function processRequestedSorting($requestedSort)
     {
         $sortColumn = $requestedSort['column'] ?? $this->sortColumn ?? $this->primaryColumn;
-        $sortOrder = $requestedSort['order'] ?? $this->sortOrder;
+        $sortOrder = strtolower($requestedSort['order'] ?? $this->sortOrder) === 'asc' ? 'asc' : 'desc';
 
         if ($attributePath = $this->getAttributePathForSort($sortColumn)) {
             $attribute = $this->attributeService->findAttributeByCode($sortColumn) ?? 'text';
@@ -663,9 +663,11 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
 
         $sort = $sortMapping[$sort] ?? $this->getAttributePathForSort($sort, 'elasticsearch');
 
+        $sortOrder = strtolower($params['order'] ?? $this->sortOrder) === 'asc' ? 'asc' : 'desc';
+
         ElasticSearchQuery::orderBy([
             $sort => [
-                'order'         => $params['order'] ?? $this->sortOrder,
+                'order'         => $sortOrder,
                 'missing'       => '_last',
                 'unmapped_type' => 'keyword',
             ],

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\Admin\DataGrids\Catalog\ProductDataGrid;
+
+/**
+ * Regression coverage for the ORDER BY SQL injection in the product grid.
+ *
+ * `processRequestedSorting()` concatenated the request-supplied sort direction straight
+ * into orderByRaw(). The fix allowlists the direction to asc/desc, so a malicious
+ * `sort[order]` can never inject SQL into the ORDER BY clause.
+ */
+function sortedProductSql(array $sort): string
+{
+    $grid = app(ProductDataGrid::class);
+
+    $queryBuilder = new ReflectionProperty($grid, 'queryBuilder');
+    $queryBuilder->setAccessible(true);
+    $queryBuilder->setValue($grid, DB::table('products'));
+
+    return $grid->processRequestedSorting($sort)->toSql();
+}
+
+it('does not let a malicious sort order inject SQL into the ORDER BY clause', function () {
+    $payload = 'asc,(SELECT CASE WHEN (1=1) THEN name ELSE id END FROM admins LIMIT 1)';
+
+    $sql = sortedProductSql(['column' => 'name', 'order' => $payload]);
+
+    expect($sql)->not->toContain('SELECT CASE WHEN');
+    expect($sql)->not->toContain('admins');
+    expect(strtolower($sql))->toContain('desc');
+});
+
+it('preserves a valid ascending sort', function () {
+    $sql = strtolower(sortedProductSql(['column' => 'name', 'order' => 'asc']));
+
+    expect($sql)->toContain('asc');
+    expect($sql)->not->toContain('select case when');
+});
+
+it('preserves a valid descending sort', function () {
+    $sql = strtolower(sortedProductSql(['column' => 'name', 'order' => 'desc']));
+
+    expect($sql)->toContain('desc');
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php
@@ -3,13 +3,6 @@
 use Illuminate\Support\Facades\DB;
 use Webkul\Admin\DataGrids\Catalog\ProductDataGrid;
 
-/**
- * Regression coverage for the ORDER BY SQL injection in the product grid.
- *
- * `processRequestedSorting()` concatenated the request-supplied sort direction straight
- * into orderByRaw(). The fix allowlists the direction to asc/desc, so a malicious
- * `sort[order]` can never inject SQL into the ORDER BY clause.
- */
 function sortedProductSql(array $sort): string
 {
     $grid = app(ProductDataGrid::class);

--- a/tests/e2e-pw/tests/08-security/product-sort-injection.spec.js
+++ b/tests/e2e-pw/tests/08-security/product-sort-injection.spec.js
@@ -1,11 +1,5 @@
 const { test, expect } = require('../../utils/fixtures');
 
-/**
- * Security regression (audit finding #5): ORDER BY SQL injection via sort[order]
- * in the Product DataGrid. After the fix, a malicious sort direction is coerced to
- * a safe keyword, so the grid endpoint answers 200 with valid JSON (no 500 SQL
- * error, no injection).
- */
 test.describe('Product grid sort - SQL injection hardening', () => {
   const gridRequest = (adminPage, order) =>
     adminPage.request.get(

--- a/tests/e2e-pw/tests/08-security/product-sort-injection.spec.js
+++ b/tests/e2e-pw/tests/08-security/product-sort-injection.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('../../utils/fixtures');
+
+/**
+ * Security regression (audit finding #5): ORDER BY SQL injection via sort[order]
+ * in the Product DataGrid. After the fix, a malicious sort direction is coerced to
+ * a safe keyword, so the grid endpoint answers 200 with valid JSON (no 500 SQL
+ * error, no injection).
+ */
+test.describe('Product grid sort - SQL injection hardening', () => {
+  const gridRequest = (adminPage, order) =>
+    adminPage.request.get(
+      `/admin/catalog/products?sort[column]=name&sort[order]=${encodeURIComponent(order)}`,
+      { headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' } },
+    );
+
+  test('malicious sort[order] is handled safely (no SQL error)', async ({ adminPage }) => {
+    const payload = 'asc,(SELECT CASE WHEN (1=1) THEN name ELSE id END FROM admins LIMIT 1)';
+
+    const res = await gridRequest(adminPage, payload);
+
+    expect(res.status(), 'grid must not 500 on a malicious sort order').toBe(200);
+    expect(await res.json()).toHaveProperty('records');
+  });
+
+  test('a normal ascending sort still works', async ({ adminPage }) => {
+    const res = await gridRequest(adminPage, 'asc');
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toHaveProperty('records');
+  });
+});

--- a/tests/e2e-pw/utils/login.js
+++ b/tests/e2e-pw/utils/login.js
@@ -4,9 +4,15 @@ export async function login(page) {
   const baseURL = process.env.BASE_URL || 'http://127.0.0.1:8000';
   const email = process.env.ADMIN_USERNAME || process.env.ADMIN_EMAIL || 'admin@example.com';
   const password = process.env.ADMIN_PASSWORD || 'admin123';
-  await page.goto(`${baseURL}/admin/login`);
-  await page.getByRole('textbox', { name: 'Email Address' }).fill(email);
-  await page.getByRole('textbox', { name: 'Password' }).fill(password);
-  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  const html = await (await page.request.get(`${baseURL}/admin/login`)).text();
+  const match = html.match(/name="_token"\s+value="([^"]+)"/);
+  const token = match ? match[1] : '';
+
+  await page.request.post(`${baseURL}/admin/login`, {
+    form: { _token: token, email, password },
+  });
+
+  await page.goto(`${baseURL}/admin/dashboard`);
   await page.waitForLoadState('networkidle');
 }


### PR DESCRIPTION
## Issue Reference
Fixes High finding  SQL injection (ORDER BY) in the Product DataGrid.

## Description
`ProductDataGrid::processRequestedSorting()` concatenated the request-supplied
sort direction (`sort[order]`) directly into a raw SQL string via `orderByRaw()`,
and the base DataGrid only validated that `sort` is an array — there was no
allowlist restricting the direction to `asc`/`desc`. As a result an attacker could
inject arbitrary SQL into the ORDER BY clause and perform blind/error-based data
exfiltration (e.g. from the admins table). The raw branch runs whenever
`sort[column]` is a valid attribute code, and is the active path when Elasticsearch
is unavailable (DB fallback).

**Changes:**
- `ProductDataGrid::processRequestedSorting()` and `setElasticSort()`: coerce the
  sort direction to a strict `asc`/`desc` allowlist before it is used.
- Add `ProductDataGridSortInjectionTest` (Pest) and
  `tests/08-security/product-sort-injection.spec.js` (Playwright, live app).
- Harden `tests/e2e-pw/utils/login.js` to authenticate over HTTP so global-setup
  produces a valid storageState (the DOM login failed silently in headless runs).

## How To Test This?
- Request the grid with a malicious order, e.g.
  `/admin/catalog/products?sort[column]=name&sort[order]=asc,(SELECT CASE WHEN (1=1) THEN name ELSE id END FROM admins LIMIT 1)`
  → the direction is coerced to a safe keyword; the response is 200 with valid JSON
  (no SQL error, no injection). Normal `asc`/`desc` still works.
- `vendor/bin/pest packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php` → 3 passed.
- `npx playwright test tests/08-security/product-sort-injection.spec.js` → 2 passed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.1

## Pint
- [x] All Pint checks pass.

## Tailwind Reordering
- [x] N/A — no Blade/Tailwind changes.

## Tests
- Pint ✅
- New Pest test: 3 passed ✅
- New Playwright spec: 2 passed ✅
- Existing Product + Catalog suites: 325 passed / 0 failures ✅
- Translations: 256/256 (no new key) ✅
