### PR TITLE
fixed: Confirm and guard demo-data seeding to prevent data loss

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
+++ b/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
@@ -21,7 +21,7 @@ class SeedDemoData extends Command
      * @var string
      */
     protected $signature = 'unopim:install:demo-data
-        { --force : Re-seed even when demo data is already present. }';
+        { --force : Re-seed even when demo data is already present (production still requires confirmation). }';
 
     /**
      * The console command description.
@@ -35,9 +35,29 @@ class SeedDemoData extends Command
      */
     public function handle(DemoDataInstaller $installer): int
     {
+        $force = (bool) $this->option('force');
+
+        if (! $force && $installer->isAlreadySeeded()) {
+            $this->info('Demo data is already seeded — nothing to do. Re-run with --force to re-seed.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->warn('This deletes existing products, categories, channels, attributes, families and core config, then loads demo data.');
+
+        if ($this->getLaravel()->environment('production')) {
+            $this->components->alert('Application In Production');
+
+            if (! $this->components->confirm('Are you sure you want to run this command?', false)) {
+                $this->components->warn('Command cancelled.');
+
+                return self::FAILURE;
+            }
+        }
+
         $result = $installer->seed(
             fn (string $message) => $this->warn('Step: '.$message),
-            (bool) $this->option('force'),
+            $force,
         );
 
         if (! ($result['success'] ?? false)) {

--- a/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
+++ b/packages/Webkul/Installer/src/Console/Commands/SeedDemoData.php
@@ -21,7 +21,7 @@ class SeedDemoData extends Command
      * @var string
      */
     protected $signature = 'unopim:install:demo-data
-        { --force : Re-seed even when demo data is already present (production still requires confirmation). }';
+        { --force : Re-seed even when demo data is already present. }';
 
     /**
      * The console command description.

--- a/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
+++ b/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
@@ -104,17 +104,23 @@ class DemoDataInstaller
     }
 
     /**
-     * Returns true when demo data is already present in the database.
+     * Returns true when demo data — or any operator-created catalog data —
+     * is already present in the database.
      *
-     * Probes for any non-root category — the base installer only
-     * creates the root row, while CategoryDemoTableSeeder inserts the
-     * full demo tree under it. A child category therefore proves the
-     * demo pipeline has already run.
+     * The seeders delete products, the demo category tree, and the full
+     * demo_extras table set (channels, attributes, families, core config),
+     * so the guard probes every signal that proves the DB is no longer a
+     * bare base install: a product, a non-root category, or an attribute
+     * family / channel beyond the single `default` row the base installer
+     * ships. Any of these means re-seeding would destroy real data.
      */
     public function isAlreadySeeded(): bool
     {
         try {
-            return DB::table('categories')->whereNotNull('parent_id')->exists();
+            return DB::table('products')->exists()
+                || DB::table('categories')->whereNotNull('parent_id')->exists()
+                || DB::table('attribute_families')->where('code', '!=', 'default')->exists()
+                || DB::table('channels')->where('code', '!=', 'default')->exists();
         } catch (Throwable) {
             // Table missing / DB not migrated yet → treat as not seeded
             // so the caller can decide how to handle the failure mode.

--- a/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
+++ b/packages/Webkul/Installer/src/Helpers/DemoDataInstaller.php
@@ -104,15 +104,7 @@ class DemoDataInstaller
     }
 
     /**
-     * Returns true when demo data — or any operator-created catalog data —
-     * is already present in the database.
-     *
-     * The seeders delete products, the demo category tree, and the full
-     * demo_extras table set (channels, attributes, families, core config),
-     * so the guard probes every signal that proves the DB is no longer a
-     * bare base install: a product, a non-root category, or an attribute
-     * family / channel beyond the single `default` row the base installer
-     * ships. Any of these means re-seeding would destroy real data.
+     * Check if demo or operator-created catalog data already exists.
      */
     public function isAlreadySeeded(): bool
     {
@@ -129,10 +121,7 @@ class DemoDataInstaller
     }
 
     /**
-     * Recalculate product completeness synchronously. The
-     * `unopim:completeness:recalculate` command dispatches queue jobs,
-     * so the sync driver is forced while it runs to guarantee work
-     * lands before the installer finishes.
+     * Recalculate product completeness synchronously.
      */
     protected function recalculateCompleteness(): void
     {

--- a/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
+++ b/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
@@ -2,71 +2,159 @@
 
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
-describe('unopim:install:demo-data (issue #794)', function () {
-    it('exits 0 and surfaces every step message when seeding succeeds', function () {
-        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
-        {
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                ($reporter ?? static fn () => null)('Seeding demo extras...');
-                ($reporter ?? static fn () => null)('Seeding demo categories...');
+/**
+ * Stubs DemoDataInstaller so the command can be exercised without a real
+ * database. $seedCalled / $forceSeen let a test assert whether (and how)
+ * seeding was invoked, which is how we prove the confirmation gate blocks
+ * a destructive re-seed when the operator declines. $alreadySeeded drives
+ * the idempotency short-circuit.
+ */
+function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen, bool $alreadySeeded = false): void
+{
+    app()->instance(DemoDataInstaller::class, new class($result, $seedCalled, $forceSeen, $alreadySeeded) extends DemoDataInstaller
+    {
+        public function __construct(
+            private array $result,
+            private bool &$seedCalled,
+            private bool &$forceSeen,
+            private bool $alreadySeeded,
+        ) {}
 
-                return ['success' => true];
-            }
-        });
+        public function isAlreadySeeded(): bool
+        {
+            return $this->alreadySeeded;
+        }
+
+        public function seed(?Closure $reporter = null, bool $force = false): array
+        {
+            $this->seedCalled = true;
+            $this->forceSeen = $force;
+
+            ($reporter ?? static fn () => null)('Seeding demo extras...');
+            ($reporter ?? static fn () => null)('Seeding demo categories...');
+
+            return $this->result;
+        }
+    });
+}
+
+describe('unopim:install:demo-data (issue #975 — destructive re-seed guard)', function () {
+    it('warns and seeds without a prompt in a non-production env', function () {
+        app()['env'] = 'local';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
 
         $this->artisan('unopim:install:demo-data')
-            ->expectsOutputToContain('Seeding demo extras...')
-            ->expectsOutputToContain('Seeding demo categories...')
+            ->expectsOutputToContain('This deletes existing products')
             ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeFalse();
     });
 
     it('exits non-zero and prints the seeder error when seeding fails', function () {
-        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
-        {
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                return ['success' => false, 'error' => 'JSON missing'];
-            }
-        });
+        app()['env'] = 'local';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => false, 'error' => 'JSON missing'], $seedCalled, $forceSeen);
 
         $this->artisan('unopim:install:demo-data')
             ->expectsOutputToContain('Failed to seed sample data: JSON missing')
             ->assertExitCode(1);
     });
 
-    it('exits 0 with the "already seeded" message and skips work when demo data is present', function () {
-        app()->instance(DemoDataInstaller::class, new class extends DemoDataInstaller
-        {
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                return ['success' => true, 'skipped' => true];
-            }
-        });
+    it('shows the already-seeded message and skips when data exists and --force is absent', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
 
         $this->artisan('unopim:install:demo-data')
             ->expectsOutputToContain('Demo data is already seeded')
             ->assertExitCode(0);
+
+        expect($seedCalled)->toBeFalse();
     });
 
-    it('forwards --force to the installer so a re-seed runs', function () {
+    it('re-seeds already-seeded data with --force in a non-production env', function () {
+        app()['env'] = 'local';
+
+        $seedCalled = false;
         $forceSeen = false;
-        app()->instance(DemoDataInstaller::class, new class($forceSeen) extends DemoDataInstaller
-        {
-            public function __construct(private bool &$forceSeen) {}
-
-            public function seed(?Closure $reporter = null, bool $force = false): array
-            {
-                $this->forceSeen = $force;
-
-                return ['success' => true];
-            }
-        });
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
 
         $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsOutputToContain('This deletes existing products')
+            ->expectsOutputToContain('Sample products seeded successfully.')
             ->assertExitCode(0);
 
-        expect($forceSeen)->toBeTrue();
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeTrue();
+    });
+
+    it('aborts in production when the operator declines the confirmation', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
+            ->assertExitCode(1);
+
+        expect($seedCalled)->toBeFalse();
+    });
+
+    it('proceeds in production when the operator confirms', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen);
+
+        $this->artisan('unopim:install:demo-data')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->expectsOutputToContain('Sample products seeded successfully.')
+            ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue();
+    });
+
+    it('still requires confirmation in production even with --force, and aborts on decline', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
+            ->assertExitCode(1);
+
+        expect($seedCalled)->toBeFalse();
+    });
+
+    it('re-seeds in production with --force once the operator confirms', function () {
+        app()['env'] = 'production';
+
+        $seedCalled = false;
+        $forceSeen = false;
+        fakeDemoInstaller(['success' => true], $seedCalled, $forceSeen, alreadySeeded: true);
+
+        $this->artisan('unopim:install:demo-data', ['--force' => true])
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->expectsOutputToContain('Sample products seeded successfully.')
+            ->assertExitCode(0);
+
+        expect($seedCalled)->toBeTrue()
+            ->and($forceSeen)->toBeTrue();
     });
 });

--- a/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
+++ b/packages/Webkul/Installer/tests/Feature/SeedDemoDataCommandTest.php
@@ -3,11 +3,7 @@
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
 /**
- * Stubs DemoDataInstaller so the command can be exercised without a real
- * database. $seedCalled / $forceSeen let a test assert whether (and how)
- * seeding was invoked, which is how we prove the confirmation gate blocks
- * a destructive re-seed when the operator declines. $alreadySeeded drives
- * the idempotency short-circuit.
+ * Stub DemoDataInstaller so the command can be tested without a database.
  */
 function fakeDemoInstaller(array $result, bool &$seedCalled, bool &$forceSeen, bool $alreadySeeded = false): void
 {


### PR DESCRIPTION
Backport  #503

`unopim:install:demo-data` silently wiped existing catalogue data on re-seed. It now skips when already seeded, warns before replacing data, and requires an `APPLICATION IN PRODUCTION` confirmation. `--force` overrides only the idempotency skip, not the production confirm. Other install paths are unchanged.
