### PR TITLE
Fix stored XSS via channel name breaking out of HTML attribute (family completeness)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/families/completeness/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/families/completeness/index.blade.php
@@ -118,7 +118,7 @@
                                         type="multiselect"
                                         :ref="'channel_requirements_multiselect_' + record.id"
                                         name="channel_requirements"
-                                        options='{!! $allChannels !!}'
+                                        options="{{ $allChannels }}"
                                         :value="record.channel_required
                                             ? record.channel_required.split(',').map(channel => channel.trim())
                                             : []"

--- a/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
@@ -7,11 +7,14 @@ it('escapes a malicious channel name on the family completeness page', function 
     $this->loginAsAdmin();
 
     $channel = Channel::first();
-    $locale = $channel->translations->first()->locale ?? 'en_US';
 
     $payload = "'><img src=x onerror=alert(document.domain)>";
-    $channel->translate($locale)->name = $payload;
-    $channel->translate($locale)->save();
+
+    // Set the payload for every locale so it renders regardless of the admin's UI locale.
+    foreach ($channel->translations as $translation) {
+        $translation->name = $payload;
+        $translation->save();
+    }
 
     $family = AttributeFamily::first();
 

--- a/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
@@ -10,7 +10,6 @@ it('escapes a malicious channel name on the family completeness page', function 
 
     $payload = "'><img src=x onerror=alert(document.domain)>";
 
-    // Set the payload for every locale so it renders regardless of the admin's UI locale.
     foreach ($channel->translations as $translation) {
         $translation->name = $payload;
         $translation->save();

--- a/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Webkul\Attribute\Models\AttributeFamily;
+use Webkul\Core\Models\Channel;
+
+it('escapes a malicious channel name on the family completeness page', function () {
+    $this->loginAsAdmin();
+
+    $channel = Channel::first();
+    $locale = $channel->translations->first()->locale ?? 'en_US';
+
+    $payload = "'><img src=x onerror=alert(document.domain)>";
+    $channel->translate($locale)->name = $payload;
+    $channel->translate($locale)->save();
+
+    $family = AttributeFamily::first();
+
+    $response = $this->get(route('admin.catalog.families.edit', ['id' => $family->id, 'completeness' => 1]));
+
+    $response->assertOk();
+
+    $response->assertDontSee("'><img src=x onerror", false);
+    $response->assertDontSee('onerror=alert(document.domain)>', false);
+
+    $response->assertSee('&#039;&gt;&lt;img', false);
+});


### PR DESCRIPTION

## Issue Reference
Fixes High finding  stored XSS (HTML-attribute breakout) on the Attribute Family completeness tab.

## Description
On the family **Completeness** tab the channel list was emitted raw into a single-quoted HTML attribute:

```blade
options='{!! $allChannels !!}'
```

`$allChannels` comes from `getChannelAsOptions()->toJson()` (default `json_encode`, which does not escape `'`, `<`, `>`), and a channel `name` is validated only as `nullable`. So a channel name like `'><img src=x onerror=alert(document.domain)>` breaks out of the `options='...'` attribute and injects HTML — executing in the authenticated session of any admin who opens Catalog → Families → edit → Completeness (stored XSS).

**Change:**
- Escape the output with `{{ $allChannels }}` (Laravel `e()` / `htmlspecialchars` with `ENT_QUOTES`), so `'` `<` `>` `"` become HTML entities and the value can no longer break out of the attribute. The browser decodes the entities when reading the attribute, so `v-multiselect-handler` still receives valid JSON for legitimate names (no functional change).
- Add `FamilyCompletenessChannelXssTest`.

## How To Test This?
- Set a channel name (any locale) to `'><img src=x onerror=alert(document.domain)>`, then open
  `/admin/catalog/families/edit/{id}?completeness`.
- Before: the payload breaks out of `options='...'` and the `<img onerror>` executes.
- After: the value renders HTML-escaped (`&#039;&gt;&lt;img...`) — inert text, no execution.
- `vendor/bin/pest packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php` → 1 passed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.1

## Pint
- [x] All Pint checks pass.

## Tailwind Reordering
- [x] N/A — single attribute output change, no class reordering.

## Tests
- Pint ✅
- New test: 1 passed (4 assertions) ✅
- Translations: 256/256 (no new key) ✅
