### PR TITLE
Fixed Index audits, skip empty translation audits, and fix history preview[2.1]

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Catalog/AttributeAuditTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/AttributeAuditTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeTranslation;
+use Webkul\Attribute\Repositories\AttributeRepository;
+use Webkul\Core\Models\Locale;
+
+describe('audits composite index', function () {
+    it('exists on the audits table covering (tags, history_id)', function () {
+        $index = collect(Schema::getIndexes('audits'))
+            ->firstWhere('name', 'audits_tags_history_id_index');
+
+        expect($index)->not->toBeNull();
+        expect($index['columns'])->toBe(['tags', 'history_id']);
+    });
+});
+
+describe('HistoryTrait::readyForAuditing for translatable models', function () {
+    it('reports an empty translation as not ready for auditing', function () {
+        $translation = new AttributeTranslation(['name' => '']);
+        $translation->setAuditEvent('created');
+
+        expect($translation->readyForAuditing())->toBeFalse();
+    });
+
+    it('reports a filled translation as ready for auditing', function () {
+        $translation = new AttributeTranslation(['name' => 'Size']);
+        $translation->setAuditEvent('created');
+
+        expect($translation->readyForAuditing())->toBeTrue();
+    });
+});
+
+describe('attribute creation audit records', function () {
+    beforeEach(function () {
+        $this->repository = app(AttributeRepository::class);
+        $this->attributeType = (new Attribute)->getMorphClass();
+        $this->translationType = (new AttributeTranslation)->getMorphClass();
+
+        if (Locale::where('status', 1)->count() < 2) {
+            Locale::where('status', 0)->orderBy('id')->take(2)->get()
+                ->each(fn ($locale) => $locale->update(['status' => 1]));
+        }
+
+        $this->activeLocales = Locale::where('status', 1)->orderBy('id')->get();
+    });
+
+    it('does not audit blank locale translations, only the filled one', function () {
+        $locales = $this->activeLocales;
+
+        $data = ['code' => 'audit_skip_empty_'.uniqid(), 'type' => 'text', 'ai_translate' => 0];
+
+        foreach ($locales as $index => $locale) {
+            $data[$locale->code] = ['name' => $index === 0 ? 'Filled Label' : ''];
+        }
+
+        $attribute = $this->repository->create($data);
+
+        expect(AttributeTranslation::where('attribute_id', $attribute->id)->count())
+            ->toBe($locales->count());
+
+        $translationAudits = DB::table('audits')
+            ->where('auditable_type', $this->translationType)
+            ->where('history_id', $attribute->id)
+            ->count();
+
+        expect($translationAudits)->toBe(1);
+    });
+
+    it('still audits the parent attribute even when every translation is empty', function () {
+        $locales = $this->activeLocales;
+
+        $data = ['code' => 'audit_attr_only_'.uniqid(), 'type' => 'text', 'ai_translate' => 0];
+
+        foreach ($locales as $locale) {
+            $data[$locale->code] = ['name' => ''];
+        }
+
+        $attribute = $this->repository->create($data);
+
+        $attributeAudits = DB::table('audits')
+            ->where('auditable_type', $this->attributeType)
+            ->where('history_id', $attribute->id)
+            ->count();
+
+        $translationAudits = DB::table('audits')
+            ->where('auditable_type', $this->translationType)
+            ->where('history_id', $attribute->id)
+            ->count();
+
+        expect($attributeAudits)->toBe(1);
+        expect($translationAudits)->toBe(0);
+    });
+
+    it('audits every translation that has a value', function () {
+        $locales = $this->activeLocales;
+
+        $data = ['code' => 'audit_filled_'.uniqid(), 'type' => 'text', 'ai_translate' => 0];
+
+        foreach ($locales as $locale) {
+            $data[$locale->code] = ['name' => 'Name '.$locale->code];
+        }
+
+        $attribute = $this->repository->create($data);
+
+        $translationAudits = DB::table('audits')
+            ->where('auditable_type', $this->translationType)
+            ->where('history_id', $attribute->id)
+            ->count();
+
+        expect($translationAudits)->toBe($locales->count());
+    });
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/AttributeHistoryViewTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/AttributeHistoryViewTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Webkul\Attribute\Repositories\AttributeRepository;
+use Webkul\HistoryControl\Http\Controllers\HistoryController;
+
+dataset('attribute types', [
+    'text', 'textarea', 'price', 'boolean', 'select', 'multiselect',
+    'datetime', 'date', 'image', 'gallery', 'file', 'checkbox',
+]);
+
+beforeEach(function () {
+    $this->repository = app(AttributeRepository::class);
+    $this->controller = app(HistoryController::class);
+});
+
+it('renders create-version history without crashing for every attribute type', function (string $type) {
+    $attribute = $this->repository->create([
+        'code'         => 'hist_'.$type.'_'.uniqid(),
+        'type'         => $type,
+        'ai_translate' => 0,
+    ]);
+
+    $response = $this->controller->getVersionHistoryView('attribute', $attribute->id, 1);
+
+    expect($response->getStatusCode())->toBe(200);
+
+    $data = json_decode($response->getContent(), true);
+
+    expect($data['version'])->toBe(1);
+    expect($data['versionHistory'])->toHaveKey('type');
+    expect($data['versionHistory'])->toHaveKey('code');
+    expect($data['versionHistory']['type']['new'])->not->toBe('');
+})->with('attribute types');
+
+it('filters empty and falsy-default noise fields for every attribute type', function (string $type) {
+    $attribute = $this->repository->create([
+        'code'         => 'noise_'.$type.'_'.uniqid(),
+        'type'         => $type,
+        'ai_translate' => 0,
+    ]);
+
+    $data = json_decode(
+        $this->controller->getVersionHistoryView('attribute', $attribute->id, 1)->getContent(),
+        true
+    );
+
+    expect($data['versionHistory'])->not->toHaveKey('validation');
+    expect($data['versionHistory'])->not->toHaveKey('regex_pattern');
+    expect($data['versionHistory'])->not->toHaveKey('ai_translate');
+})->with('attribute types');

--- a/packages/Webkul/Attribute/src/Presenters/AttributeHistoryPresenter.php
+++ b/packages/Webkul/Attribute/src/Presenters/AttributeHistoryPresenter.php
@@ -51,6 +51,11 @@ class AttributeHistoryPresenter implements HistoryPresenterInterface
 
     protected static function formatValue(string $fieldName, mixed $value): mixed
     {
+
+        if (is_array($value)) {
+            return '';
+        }
+
         if (in_array($fieldName, static::$booleanFields)) {
             return $value
                 ? trans('admin::app.catalog.attributes.create.yes')

--- a/packages/Webkul/Attribute/tests/Unit/Presenters/AttributeHistoryPresenterTest.php
+++ b/packages/Webkul/Attribute/tests/Unit/Presenters/AttributeHistoryPresenterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Webkul\Attribute\Presenters\AttributeHistoryPresenter;
+
+it('represents a created-event empty old value as blank without crashing', function () {
+    $result = AttributeHistoryPresenter::representValueForHistory([], 'text', 'type');
+
+    expect($result)->toHaveKey('type');
+    expect($result['type']['old'])->toBe('');
+    expect($result['type']['new'])->not->toBe('');
+});
+
+it('formats a boolean field with an empty old value as blank', function () {
+    $result = AttributeHistoryPresenter::representValueForHistory([], 1, 'is_required');
+
+    expect($result['is_required']['old'])->toBe('');
+    expect($result['is_required']['new'])->not->toBe('');
+});
+
+it('formats scalar old and new type values', function () {
+    $result = AttributeHistoryPresenter::representValueForHistory('text', 'textarea', 'type');
+
+    expect($result['type']['old'])->not->toBe('');
+    expect($result['type']['new'])->not->toBe('');
+});

--- a/packages/Webkul/HistoryControl/src/Database/Migrations/2024_08_16_173200_add_tags_history_id_index_to_audits.php
+++ b/packages/Webkul/HistoryControl/src/Database/Migrations/2024_08_16_173200_add_tags_history_id_index_to_audits.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The audit_before_insert trigger runs two queries on every INSERT that
+     * filter by (tags, history_id). Without an index these are full table
+     * scans, so audit-heavy operations (e.g. creating an attribute, which
+     * inserts one row per active locale) become extremely slow as the audits
+     * table grows. This composite index turns those scans into index lookups.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('audits') && ! $this->indexExists('audits', 'audits_tags_history_id_index')) {
+            Schema::table('audits', function (Blueprint $table) {
+                $table->index(['tags', 'history_id'], 'audits_tags_history_id_index');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('audits') && $this->indexExists('audits', 'audits_tags_history_id_index')) {
+            Schema::table('audits', function (Blueprint $table) {
+                $table->dropIndex('audits_tags_history_id_index');
+            });
+        }
+    }
+
+    /**
+     * Check whether an index exists (prefix-aware, mysql + pgsql).
+     */
+    private function indexExists(string $table, string $index): bool
+    {
+        $prefix = DB::getTablePrefix();
+
+        if (DB::getDriverName() === 'pgsql') {
+            return (bool) DB::select('SELECT 1 FROM pg_indexes WHERE indexname = ?', [$index]);
+        }
+
+        foreach (DB::select("SHOW INDEX FROM `{$prefix}{$table}`") as $row) {
+            if (($row->Key_name ?? null) === $index) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};

--- a/packages/Webkul/HistoryControl/src/Http/Controllers/HistoryController.php
+++ b/packages/Webkul/HistoryControl/src/Http/Controllers/HistoryController.php
@@ -134,6 +134,11 @@ class HistoryController extends Controller
             }
         }
 
+        $normalizedData['versionHistory'] = array_filter(
+            $normalizedData['versionHistory'],
+            fn ($entry) => ! empty($entry['old']) || ! empty($entry['new'])
+        );
+
         return $normalizedData;
     }
 

--- a/packages/Webkul/HistoryControl/src/Traits/HistoryTrait.php
+++ b/packages/Webkul/HistoryControl/src/Traits/HistoryTrait.php
@@ -10,7 +10,9 @@ use Webkul\Category\Models\CategoryProxy;
  */
 trait HistoryTrait
 {
-    use Auditable;
+    use Auditable {
+        readyForAuditing as protected auditableReadyForAuditing;
+    }
 
     /**
      * Transform the audit data.
@@ -62,5 +64,32 @@ trait HistoryTrait
     public function getPrimaryModelIdForHistory(): int
     {
         return $this->id;
+    }
+
+    /**
+     * Skip auditing when a model exposes only translatable history fields and
+     * all of them are empty (e.g. an AttributeTranslation row created for a
+     * locale the user left blank). Such rows carry no real history and would
+     * otherwise fire the audits trigger once per empty locale for nothing.
+     *
+     * {@inheritdoc}
+     */
+    public function readyForAuditing(): bool
+    {
+        if (! $this->auditableReadyForAuditing()) {
+            return false;
+        }
+
+        if (isset($this->historyTranslatableFields)) {
+            foreach (array_keys($this->historyTranslatableFields) as $field) {
+                if (filled($this->{$field})) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION


## Description
Creating an attribute returns a **504** on installs with a large `audits` table,
and viewing an attribute's **History** failed / showed noise.

**Root cause**
- `AttributeTranslation` and other translatable models use `HistoryTrait`, so
  creating one attribute writes one audit row per active locale. The
  `audit_before_insert` trigger runs two queries per insert filtering by
  `(tags, history_id)`, which was never indexed — every insert is a full table
  scan, so creation times out as `audits` grows.
- Blank locales still produced empty audit rows (noise + trigger load).
- The History version preview crashed ("Array to string conversion") on a
  *created* version because the old value is an empty array, and it listed
  empty/default fields (`validation`, `regex_pattern`, `ai_translate`).

**Changes**
1. Add composite index on `audits(tags, history_id)` (prefix-aware, idempotent,
   MySQL + PostgreSQL). The trigger's two lookups become index lookups
   (`EXPLAIN`: `type=ALL` → `type=ref`, `rows=1`).
2. Override OwenIt's `readyForAuditing()` in `HistoryTrait` to skip auditing a
   translatable model when all of its `historyTranslatableFields` are empty.
   Non-translatable models (Attribute, Product, Category, …) are unaffected.
3. Guard `AttributeHistoryPresenter::formatValue()` against array (empty old)
   values so the created-version history no longer 500s.
4. Drop history rows that are empty on both sides so the preview shows only
   meaningful changes.
5. Add Pest tests: audits index/behaviour, the presenter, and the history
   preview across every attribute type.

Measured on ~2.1M audit rows: one attribute create dropped from ~138s to ~1.9s;
audit inserts per create dropped from 51 to 2.

## How To Test This?
1. `vendor/bin/pest packages/Webkul/Admin/tests/Feature/Catalog/AttributeAuditTest.php`
2. `vendor/bin/pest packages/Webkul/Admin/tests/Feature/Catalog/AttributeHistoryViewTest.php`
3. Manually: Catalog → Attributes → Create Attribute → code + type + name → Save.
   Saves quickly even on a large audits table; open the **History** tab → view a
   version: it renders without error and omits empty fields.
4. `SHOW INDEX FROM audits;` shows `audits_tags_history_id_index (tags, history_id)`.


## Checklist
- [x] `vendor/bin/pest` passes locally (33 passed)
- [x] `vendor/bin/pint --test` reports no style issues
- [x] `php artisan unopim:translations:check` passes (256 locales, 100%)
- [x] Target branch is `2.1`
