### PR TITLE
Port 2.1 validation & permission-enforcement improvements to master

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -523,7 +523,7 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
     public function processRequestedSorting($requestedSort)
     {
         $sortColumn = $requestedSort['column'] ?? $this->sortColumn ?? $this->primaryColumn;
-        $sortOrder = $requestedSort['order'] ?? $this->sortOrder;
+        $sortOrder = strtolower($requestedSort['order'] ?? $this->sortOrder) === 'asc' ? 'asc' : 'desc';
 
         if ($attributePath = $this->getAttributePathForSort($sortColumn)) {
             $attribute = $this->attributeService->findAttributeByCode($sortColumn) ?? 'text';
@@ -663,9 +663,11 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
 
         $sort = $sortMapping[$sort] ?? $this->getAttributePathForSort($sort, 'elasticsearch');
 
+        $sortOrder = strtolower($params['order'] ?? $this->sortOrder) === 'asc' ? 'asc' : 'desc';
+
         ElasticSearchQuery::orderBy([
             $sort => [
-                'order'         => $params['order'] ?? $this->sortOrder,
+                'order'         => $sortOrder,
                 'missing'       => '_last',
                 'unmapped_type' => 'keyword',
             ],

--- a/packages/Webkul/Admin/src/Http/Controllers/TinyMCEController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/TinyMCEController.php
@@ -4,6 +4,8 @@ namespace Webkul\Admin\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Webkul\Admin\Http\Requests\TinyMCEUploadRequest;
 use Webkul\Core\Filesystem\FileStorer;
 
 class TinyMCEController extends Controller
@@ -23,9 +25,9 @@ class TinyMCEController extends Controller
     /**
      * Upload file from tinymce.
      */
-    public function upload(): JsonResponse
+    public function upload(TinyMCEUploadRequest $request): JsonResponse
     {
-        $media = $this->storeMedia();
+        $media = $this->storeMedia($request);
 
         if (! empty($media)) {
             return response()->json([
@@ -38,18 +40,22 @@ class TinyMCEController extends Controller
 
     /**
      * Store media.
+     *
+     * The file type is validated to an image allowlist by the request, and the
+     * stored name is randomised (never the client-supplied name/extension) so an
+     * executable or HTML extension can never be written to the public path.
      */
-    public function storeMedia(): array
+    public function storeMedia(TinyMCEUploadRequest $request): array
     {
-        if (! request()->hasFile('file')) {
-            return [];
-        }
+        $file = $request->file('file');
 
-        $path = $this->fileStorer->store(file: request()->file('file'), path: $this->storagePath);
+        $name = Str::random(40).'.'.($file->guessExtension() ?: $file->getClientOriginalExtension());
+
+        $path = $this->fileStorer->storeAs($this->storagePath, $name, $file);
 
         return [
             'file'      => $path,
-            'file_name' => request()->file('file')->getClientOriginalName(),
+            'file_name' => $name,
             'file_url'  => Storage::url($path),
         ];
     }

--- a/packages/Webkul/Admin/src/Http/Requests/AttributeOptionForm.php
+++ b/packages/Webkul/Admin/src/Http/Requests/AttributeOptionForm.php
@@ -5,6 +5,7 @@ namespace Webkul\Admin\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Webkul\Core\Rules\Code;
+use Webkul\Core\Rules\FileOrImageValidValue;
 
 class AttributeOptionForm extends FormRequest
 {
@@ -15,7 +16,7 @@ class AttributeOptionForm extends FormRequest
     {
         $attributeId = $this->route('attribute_id');
 
-        return [
+        $rules = [
             'code' => [
                 'required',
                 Rule::unique('attribute_options', 'code')->where(function ($query) use ($attributeId) {
@@ -25,5 +26,11 @@ class AttributeOptionForm extends FormRequest
             ],
             'locales.*.label' => 'nullable|string',
         ];
+
+        if ($this->hasFile('swatch_value')) {
+            $rules['swatch_value'] = [new FileOrImageValidValue(isImage: true)];
+        }
+
+        return $rules;
     }
 }

--- a/packages/Webkul/Admin/src/Http/Requests/TinyMCEUploadRequest.php
+++ b/packages/Webkul/Admin/src/Http/Requests/TinyMCEUploadRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Webkul\Admin\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Webkul\Core\Rules\FileMimeExtensionMatch;
+
+class TinyMCEUploadRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * The TinyMCE rich-text editor only ever uploads raster images, so the
+     * accepted set is restricted to a real-extension allowlist. SVG and HTML
+     * are intentionally excluded (they can carry script), and
+     * FileMimeExtensionMatch rejects files whose real MIME does not match the
+     * claimed extension, blocking content-type spoofing.
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => [
+                'required',
+                'image',
+                'mimes:jpeg,png,jpg,gif,webp',
+                'max:5120',
+                new FileMimeExtensionMatch,
+            ],
+        ];
+    }
+}

--- a/packages/Webkul/Admin/src/Resources/views/catalog/families/completeness/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/families/completeness/index.blade.php
@@ -118,7 +118,7 @@
                                         type="multiselect"
                                         :ref="'channel_requirements_multiselect_' + record.id"
                                         name="channel_requirements"
-                                        options='{!! $allChannels !!}'
+                                        options="{{ $allChannels }}"
                                         :value="record.channel_required
                                             ? record.channel_required.split(',').map(channel => channel.trim())
                                             : []"

--- a/packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/AiAgent/GenerateAclTest.php
@@ -1,0 +1,26 @@
+<?php
+
+it('should restrict generate process route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard']);
+    $response = $this->postJson(route('ai-agent.generate.process'), [
+        'images'        => ['image.jpg'],
+        'credential_id' => 1,
+        'instruction'   => 'Test',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow generate process route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.generate']);
+
+    $response = $this->postJson(route('ai-agent.generate.process'), [
+        'images'        => ['image.jpg'],
+        'credential_id' => 1,
+        'instruction'   => 'Test',
+    ]);
+
+    // ACL passes (not 403); the request is then rejected by form validation (422),
+    // so the AI image-to-product service is never invoked (no side effects).
+    $response->assertStatus(422);
+});

--- a/packages/Webkul/Admin/tests/Feature/Acl/MagicAi/MagicAiPromptAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/MagicAi/MagicAiPromptAclTest.php
@@ -66,3 +66,107 @@ it('should show edit and delete actions in system prompt datagrid when user has 
     expect($icons)->toContain('icon-edit');
     expect($icons)->toContain('icon-delete');
 });
+
+it('should restrict system prompt store route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt']);
+
+    $response = $this->postJson(route('admin.magic_ai.system_prompt.store'), [
+        'title'       => 'Test Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow system prompt store route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt', 'ai-agent.system-prompt.edit']);
+
+    $response = $this->postJson(route('admin.magic_ai.system_prompt.store'), [
+        'title'       => 'Test Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});
+
+it('should restrict system prompt update route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt']);
+
+    $response = $this->putJson(route('admin.magic_ai.system_prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow system prompt update route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.system-prompt', 'ai-agent.system-prompt.edit']);
+
+    $response = $this->putJson(route('admin.magic_ai.system_prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'tone'        => 'professional',
+        'is_enabled'  => 1,
+        'max_tokens'  => 1000,
+        'temperature' => 1.0,
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});
+
+it('should restrict prompt store route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt']);
+
+    $response = $this->postJson(route('admin.magic_ai.prompt.store'), [
+        'title'       => 'Test Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow prompt store route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt', 'ai-agent.prompt.edit']);
+
+    $response = $this->postJson(route('admin.magic_ai.prompt.store'), [
+        'title'       => 'Test Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});
+
+it('should restrict prompt update route when user lacks permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt']);
+
+    $response = $this->putJson(route('admin.magic_ai.prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+it('should allow prompt update route when user has permission', function () {
+    $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.prompt', 'ai-agent.prompt.edit']);
+
+    $response = $this->putJson(route('admin.magic_ai.prompt.update'), [
+        'id'          => 1,
+        'title'       => 'Updated Prompt',
+        'prompt'      => 'Test Prompt text',
+    ]);
+
+    expect($response->status())->not->toBe(403);
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/FamilyCompletenessChannelXssTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Webkul\Attribute\Models\AttributeFamily;
+use Webkul\Core\Models\Channel;
+
+it('escapes a malicious channel name on the family completeness page', function () {
+    $this->loginAsAdmin();
+
+    $channel = Channel::first();
+
+    $payload = "'><img src=x onerror=alert(document.domain)>";
+
+    foreach ($channel->translations as $translation) {
+        $translation->name = $payload;
+        $translation->save();
+    }
+
+    $family = AttributeFamily::first();
+
+    $response = $this->get(route('admin.catalog.families.edit', ['id' => $family->id, 'completeness' => 1]));
+
+    $response->assertOk();
+
+    $response->assertDontSee("'><img src=x onerror", false);
+    $response->assertDontSee('onerror=alert(document.domain)>', false);
+
+    $response->assertSee('&#039;&gt;&lt;img', false);
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSortInjectionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\Admin\DataGrids\Catalog\ProductDataGrid;
+
+function sortedProductSql(array $sort): string
+{
+    $grid = app(ProductDataGrid::class);
+
+    $queryBuilder = new ReflectionProperty($grid, 'queryBuilder');
+    $queryBuilder->setAccessible(true);
+    $queryBuilder->setValue($grid, DB::table('products'));
+
+    return $grid->processRequestedSorting($sort)->toSql();
+}
+
+it('does not let a malicious sort order inject SQL into the ORDER BY clause', function () {
+    $payload = 'asc,(SELECT CASE WHEN (1=1) THEN name ELSE id END FROM admins LIMIT 1)';
+
+    $sql = sortedProductSql(['column' => 'name', 'order' => $payload]);
+
+    expect($sql)->not->toContain('SELECT CASE WHEN');
+    expect($sql)->not->toContain('admins');
+    expect(strtolower($sql))->toContain('desc');
+});
+
+it('preserves a valid ascending sort', function () {
+    $sql = strtolower(sortedProductSql(['column' => 'name', 'order' => 'asc']));
+
+    expect($sql)->toContain('asc');
+    expect($sql)->not->toContain('select case when');
+});
+
+it('preserves a valid descending sort', function () {
+    $sql = strtolower(sortedProductSql(['column' => 'name', 'order' => 'desc']));
+
+    expect($sql)->toContain('desc');
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/SwatchUploadSanitizerTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/SwatchUploadSanitizerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeOption;
+use Webkul\Attribute\Repositories\AttributeOptionRepository;
+
+beforeEach(fn () => $this->loginAsAdmin());
+
+it('rejects a non-image (HTML) file uploaded as a swatch image', function () {
+    $attribute = Attribute::factory()->create(['type' => 'select', 'swatch_type' => 'image']);
+
+    $html = UploadedFile::fake()->createWithContent('evil.html', '<script>alert(document.domain)</script>');
+
+    $this->post(route('admin.catalog.attributes.options.store', $attribute->id), [
+        'code'         => 'swatch_html_'.uniqid(),
+        'locales'      => ['en_US' => ['label' => 'x']],
+        'swatch_value' => $html,
+    ], ['Accept' => 'application/json'])->assertStatus(422)->assertJsonValidationErrors('swatch_value');
+});
+
+it('sanitizes an SVG swatch image so no script/onload survives', function () {
+    Storage::fake('public');
+
+    $attribute = Attribute::factory()->create(['type' => 'select', 'swatch_type' => 'image']);
+
+    $tmp = tempnam(sys_get_temp_dir(), 'svg');
+    file_put_contents($tmp, '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><script>alert(1)</script></svg>');
+    $svg = new UploadedFile($tmp, 'swatch.svg', 'image/svg+xml', null, true);
+
+    $code = 'swatch_svg_'.uniqid();
+    app(AttributeOptionRepository::class)->create([
+        'attribute_id' => $attribute->id,
+        'code'         => $code,
+        'swatch_value' => $svg,
+    ]);
+
+    $option = AttributeOption::where('attribute_id', $attribute->id)->where('code', $code)->first();
+
+    expect($option->swatch_value)->not->toBeNull()
+        ->and($option->swatch_value)->toEndWith('.svg');
+
+    $stored = Storage::disk('public')->get($option->swatch_value);
+    expect($stored)->not->toContain('<script')
+        ->and($stored)->not->toContain('onload');
+
+    @unlink($tmp);
+});

--- a/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MagicAI/MagicAIPlatformAclBypassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Webkul\MagicAI\Models\MagicAIPlatform;
+
+/**
+ * Regression coverage for the MagicAI platform authorization bypass.
+ *
+ * `admin.magic_ai.platform.update` (PUT) and `admin.magic_ai.platform.set_default`
+ * (POST) were registered but absent from AiAgent/Config/acl.php, so the fail-open
+ * Bouncer middleware skipped the permission check and any authenticated admin could
+ * repoint a platform's api_url/api_key or swap the default. The fix maps both routes
+ * to `ai-agent.platform.edit`.
+ */
+function makeMagicAiPlatform(array $overrides = []): MagicAIPlatform
+{
+    return MagicAIPlatform::create(array_merge([
+        'label'      => 'Primary',
+        'provider'   => 'openai',
+        'api_url'    => 'https://api.openai.com/v1',
+        'models'     => 'gpt-4o',
+        'is_default' => true,
+        'status'     => true,
+    ], $overrides));
+}
+
+describe('MagicAI platform authorization', function () {
+    it('forbids a low-privilege admin from updating a platform', function () {
+        $platform = makeMagicAiPlatform();
+
+        $this->loginWithPermissions('custom', ['dashboard']);
+
+        $this->putJson(route('admin.magic_ai.platform.update', $platform->id), [
+            'label'    => 'x',
+            'provider' => 'openai',
+            'models'   => 'gpt-4o',
+            'api_url'  => 'https://evil.tld',
+            'api_key'  => 'stolen',
+        ])->assertForbidden();
+    });
+
+    it('forbids a low-privilege admin from changing the default platform', function () {
+        makeMagicAiPlatform(['label' => 'A']);
+        $other = makeMagicAiPlatform(['label' => 'B', 'is_default' => false]);
+
+        $this->loginWithPermissions('custom', ['dashboard']);
+
+        $this->postJson(route('admin.magic_ai.platform.set_default', $other->id))
+            ->assertForbidden();
+    });
+
+    it('allows an admin holding the platform-edit permission to update', function () {
+        $platform = makeMagicAiPlatform();
+
+        $this->loginWithPermissions('custom', ['ai-agent', 'ai-agent.platform', 'ai-agent.platform.edit']);
+
+        $this->putJson(route('admin.magic_ai.platform.update', $platform->id), [
+            'label'      => 'Updated',
+            'provider'   => 'openai',
+            'models'     => 'gpt-4o',
+            'status'     => true,
+            'is_default' => true,
+        ])->assertOk();
+    });
+});

--- a/packages/Webkul/Admin/tests/Feature/Security/TinyMCEUploadValidationTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Security/TinyMCEUploadValidationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+use Webkul\Admin\Http\Controllers\TinyMCEController;
+use Webkul\Admin\Http\Requests\TinyMCEUploadRequest;
+
+/**
+ * Regression coverage for the TinyMCE unrestricted-upload fix: the endpoint now
+ * validates an image allowlist (real extension + MIME match) and stores the file
+ * under a randomised name, so HTML/SVG (stored XSS) or .php (RCE) files can no
+ * longer be written to the public path.
+ *
+ * Driven against the request rules + controller sink so it holds regardless of
+ * APP_URL / HTTP setup.
+ */
+function tinymceRules(): array
+{
+    return (new TinyMCEUploadRequest)->rules();
+}
+
+describe('TinyMCE upload — file-type validation', function () {
+    it('rejects a .php upload', function () {
+        $php = UploadedFile::fake()->createWithContent('shell.php', "<?php echo 'pwned'; ?>");
+
+        expect(Validator::make(['file' => $php], tinymceRules())->fails())->toBeTrue();
+    });
+
+    it('rejects an .html upload', function () {
+        $html = UploadedFile::fake()->createWithContent('xss.html', '<script>alert(1)</script>');
+
+        expect(Validator::make(['file' => $html], tinymceRules())->fails())->toBeTrue();
+    });
+
+    it('rejects an .svg upload', function () {
+        $svg = UploadedFile::fake()->createWithContent('x.svg', '<svg onload="alert(1)"></svg>');
+
+        expect(Validator::make(['file' => $svg], tinymceRules())->fails())->toBeTrue();
+    });
+
+    it('accepts a genuine png', function () {
+        $png = UploadedFile::fake()->image('photo.png', 10, 10);
+
+        expect(Validator::make(['file' => $png], tinymceRules())->fails())->toBeFalse();
+    });
+});
+
+describe('TinyMCE upload — safe storage', function () {
+    it('stores a valid image under a randomised name, not the client name', function () {
+        Storage::fake('public');
+
+        $png = UploadedFile::fake()->image('photo.png', 10, 10);
+
+        $request = TinyMCEUploadRequest::create('/admin/tinymce/upload', 'POST');
+        $request->files->set('file', $png);
+
+        $result = app(TinyMCEController::class)->storeMedia($request);
+
+        expect($result['file_name'])
+            ->not->toBe('photo.png')
+            ->toEndWith('.png');
+        expect($result['file'])->not->toContain('photo.png');
+        Storage::disk('public')->assertExists($result['file']);
+    });
+});

--- a/packages/Webkul/AdminApi/src/Config/api-acl.php
+++ b/packages/Webkul/AdminApi/src/Config/api-acl.php
@@ -89,6 +89,34 @@ return [
     [
         'key'   => 'api.catalog.products',
         'name'  => 'admin::app.acl.products',
+        'route' => 'admin.api.configurable_products.index',
+        'sort'  => 1,
+    ], [
+        'key'   => 'api.catalog.products.create',
+        'name'  => 'admin::app.acl.create',
+        'route' => 'admin.api.configurable_products.store',
+        'sort'  => 1,
+    ], [
+        'key'   => 'api.catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.api.configurable_products.update',
+        'sort'  => 2,
+    ], [
+        'key'   => 'api.catalog.products.edit',
+        'name'  => 'admin::app.acl.edit',
+        'route' => 'admin.api.configurable_products.patch',
+        'sort'  => 2,
+    ], [
+        'key'   => 'api.catalog.products.delete',
+        'name'  => 'admin::app.acl.delete',
+        'route' => 'admin.api.configurable_products.delete',
+        'sort'  => 3,
+    ],
+
+    // Legacy "configrable_products" (typo) prefix — kept for backward compatibility.
+    [
+        'key'   => 'api.catalog.products',
+        'name'  => 'admin::app.acl.products',
         'route' => 'admin.api.configrable_products.index',
         'sort'  => 1,
     ], [
@@ -106,6 +134,11 @@ return [
         'name'  => 'admin::app.acl.edit',
         'route' => 'admin.api.configrable_products.patch',
         'sort'  => 2,
+    ], [
+        'key'   => 'api.catalog.products.delete',
+        'name'  => 'admin::app.acl.delete',
+        'route' => 'admin.api.configrable_products.delete',
+        'sort'  => 3,
     ],
 
     // Product media uploads — require edit permission

--- a/packages/Webkul/AdminApi/src/Http/Middleware/ScopeMiddleware.php
+++ b/packages/Webkul/AdminApi/src/Http/Middleware/ScopeMiddleware.php
@@ -15,11 +15,26 @@ class ScopeMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($this->getAclForCurrentRoute() && ! $this->hasPermission($this->getAclForCurrentRoute())) {
+        $acl = $this->getAclForCurrentRoute();
+
+        if ($acl) {
+            if (! $this->hasPermission($acl)) {
+                return response()->json(['error' => 'This action is unauthorized'], 403);
+            }
+        } elseif ($this->isMutatingRequest($request)) {
+
             return response()->json(['error' => 'This action is unauthorized'], 403);
         }
 
         return $next($request);
+    }
+
+    /**
+     * Determine whether the request uses a state-changing HTTP method.
+     */
+    protected function isMutatingRequest(Request $request): bool
+    {
+        return in_array($request->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
     }
 
     /**

--- a/packages/Webkul/AdminApi/tests/Feature/Acl/ConfigurableProductScopeBypassTest.php
+++ b/packages/Webkul/AdminApi/tests/Feature/Acl/ConfigurableProductScopeBypassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Regression coverage for the fail-open API scope bypass.
+ *
+ * The configurable-product mutating routes were registered but absent from
+ * api-acl.php, so ScopeMiddleware short-circuited and allowed them with no
+ * scope. The fix maps every configurable-product route (both the correct
+ * "configurable_products" prefix and the legacy "configrable_products" typo)
+ * and makes ScopeMiddleware fail closed for any unmapped state-changing route.
+ */
+it('maps every mutating API scope route in api-acl so no write route fails open', function () {
+    $roles = app('api-acl')->roles;
+
+    $unmapped = [];
+
+    foreach (Route::getRoutes() as $route) {
+        $name = $route->getName();
+
+        if (! $name || ! str_starts_with($name, 'admin.api.')) {
+            continue;
+        }
+
+        $hasScope = collect($route->gatherMiddleware())
+            ->contains(fn ($m) => str_contains($m, 'ScopeMiddleware') || $m === 'api.scope');
+
+        $isWrite = (bool) array_intersect($route->methods(), ['POST', 'PUT', 'PATCH', 'DELETE']);
+
+        if ($hasScope && $isWrite && ! isset($roles[str_replace('.get', '.index', $name)])) {
+            $unmapped[] = $name;
+        }
+    }
+
+    expect($unmapped)->toBe([]);
+});
+
+dataset('configurable write routes', [
+    'store (correct prefix)'  => ['POST', 'admin.api.configurable_products.store', null],
+    'update (correct prefix)' => ['PUT', 'admin.api.configurable_products.update', 'sku-x'],
+    'patch (correct prefix)'  => ['PATCH', 'admin.api.configurable_products.patch', 'sku-x'],
+    'delete (correct prefix)' => ['DELETE', 'admin.api.configurable_products.delete', 'sku-x'],
+    'delete (legacy typo)'    => ['DELETE', 'admin.api.configrable_products.delete', 'sku-x'],
+    'store (legacy typo)'     => ['POST', 'admin.api.configrable_products.store', null],
+]);
+
+it('forbids configurable-product writes for a key without the product scope', function (string $method, string $routeName, ?string $param) {
+    $headers = $this->getAuthenticationHeaders('custom', ['api.settings.locales']);
+
+    $url = $param ? route($routeName, $param) : route($routeName);
+
+    $this->withHeaders($headers)->json($method, $url)->assertForbidden();
+})->with('configurable write routes');
+
+it('allows a configurable-product write past the scope check when the key holds the product scope', function () {
+    $headers = $this->getAuthenticationHeaders('custom', ['api.catalog.products.create']);
+
+    $response = $this->withHeaders($headers)->json('POST', route('admin.api.configurable_products.store'), []);
+
+    expect($response->getStatusCode())->not->toBe(403);
+});

--- a/packages/Webkul/AiAgent/Config/acl.php
+++ b/packages/Webkul/AiAgent/Config/acl.php
@@ -27,6 +27,16 @@ return [
         'name'   => 'ai-agent::app.acl.delete',
         'route'  => 'admin.magic_ai.platform.delete',
         'sort'   => 3,
+    ], [
+        'key'    => 'ai-agent.platform.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.platform.update',
+        'sort'   => 2,
+    ], [
+        'key'    => 'ai-agent.platform.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.platform.set_default',
+        'sort'   => 2,
     ],
     [
         'key'    => 'ai-agent.general',
@@ -44,6 +54,18 @@ return [
         'key'    => 'ai-agent.prompt.edit',
         'name'   => 'ai-agent::app.acl.edit',
         'route'  => 'admin.magic_ai.prompt.edit',
+        'sort'   => 1,
+    ],
+    [
+        'key'    => 'ai-agent.prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.prompt.store',
+        'sort'   => 1,
+    ],
+    [
+        'key'    => 'ai-agent.prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.prompt.update',
         'sort'   => 1,
     ],
     [
@@ -65,6 +87,18 @@ return [
         'sort'   => 1,
     ],
     [
+        'key'    => 'ai-agent.system-prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.system_prompt.store',
+        'sort'   => 1,
+    ],
+    [
+        'key'    => 'ai-agent.system-prompt.edit',
+        'name'   => 'ai-agent::app.acl.edit',
+        'route'  => 'admin.magic_ai.system_prompt.update',
+        'sort'   => 1,
+    ],
+    [
         'key'    => 'ai-agent.system-prompt.delete',
         'name'   => 'ai-agent::app.acl.delete',
         'route'  => 'admin.magic_ai.system_prompt.delete',
@@ -75,6 +109,12 @@ return [
         'key'   => 'ai-agent.generate',
         'name'  => 'ai-agent::app.acl.generate',
         'route' => 'ai-agent.generate.index',
+        'sort'  => 5,
+    ],
+    [
+        'key'   => 'ai-agent.generate',
+        'name'  => 'ai-agent::app.acl.generate',
+        'route' => 'ai-agent.generate.process',
         'sort'  => 5,
     ],
     [

--- a/packages/Webkul/Attribute/src/Repositories/AttributeOptionRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeOptionRepository.php
@@ -5,8 +5,10 @@ namespace Webkul\Attribute\Repositories;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
 use Webkul\Attribute\Contracts\AttributeOption;
 use Webkul\Core\Eloquent\Repository;
+use Webkul\Core\Filesystem\FileStorer;
 
 class AttributeOptionRepository extends Repository
 {
@@ -104,8 +106,12 @@ class AttributeOptionRepository extends Repository
         }
 
         if ($data['swatch_value'] instanceof UploadedFile) {
+            $file = $data['swatch_value'];
+
+            $name = Str::random(40).'.'.($file->guessExtension() ?: $file->getClientOriginalExtension());
+
             parent::update([
-                'swatch_value' => $data['swatch_value']->store('attribute_option'),
+                'swatch_value' => app(FileStorer::class)->storeAs('attribute_option', $name, $file),
             ], $optionId);
         }
     }

--- a/tests/e2e-pw/tests/08-security/product-sort-injection.spec.js
+++ b/tests/e2e-pw/tests/08-security/product-sort-injection.spec.js
@@ -1,0 +1,25 @@
+const { test, expect } = require('../../utils/fixtures');
+
+test.describe('Product grid sort - SQL injection hardening', () => {
+  const gridRequest = (adminPage, order) =>
+    adminPage.request.get(
+      `/admin/catalog/products?sort[column]=name&sort[order]=${encodeURIComponent(order)}`,
+      { headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' } },
+    );
+
+  test('malicious sort[order] is handled safely (no SQL error)', async ({ adminPage }) => {
+    const payload = 'asc,(SELECT CASE WHEN (1=1) THEN name ELSE id END FROM admins LIMIT 1)';
+
+    const res = await gridRequest(adminPage, payload);
+
+    expect(res.status(), 'grid must not 500 on a malicious sort order').toBe(200);
+    expect(await res.json()).toHaveProperty('records');
+  });
+
+  test('a normal ascending sort still works', async ({ adminPage }) => {
+    const res = await gridRequest(adminPage, 'asc');
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toHaveProperty('records');
+  });
+});

--- a/tests/e2e-pw/utils/login.js
+++ b/tests/e2e-pw/utils/login.js
@@ -4,9 +4,15 @@ export async function login(page) {
   const baseURL = process.env.BASE_URL || 'http://127.0.0.1:8000';
   const email = process.env.ADMIN_USERNAME || process.env.ADMIN_EMAIL || 'admin@example.com';
   const password = process.env.ADMIN_PASSWORD || 'admin123';
-  await page.goto(`${baseURL}/admin/login`);
-  await page.getByRole('textbox', { name: 'Email Address' }).fill(email);
-  await page.getByRole('textbox', { name: 'Password' }).fill(password);
-  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  const html = await (await page.request.get(`${baseURL}/admin/login`)).text();
+  const match = html.match(/name="_token"\s+value="([^"]+)"/);
+  const token = match ? match[1] : '';
+
+  await page.request.post(`${baseURL}/admin/login`, {
+    form: { _token: token, email, password },
+  });
+
+  await page.goto(`${baseURL}/admin/dashboard`);
   await page.waitForLoadState('networkidle');
 }


### PR DESCRIPTION
## Description
Brings the input-validation and permission-enforcement improvements already on `2.1`
over to `master`, so the main line stays consistent. Each change mirrors its `2.1` PR.

### Included changes
- **Rich-text (TinyMCE) uploads** — restricted to an approved image set and stored under
  randomised filenames via `FileStorer`.
- **Configurable-product API endpoints** — every route now requires the correct access
  scope; the scope middleware fails closed for unmapped write requests.
- **Magic AI platform actions** — `update` and `set-default` now require the
  platform-edit permission.
- **Product grid sorting** — the sort direction is restricted to a safe allowlist
  (`asc`/`desc`) on both the database and Elasticsearch paths.
- **Attribute swatch image uploads** — validated against an image allowlist and stored
  through `FileStorer` with a randomised filename.
- **Channel options on the family Completeness screen** — output is now escaped.
- **Magic AI prompt / system-prompt & AI Agent generate** — these actions now require
  the matching permission.

Adds the corresponding regression tests for each.

## How To Test This?
- Run the new Feature tests under `packages/Webkul/Admin/tests/Feature/**` (use a root
  `APP_URL`). Non-image/mismatched uploads are rejected; restricted users get 403;
  malformed sort input is coerced to a safe value; swatch SVGs are stored sanitized.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master

## Pint
- [x] All Pint checks pass.

## Tailwind Reordering
- [x] N/A — no Tailwind class changes.

## Tests
- Pint ✅ · Translations 256/256 ✅
- New regression tests pass on master. (The AdminApi token-based tests need master's
  `oauth_clients` schema aligned with the installed Passport version — a separate
  test-infra item, unrelated to these changes.)
