### PR TITLE
feat: integrate unopim/mcp server with Passport OAuth for remote MCP clients

### DIFF
--- a/app/Http/Middleware/AuthenticateAdminFromApiGuard.php
+++ b/app/Http/Middleware/AuthenticateAdminFromApiGuard.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateAdminFromApiGuard
+{
+    /**
+     * Propagate the Passport-authenticated admin onto the session "admin"
+     * guard so ACL checks (bouncer()) work for token-based MCP requests.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user('api');
+
+        if ($user && ! auth()->guard('admin')->check()) {
+            auth()->guard('admin')->setUser($user);
+        }
+
+        return $next($request);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "pusher/pusher-php-server": "^7.0",
         "shetabit/visitor": "^4.1",
         "spatie/laravel-responsecache": "^7.4",
-        "symfony/intl": "^7.0"
+        "symfony/intl": "^7.0",
+        "unopim/mcp": "^1.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a97f7adbb554f4f36f35180234b3ed1",
+    "content-hash": "ab47c55f42007abf6ca41bcf8bfae431",
     "packages": [
         {
             "name": "astrotomic/laravel-translatable",
@@ -3109,6 +3109,79 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2026-05-26T23:41:33+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "3513b4feca5f1678be4d2261dcfa8e456436d02a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/3513b4feca5f1678be4d2261dcfa8e456436d02a",
+                "reference": "3513b4feca5f1678be4d2261dcfa8e456436d02a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-04-21T10:23:03+00:00"
         },
         {
             "name": "laravel/octane",
@@ -10912,6 +10985,68 @@
             "time": "2025-07-17T15:43:24+00:00"
         },
         {
+            "name": "unopim/mcp",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/unopim/unopim-mcp.git",
+                "reference": "3def45d8e4b822ceb3c7b9ea26c743255e52a895"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/unopim/unopim-mcp/zipball/3def45d8e4b822ceb3c7b9ea26c743255e52a895",
+                "reference": "3def45d8e4b822ceb3c7b9ea26c743255e52a895",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/mcp": "^0.5.1 || ^0.6 || ^0.7 || ^1.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.0"
+            },
+            "type": "laravel-library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Webkul\\MCP\\Providers\\MCPServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webkul\\MCP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Webkul",
+                    "email": "support@webkul.com"
+                }
+            ],
+            "description": "UnoPim Model Context Protocol (MCP) bridge for AI-powered catalog interaction.",
+            "keywords": [
+                "PIM",
+                "ai",
+                "automation",
+                "laravel",
+                "mcp",
+                "security",
+                "unopim"
+            ],
+            "support": {
+                "issues": "https://github.com/unopim/unopim-mcp/issues",
+                "source": "https://github.com/unopim/unopim-mcp/tree/v1.0.0"
+            },
+            "time": "2026-04-22T11:32:51+00:00"
+        },
+        {
             "name": "vlucas/phpdotenv",
             "version": "v5.6.3",
             "source": {
@@ -11682,79 +11817,6 @@
                 "source": "https://github.com/laravel/boost"
             },
             "time": "2026-05-19T20:09:50+00:00"
-        },
-        {
-            "name": "laravel/mcp",
-            "version": "v0.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/mcp.git",
-                "reference": "3513b4feca5f1678be4d2261dcfa8e456436d02a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/3513b4feca5f1678be4d2261dcfa8e456436d02a",
-                "reference": "3513b4feca5f1678be4d2261dcfa8e456436d02a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/json-schema": "^12.41.1|^13.0",
-                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.20",
-                "orchestra/testbench": "^9.15|^10.8|^11.0",
-                "pestphp/pest": "^3.8.5|^4.3.2",
-                "phpstan/phpstan": "^2.1.27",
-                "rector/rector": "^2.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
-                    },
-                    "providers": [
-                        "Laravel\\Mcp\\Server\\McpServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laravel\\Mcp\\": "src/",
-                    "Laravel\\Mcp\\Server\\": "src/Server/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "Rapidly build MCP servers for your Laravel applications.",
-            "homepage": "https://github.com/laravel/mcp",
-            "keywords": [
-                "laravel",
-                "mcp"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/mcp/issues",
-                "source": "https://github.com/laravel/mcp"
-            },
-            "time": "2026-04-21T10:23:03+00:00"
         },
         {
             "name": "laravel/pint",

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -1,0 +1,82 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | MCP API Authentication
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, all MCP HTTP endpoints (SSE) require a valid Bearer token.
+    | Default is true for production security.
+    |
+    */
+    'api_auth' => env('MCP_API_AUTH', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate Limiting
+    |--------------------------------------------------------------------------
+    |
+    | Define the maximum number of requests allowed per minute per tool.
+    |
+    */
+    'rate_limit' => env('MCP_RATE_LIMIT', 60),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Path Restriction
+    |--------------------------------------------------------------------------
+    |
+    | The file manager will only allow operations within these base paths.
+    | Any attempt to access paths outside these will be rejected.
+    |
+    */
+    'allowed_paths' => [
+        base_path(),
+        sys_get_temp_dir(),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Audit Logging
+    |--------------------------------------------------------------------------
+    |
+    | Enable or disable audit logging for destructive tool operations.
+    |
+    */
+    'audit_logging' => env('MCP_AUDIT_LOGGING', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Skills Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure the dynamic skills system that loads SKILL.md files
+    | from the filesystem and registers them as MCP tools.
+    |
+    */
+    'skills_path' => env('MCP_SKILLS_PATH', base_path('.ai/skills')),
+
+    'enable_cache' => env('MCP_ENABLE_CACHE', true),
+
+    'cache_key' => 'mcp.skills',
+
+    'cache_ttl' => env('MCP_CACHE_TTL', 3600),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Media Validation
+    |--------------------------------------------------------------------------
+    |
+    | Define allowed file extensions and MIME types for media uploads.
+    |
+    */
+    'media' => [
+        'allowed_extensions' => ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'pdf', 'csv', 'xlsx'],
+        'allowed_mimes'      => [
+            'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml',
+            'application/pdf', 'text/csv', 'text/plain', 'application/vnd.ms-excel',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        ],
+    ],
+];

--- a/config/passport.php
+++ b/config/passport.php
@@ -15,6 +15,19 @@ return [
     |
     */
 
+    /*
+    |--------------------------------------------------------------------------
+    | Passport Guard
+    |--------------------------------------------------------------------------
+    |
+    | Passport defaults to the "web" guard, which Unopim does not define.
+    | Admin sessions live on the "admin" guard, so the OAuth authorize
+    | flow must check that guard to recognize logged-in admins.
+    |
+    */
+
+    'guard' => 'admin',
+
     'private_key' => env('PASSPORT_PRIVATE_KEY'),
 
     'public_key' => env('PASSPORT_PUBLIC_KEY'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,3 +10,32 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
+
+use App\Http\Middleware\AuthenticateAdminFromApiGuard;
+use Illuminate\Support\Facades\Route;
+use Laravel\Mcp\Facades\Mcp;
+
+/**
+ * OAuth discovery + dynamic client registration endpoints for remote
+ * MCP clients (e.g. claude.ai custom connectors).
+ */
+Mcp::oauthRoutes();
+
+/**
+ * Passport's authorize flow redirects guests to the framework-default
+ * `login` route, which UnoPim does not define — alias it to admin login.
+ */
+Route::get('login', fn () => redirect()->route('admin.session.create'))->name('login');
+
+/**
+ * The MCP endpoint authenticates via Passport (api guard), but UnoPim's
+ * bouncer() ACL reads the admin session guard — bridge the two so MCP
+ * tool calls pass permission checks.
+ */
+app()->booted(function () {
+    foreach (app('router')->getRoutes() as $route) {
+        if ($route->uri() === 'mcp/unopim' && in_array('POST', $route->methods())) {
+            $route->middleware(AuthenticateAdminFromApiGuard::class);
+        }
+    }
+});


### PR DESCRIPTION
## Issue Reference
N/A — feature integration.

## Description
Integrates the `unopim/mcp` package so UnoPim exposes a remote MCP (Model Context Protocol) server that AI clients (e.g. claude.ai custom connectors) can connect to via OAuth.

Changes:
- **composer**: require `unopim/mcp ^1.0`.
- **config/mcp.php** (new): MCP server configuration — Bearer-token API auth, per-tool rate limiting, file-manager path restriction, audit logging for destructive operations, dynamic skills loading from `.ai/skills/`, and media upload validation.
- **config/passport.php**: set Passport `guard` to `admin` — Passport defaults to the `web` guard, which UnoPim does not define, so the OAuth authorize flow could not recognize logged-in admins.
- **routes/web.php**:
  - `Mcp::oauthRoutes()` — OAuth discovery + dynamic client registration endpoints for remote MCP clients.
  - Alias the framework-default `login` route to the admin login page (Passport redirects guests there).
  - Attach `AuthenticateAdminFromApiGuard` to the `mcp/unopim` POST endpoint.
- **app/Http/Middleware/AuthenticateAdminFromApiGuard.php** (new): propagates the Passport-authenticated (api guard) user onto the `admin` guard so `bouncer()` ACL checks pass for token-authenticated MCP tool calls.

## How To Test This?
1. `composer install` and run migrations; ensure Passport keys/clients exist (`php artisan passport:keys`).
2. In claude.ai (or any MCP client supporting remote connectors), add a custom connector pointing at `https://<host>/mcp/unopim`.
3. Complete the OAuth flow — you should be redirected to the UnoPim admin login, and after login the consent/authorize screen should appear (verifies the `admin` guard + `login` route alias).
4. Once connected, invoke MCP tools (e.g. product search) — tool calls should respect the admin user's ACL permissions (verifies the guard-bridge middleware).
5. Verify unauthenticated requests to `mcp/unopim` are rejected when `MCP_API_AUTH=true`.

## Documentation
- [x] My pull request requires an update on the documentation repository.
Document MCP server setup: env vars (`MCP_API_AUTH`, `MCP_RATE_LIMIT`, `MCP_SKILLS_PATH`, etc.) and connecting remote MCP clients via OAuth.

## Branch Selection
- [x] Target Branch: master

## Pint
All Pint checks pass (`vendor/bin/pint --test --dirty`).

## Tailwind Reordering
N/A — no Blade/CSS changes.