### PR TITLE
Fixed   Confirm before demo-data seeding overwrites existing data[2.1]

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
+++ b/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
@@ -3,7 +3,6 @@
 namespace Webkul\Installer\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Console\ConfirmableTrait;
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
 /**
@@ -16,15 +15,13 @@ use Webkul\Installer\Helpers\DemoDataInstaller;
  */
 class SeedDemoData extends Command
 {
-    use ConfirmableTrait;
-
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
     protected $signature = 'unopim:install:demo-data
-        { --force : Skip confirmation and re-seed even when demo data is already present (use for CI / Docker). }';
+        { --force : Re-seed even when demo data is already present (production still requires confirmation). }';
 
     /**
      * The console command description.
@@ -38,23 +35,41 @@ class SeedDemoData extends Command
      */
     public function handle(DemoDataInstaller $installer): int
     {
-        if (! $this->getLaravel()->environment('production')) {
-            $this->components->warn('Your existing data will be removed and replaced with demo data.');
+        $force = (bool) $this->option('force');
+
+        if (! $force && $installer->isAlreadySeeded()) {
+            $this->info('Demo data is already seeded — nothing to do. Re-run with --force to re-seed.');
+
+            return self::SUCCESS;
         }
 
-        if (! $this->confirmToProceed()) {
-            return self::FAILURE;
+        $this->components->warn('This deletes existing products, categories, channels, attributes, families and core config, then loads demo data.');
+
+        if ($this->getLaravel()->environment('production')) {
+            $this->components->alert('Application In Production');
+
+            if (! $this->components->confirm('Are you sure you want to run this command?', false)) {
+                $this->components->warn('Command cancelled.');
+
+                return self::FAILURE;
+            }
         }
 
         $result = $installer->seed(
             fn (string $message) => $this->warn('Step: '.$message),
-            true,
+            $force,
         );
 
         if (! ($result['success'] ?? false)) {
             $this->error("Failed to seed sample data: {$result['error']}");
 
             return self::FAILURE;
+        }
+
+        if ($result['skipped'] ?? false) {
+            $this->info('Demo data is already seeded — nothing to do. Re-run with --force to re-seed.');
+
+            return self::SUCCESS;
         }
 
         $this->info('Sample products seeded successfully.');

--- a/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
+++ b/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
@@ -21,7 +21,7 @@ class SeedDemoData extends Command
      * @var string
      */
     protected $signature = 'unopim:install:demo-data
-        { --force : Re-seed even when demo data is already present (production still requires confirmation). }';
+        { --force : Re-seed even when demo data is already present. }';
 
     /**
      * The console command description.

--- a/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
+++ b/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
@@ -3,6 +3,7 @@
 namespace Webkul\Installer\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
 /**
@@ -15,13 +16,15 @@ use Webkul\Installer\Helpers\DemoDataInstaller;
  */
 class SeedDemoData extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
     protected $signature = 'unopim:install:demo-data
-        { --force : Re-seed even when demo data is already present. }';
+        { --force : Skip confirmation and re-seed even when demo data is already present (use for CI / Docker). }';
 
     /**
      * The console command description.
@@ -35,21 +38,23 @@ class SeedDemoData extends Command
      */
     public function handle(DemoDataInstaller $installer): int
     {
+        if (! $this->getLaravel()->environment('production')) {
+            $this->components->warn('Your existing data will be removed and replaced with demo data.');
+        }
+
+        if (! $this->confirmToProceed()) {
+            return self::FAILURE;
+        }
+
         $result = $installer->seed(
             fn (string $message) => $this->warn('Step: '.$message),
-            (bool) $this->option('force'),
+            true,
         );
 
         if (! ($result['success'] ?? false)) {
             $this->error("Failed to seed sample data: {$result['error']}");
 
             return self::FAILURE;
-        }
-
-        if ($result['skipped'] ?? false) {
-            $this->info('Demo data is already seeded — nothing to do. Re-run with --force to re-seed.');
-
-            return self::SUCCESS;
         }
 
         $this->info('Sample products seeded successfully.');

--- a/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
+++ b/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
@@ -119,17 +119,23 @@ class DemoDataInstaller
     }
 
     /**
-     * Returns true when demo data is already present in the database.
+     * Returns true when demo data — or any operator-created catalog data —
+     * is already present in the database.
      *
-     * Probes for any non-root category — the base installer only
-     * creates the root row, while CategoryDemoTableSeeder inserts the
-     * full demo tree under it. A child category therefore proves the
-     * demo pipeline has already run.
+     * The seeders delete products, the demo category tree, and the full
+     * demo_extras table set (channels, attributes, families, core config),
+     * so the guard probes every signal that proves the DB is no longer a
+     * bare base install: a product, a non-root category, or an attribute
+     * family / channel beyond the single `default` row the base installer
+     * ships. Any of these means re-seeding would destroy real data.
      */
     public function isAlreadySeeded(): bool
     {
         try {
-            return DB::table('categories')->whereNotNull('parent_id')->exists();
+            return DB::table('products')->exists()
+                || DB::table('categories')->whereNotNull('parent_id')->exists()
+                || DB::table('attribute_families')->where('code', '!=', 'default')->exists()
+                || DB::table('channels')->where('code', '!=', 'default')->exists();
         } catch (Throwable) {
             // Table missing / DB not migrated yet → treat as not seeded
             // so the caller can decide how to handle the failure mode.

--- a/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
+++ b/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
@@ -119,15 +119,7 @@ class DemoDataInstaller
     }
 
     /**
-     * Returns true when demo data — or any operator-created catalog data —
-     * is already present in the database.
-     *
-     * The seeders delete products, the demo category tree, and the full
-     * demo_extras table set (channels, attributes, families, core config),
-     * so the guard probes every signal that proves the DB is no longer a
-     * bare base install: a product, a non-root category, or an attribute
-     * family / channel beyond the single `default` row the base installer
-     * ships. Any of these means re-seeding would destroy real data.
+     * Check if demo or operator-created catalog data already exists.
      */
     public function isAlreadySeeded(): bool
     {
@@ -144,10 +136,7 @@ class DemoDataInstaller
     }
 
     /**
-     * Recalculate product completeness synchronously. The
-     * `unopim:completeness:recalculate` command dispatches queue jobs,
-     * so the sync driver is forced while it runs to guarantee work
-     * lands before the installer finishes.
+     * Recalculate product completeness synchronously.
      */
     protected function recalculateCompleteness(): void
     {
@@ -155,10 +144,6 @@ class DemoDataInstaller
 
         try {
             config(['queue.default' => 'sync']);
-
-            // The Completeness package only auto-registers this command when
-            // running in the console, so register it explicitly for the web
-            // installer (which calls this inside an HTTP request).
             Artisan::registerCommand(app(RecalculateCompletenessCommand::class));
 
             Artisan::call('unopim:completeness:recalculate', ['--all' => true]);

--- a/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
+++ b/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
@@ -6,17 +6,24 @@ use Webkul\Installer\Helpers\DemoDataInstaller;
  * Stubs DemoDataInstaller so the command can be exercised without a real
  * database. $seedCalled / $forceSeen let a test assert whether (and how)
  * seeding was invoked, which is how we prove the confirmation gate blocks
- * a destructive re-seed when the operator declines.
+ * a destructive re-seed when the operator declines. $alreadySeeded drives
+ * the idempotency short-circuit.
  */
-function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen): void
+function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen, bool $alreadySeeded = false): void
 {
-    app()->instance(DemoDataInstaller::class, new class($result, $seedCalled, $forceSeen) extends DemoDataInstaller
+    app()->instance(DemoDataInstaller::class, new class($result, $seedCalled, $forceSeen, $alreadySeeded) extends DemoDataInstaller
     {
         public function __construct(
             private array $result,
             private bool &$seedCalled,
             private bool &$forceSeen,
+            private bool $alreadySeeded,
         ) {}
+
+        public function isAlreadySeeded(): bool
+        {
+            return $this->alreadySeeded;
+        }
 
         public function seed(?Closure $reporter = null, bool $force = false): array
         {
@@ -32,32 +39,7 @@ function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen): 
 }
 
 describe('unopim:install:demo-data (issue #975 — destructive re-seed guard)', function () {
-    it('seeds and exits 0 when --force is passed', function () {
-        $seedCalled = false;
-        $forceSeen = false;
-        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
-
-        $this->artisan('unopim:install:demo-data', ['--force' => true])
-            ->expectsOutputToContain('Seeding demo extras...')
-            ->expectsOutputToContain('Seeding demo categories...')
-            ->expectsOutputToContain('Sample products seeded successfully.')
-            ->assertExitCode(0);
-
-        expect($seedCalled)->toBeTrue()
-            ->and($forceSeen)->toBeTrue();
-    });
-
-    it('exits non-zero and prints the seeder error when seeding fails', function () {
-        $seedCalled = false;
-        $forceSeen = false;
-        fakeDemoInstaller(['success' => false, 'error' => 'JSON missing'], $seedCalled, $forceSeen);
-
-        $this->artisan('unopim:install:demo-data', ['--force' => true])
-            ->expectsOutputToContain('Failed to seed sample data: JSON missing')
-            ->assertExitCode(1);
-    });
-
-    it('warns but proceeds without confirmation in local env', function () {
+    it('warns and seeds without a prompt in a non-production env', function () {
         app()['env'] = 'local';
 
         $seedCalled = false;
@@ -65,7 +47,49 @@ describe('unopim:install:demo-data (issue #975 — destructive re-seed guard)', 
         fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
         $this->artisan('unopim:install:demo-data')
-            ->expectsOutputToContain('Your existing data will be removed')
+            ->expectsOutputToContain('This deletes existing products')
+            ->expectsOutputToContain('Sample products seeded successfully.')
+            ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeFalse();
+    });
+
+    it('exits non-zero and prints the seeder error when seeding fails', function () {
+        app()['env'] = 'local';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => false, 'error' => 'JSON missing'], $seedCalled, $forceSeen);
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsOutputToContain('Failed to seed sample data: JSON missing')
+            ->assertExitCode(1);
+    });
+
+    it('shows the already-seeded message and skips when data exists and --force is absent', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsOutputToContain('Demo data is already seeded')
+            ->assertExitCode(0);
+
+        expect($seedCalled)->toBeFalse();
+    });
+
+    it('re-seeds already-seeded data with --force in a non-production env', function () {
+        app()['env'] = 'local';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsOutputToContain('This deletes existing products')
             ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
 
@@ -73,7 +97,7 @@ describe('unopim:install:demo-data (issue #975 — destructive re-seed guard)', 
             ->and($forceSeen)->toBeTrue();
     });
 
-    it('blocks seeding in production without --force', function () {
+    it('aborts in production when the operator declines the confirmation', function () {
         app()['env'] = 'production';
 
         $seedCalled = false;
@@ -81,22 +105,56 @@ describe('unopim:install:demo-data (issue #975 — destructive re-seed guard)', 
         fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
         $this->artisan('unopim:install:demo-data')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
             ->assertExitCode(1);
 
         expect($seedCalled)->toBeFalse();
     });
 
-    it('bypasses the production confirmation with --force', function () {
+    it('proceeds in production when the operator confirms', function () {
         app()['env'] = 'production';
 
         $seedCalled = false;
         $forceSeen = false;
         fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
-        $this->artisan('unopim:install:demo-data', ['--force' => true])
+        $this->artisan('unopim:install:demo-data')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
             ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
 
         expect($seedCalled)->toBeTrue();
+    });
+
+    it('still requires confirmation in production even with --force, and aborts on decline', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
+            ->assertExitCode(1);
+
+        expect($seedCalled)->toBeFalse();
+    });
+
+    it('re-seeds in production with --force once the operator confirms', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->expectsOutputToContain('Sample products seeded successfully.')
+            ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeTrue();
     });
 });

--- a/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
+++ b/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
@@ -3,11 +3,7 @@
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
 /**
- * Stubs DemoDataInstaller so the command can be exercised without a real
- * database. $seedCalled / $forceSeen let a test assert whether (and how)
- * seeding was invoked, which is how we prove the confirmation gate blocks
- * a destructive re-seed when the operator declines. $alreadySeeded drives
- * the idempotency short-circuit.
+ * Stub DemoDataInstaller so the command can be tested without a database.
  */
 function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen, bool $alreadySeeded = false): void
 {

--- a/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
+++ b/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
@@ -2,71 +2,101 @@
 
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
-describe('unopim:install:demo-data (issue #794)', function () {
-    it('exits 0 and surfaces every step message when seeding succeeds', function () {
-        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
+/**
+ * Stubs DemoDataInstaller so the command can be exercised without a real
+ * database. $seedCalled / $forceSeen let a test assert whether (and how)
+ * seeding was invoked, which is how we prove the confirmation gate blocks
+ * a destructive re-seed when the operator declines.
+ */
+function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen): void
+{
+    app()->instance(DemoDataInstaller::class, new class($result, $seedCalled, $forceSeen) extends DemoDataInstaller
+    {
+        public function __construct(
+            private array $result,
+            private bool &$seedCalled,
+            private bool &$forceSeen,
+        ) {}
+
+        public function seed(?Closure $reporter = null, bool $force = false): array
         {
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                ($reporter ?? static fn () => null)('Seeding demo extras...');
-                ($reporter ?? static fn () => null)('Seeding demo categories...');
+            $this->seedCalled = true;
+            $this->forceSeen = $force;
 
-                return ['success' => true];
-            }
-        });
+            ($reporter ?? static fn () => null)('Seeding demo extras...');
+            ($reporter ?? static fn () => null)('Seeding demo categories...');
 
-        $this->artisan('unopim:install:demo-data')
+            return $this->result;
+        }
+    });
+}
+
+describe('unopim:install:demo-data (issue #975 — destructive re-seed guard)', function () {
+    it('seeds and exits 0 when --force is passed', function () {
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
             ->expectsOutputToContain('Seeding demo extras...')
             ->expectsOutputToContain('Seeding demo categories...')
             ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeTrue();
     });
 
     it('exits non-zero and prints the seeder error when seeding fails', function () {
-        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
-        {
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                return ['success' => false, 'error' => 'JSON missing'];
-            }
-        });
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => false, 'error' => 'JSON missing'], $seedCalled, $forceSeen);
 
-        $this->artisan('unopim:install:demo-data')
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
             ->expectsOutputToContain('Failed to seed sample data: JSON missing')
             ->assertExitCode(1);
     });
 
-    it('exits 0 with the "already seeded" message and skips work when demo data is present', function () {
-        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
-        {
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                return ['success' => true, 'skipped' => true];
-            }
-        });
+    it('warns but proceeds without confirmation in local env', function () {
+        app()['env'] = 'local';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
         $this->artisan('unopim:install:demo-data')
-            ->expectsOutputToContain('Demo data is already seeded')
+            ->expectsOutputToContain('Your existing data will be removed')
+            ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeTrue();
     });
 
-    it('forwards --force to the installer so a re-seed runs', function () {
+    it('blocks seeding in production without --force', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
         $forceSeen = false;
-        app()->instance(DemoDataInstaller::class, new class($forceSeen) extends DemoDataInstaller
-        {
-            public function __construct(private bool &$forceSeen) {}
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                $this->forceSeen = $force;
+        $this->artisan('unopim:install:demo-data')
+            ->assertExitCode(1);
 
-                return ['success' => true];
-            }
-        });
+        expect($seedCalled)->toBeFalse();
+    });
+
+    it('bypasses the production confirmation with --force', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
         $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
 
-        expect($forceSeen)->toBeTrue();
+        expect($seedCalled)->toBeTrue();
     });
 });


### PR DESCRIPTION
## Description
`php artisan unopim:install:demo-data` re-seeds the demo catalog by
deleting existing rows (products, the category tree, and the demo_extras
tables: channels, attributes, attribute families, core config) before
inserting samples. Run on a populated instance it silently destroyed
user data.

This guards the standalone command before it seeds:
- **Already seeded** (no `--force`) → prints `Demo data is already
  seeded — nothing to do.` and exits **without** prompting or deleting
  anything.
- **Always** → prints a data-loss warning listing what will be replaced.
- **production** → shows the `APPLICATION IN PRODUCTION` alert + a
  `Are you sure you want to run this command?` Yes/No (default **no**);
  aborts unless confirmed.
- **local / other envs** → prints the warning, then proceeds.
- **`--force`** → overrides **only** the "already seeded" idempotency
  skip; it does **not** bypass the production confirmation.

Supporting changes:
- Widen `DemoDataInstaller::isAlreadySeeded()` to detect products, demo
  categories, and non-`default` families/channels (was a child category
  only), so the idempotency guard actually covers what the seeders wipe.
  The base install ships only the `default` channel/family, so a fresh
  `--with-demo-data` install still seeds.
- Use `$this->components->confirm()` instead of `confirmToProceed()` so
  prompt routing no longer depends on `runningUnitTests()` / app env,
  making the feature tests deterministic under the full CI suite.

Scope is limited to `SeedDemoData` (the command in the issue). The UI
installer (`seedSampleData()` + SSE stream), the CLI installer
(`unopim:install --with-demo-data`) and Docker all call
`DemoDataInstaller::seed()` directly and are unchanged — they run on a
fresh DB during install.

## How To Test This?
1. On a seeded instance, run `php artisan unopim:install:demo-data` →
   prints `Demo data is already seeded — nothing to do.`, exits 0, no
   prompt, nothing deleted.
2. Set `APP_ENV=production`. Run `php artisan unopim:install:demo-data
   --force` → the data-loss warning + `APPLICATION IN PRODUCTION` Yes/No
   still appear (force does **not** skip it); answer **no** → cancels,
   nothing changed.
3. Set `APP_ENV=local`. Run `php artisan unopim:install:demo-data
   --force` → prints the warning, then seeds (no Yes/No prompt).
4. `vendor/bin/pest packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php`

## Screenshots
N/A (CLI change)

## Checklist
- [x] `vendor/bin/pest` passes locally (8/8 for the changed command)
- [x] `vendor/bin/pint --test` reports no style issues
- [ ] Tailwind classes are reordered (N/A — no UI)
- [ ] New user-facing strings use translation keys (all 33 locales) — console messages are hardcoded English, matching the command's existing strings
- [ ] Target branch is `master` (unless a maintainer requested a backport)

