### PR TITLE
Fix authorization bypass on MagicAI prompt/system-prompt and AiAgent generate routes [2.1]

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php
@@ -1,10 +1,7 @@
 <?php
 
-use Webkul\Admin\Models\User;
-
 it('should restrict generate process route when user lacks permission', function () {
-    $this->loginWithPermissions('custom', ['dashboard']); // User without 'ai-agent.generate'
-
+    $this->loginWithPermissions('custom', ['dashboard']);
     $response = $this->postJson(route('ai-agent.generate.process'), [
         'images'        => ['image.jpg'],
         'credential_id' => 1,
@@ -23,6 +20,7 @@ it('should allow generate process route when user has permission', function () {
         'instruction'   => 'Test',
     ]);
 
-    // We expect a validation error or something other than 403, meaning ACL passed
-    expect($response->status())->not->toBe(403);
+    // ACL passes (not 403); the request is then rejected by form validation (422),
+    // so the AI image-to-product service is never invoked (no side effects).
+    $response->assertStatus(422);
 });

--- a/packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Webkul\Admin\Models\User;
+
+it('should restrict generate process route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard']); // User without 'ai-agent.generate'
+
+    $response = $this->postJson(route('ai-agent.generate.process'), [
+        'images'        => ['image.jpg'],
+        'credential_id' => 1,
+        'instruction'   => 'Test',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow generate process route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.generate']);
+
+    $response = $this->postJson(route('ai-agent.generate.process'), [
+        'images'        => ['image.jpg'],
+        'credential_id' => 1,
+        'instruction'   => 'Test',
+    ]);
+
+    // We expect a validation error or something other than 403, meaning ACL passed
+    expect($response->status())->not->toBe(403);
+});

--- a/packages/Webkul/Admin/tests/Feature/Acl/MagicAi/MagicAiPromptAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/MagicAi/MagicAiPromptAclTest.php
@@ -66,3 +66,107 @@ it('should show edit and delete actions in system prompt datagrid when user has 
     expect($icons)->toContain('icon-edit');
     expect($icons)->toContain('icon-delete');
 });
+
+it('should restrict system prompt store route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt']);
+
+    $response = $this->postJson(route('admin.magic_ai.system_prompt.store'), [
+        'title'       => 'Test Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow system prompt store route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt', 'ai-agent.system-prompt.edit']);
+
+    $response = $this->postJson(route('admin.magic_ai.system_prompt.store'), [
+        'title'       => 'Test Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});
+
+it('should restrict system prompt update route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt']);
+
+    $response = $this->putJson(route('admin.magic_ai.system_prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow system prompt update route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt', 'ai-agent.system-prompt.edit']);
+
+    $response = $this->putJson(route('admin.magic_ai.system_prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});
+
+it('should restrict prompt store route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt']);
+
+    $response = $this->postJson(route('admin.magic_ai.prompt.store'), [
+        'title'       => 'Test Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow prompt store route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt', 'ai-agent.prompt.edit']);
+
+    $response = $this->postJson(route('admin.magic_ai.prompt.store'), [
+        'title'       => 'Test Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});
+
+it('should restrict prompt update route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt']);
+
+    $response = $this->putJson(route('admin.magic_ai.prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow prompt update route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt', 'ai-agent.prompt.edit']);
+
+    $response = $this->putJson(route('admin.magic_ai.prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});

--- a/packages/Webkul/AiAgent/Config/acl.php
+++ b/packages/Webkul/AiAgent/Config/acl.php
@@ -114,6 +114,12 @@ return [
         'sort'  => 5,
     ],
     [
+        'key'   => 'ai-agent.generate',
+        'name'  => 'ai-agent::app.acl.generate',
+        'route' => 'ai-agent.generate.process',
+        'sort'  => 5,
+    ],
+    [
         'key'   => 'ai-agent.execute',
         'name'  => 'ai-agent::app.acl.execute',
         'route' => 'ai-agent.execute',

--- a/packages/Webkul/AiAgent/Config/acl.php
+++ b/packages/Webkul/AiAgent/Config/acl.php
@@ -59,6 +59,18 @@ return [
         'sort'   => 1,
     ],
     [
+        'key'    => 'ai-agent.prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.prompt.store',
+        'sort'   => 1,
+    ],
+    [
+        'key'    => 'ai-agent.prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.prompt.update',
+        'sort'   => 1,
+    ],
+    [
         'key'    => 'ai-agent.prompt.delete',
         'name'   => 'ai-agent::app.acl.delete',
         'route'  => 'admin.magic_ai.prompt.delete',
@@ -74,6 +86,18 @@ return [
         'key'    => 'ai-agent.system-prompt.edit',
         'name'   => 'ai-agent::app.acl.edit',
         'route'  => 'admin.magic_ai.system_prompt.edit',
+        'sort'   => 1,
+    ],
+    [
+        'key'    => 'ai-agent.system-prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.system_prompt.store',
+        'sort'   => 1,
+    ],
+    [
+        'key'    => 'ai-agent.system-prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.system_prompt.update',
         'sort'   => 1,
     ],
     [

--- a/packages/Webkul/AiAgent/src/Http/Controllers/GenerateController.php
+++ b/packages/Webkul/AiAgent/src/Http/Controllers/GenerateController.php
@@ -14,15 +14,7 @@ class GenerateController extends Controller
     public function __construct(
         protected CredentialRepository $credentialRepository,
         protected ImageToProductService $imageToProductService,
-    ) {
-        $this->middleware(function ($request, $next) {
-            if (! bouncer()->hasPermission('ai-agent.generate')) {
-                abort(403, trans('ai-agent::app.common.unauthorized'));
-            }
-
-            return $next($request);
-        });
-    }
+    ) {}
 
     /**
      * Show the Generate page.

--- a/packages/Webkul/AiAgent/src/Http/Controllers/GenerateController.php
+++ b/packages/Webkul/AiAgent/src/Http/Controllers/GenerateController.php
@@ -14,7 +14,15 @@ class GenerateController extends Controller
     public function __construct(
         protected CredentialRepository $credentialRepository,
         protected ImageToProductService $imageToProductService,
-    ) {}
+    ) {
+        $this->middleware(function ($request, $next) {
+            if (! bouncer()->hasPermission('ai-agent.generate')) {
+                abort(403, trans('ai-agent::app.common.unauthorized'));
+            }
+
+            return $next($request);
+        });
+    }
 
     /**
      * Show the Generate page.


### PR DESCRIPTION
## Issue Reference
Fixes Medium findings authorization bypass on MagicAI / AiAgent routes.

## Description
The fail-open Bouncer middleware only enforces a permission when a route name exists in
`acl.php`, and some state-changing routes were unmapped with no inline guard, so any
authenticated admin could reach them:

- `admin.magic_ai.system_prompt.store` / `.update` — absent from ACL (could replace
  the active system prompt governing all Magic AI generations).
- `admin.magic_ai.prompt.store` / `.update` — absent from ACL (could create/modify
  reusable AI prompts).
- `ai-agent.generate.process` — not ACL-mapped and the controller had no inline
  check (could invoke product generation, creating products / burning AI credits).

**Changes:**
- `AiAgent/Config/acl.php`: map `prompt.store`/`.update` → `ai-agent.prompt.edit` and
  `system_prompt.store`/`.update` → `ai-agent.system-prompt.edit`.
- `GenerateController`: add a constructor middleware enforcing `ai-agent.generate` on all
  actions (returns 403 otherwise).
- Add `MagicAiPromptAclTest` and `AiAgent/GenerateAclTest`.

## How To Test This?
- A low-privilege admin (without the relevant `ai-agent.*` permission) calling
  `POST/PUT` on the prompt / system-prompt routes, or `POST` on the generate route,
  now receives **403**; an admin holding the permission succeeds.
- `vendor/bin/pest packages/Webkul/Admin/tests/Feature/Acl/MagicAi/MagicAiPromptAclTest.php packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php` → 14 passed.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.1

## Pint
- [x] All Pint checks pass.

## Tailwind Reordering
- [x] N/A — no Blade/Tailwind changes.

## Tests
- Pint ✅
- New ACL tests: 14 passed (22 assertions) ✅
- Regression (AiAgent + MagicAI suites): 201 passed / 0 failures ✅
- Translations: 256/256 (no new key) ✅
