### PR TITLE
Fixed   Accept uppercase image extensions (.JPG/.JPEG)

### DIFF
--- a/packages/Webkul/Core/src/Rules/FileMimeExtensionMatch.php
+++ b/packages/Webkul/Core/src/Rules/FileMimeExtensionMatch.php
@@ -37,7 +37,7 @@ class FileMimeExtensionMatch implements ValidationRule
             $extension = 'jpg';
         }
 
-        if (! (in_array($mimeType, $mimeTypes) && $value->guessExtension() === $extension)) {
+        if (! (in_array($mimeType, $mimeTypes) && $value->guessExtension() === strtolower($extension))) {
             $fail(trans('core::validation.file-mime-extension-mismatch', ['extension' => $extension, 'mimeType' => $mimeType]));
 
             return;

--- a/packages/Webkul/Core/src/Rules/FileOrImageValidValue.php
+++ b/packages/Webkul/Core/src/Rules/FileOrImageValidValue.php
@@ -94,7 +94,7 @@ class FileOrImageValidValue implements ValidationRule
     {
         $extension = $value instanceof UploadedFile ? $value->getClientOriginalExtension() : $value->getExtension();
 
-        if ($this->allowedExtensions && ! in_array($extension, $this->allowedExtensions, true)) {
+        if ($this->allowedExtensions && ! in_array(strtolower($extension), $this->allowedExtensions, true)) {
             $fail('validation.extensions')->translate(['values' => implode(', ', $this->allowedExtensions)]);
 
             return false;


### PR DESCRIPTION
## Description
Uploading a valid image whose filename has an UPPERCASE extension
(e.g. `IMG_1234.JPG`, `PHOTO.JPEG` — common for camera/iPhone exports)
was rejected with "The image field must have one of the following
extensions...", even though the file was a genuine image.

**Root cause:** `IMAGE_ALLOWED_EXTENSIONS` is lowercase and the extension
comparisons were case-sensitive, so `"JPG" !== "jpg"`.

This affected two rules — the second is why a single-line fix would have
been incomplete (the error would have just moved from `validation.extensions`
to `file-mime-extension-mismatch`):

- `packages/Webkul/Core/src/Rules/FileOrImageValidValue.php` — lowercase
  the extension in the allowed-extensions `in_array()` check.
- `packages/Webkul/Core/src/Rules/FileMimeExtensionMatch.php` — lowercase
  the extension in the `guessExtension()` comparison.

Lowercasing is applied **only inside the comparisons**, so:
- already-lowercase uploads behave identically (zero behavior change),
- error messages and mime lookups are untouched,
- the mime-vs-extension security check still runs — a file whose real
  type doesn't match its extension is still rejected.

Impacted upload paths: product image/file attributes, category image
fields, attribute-option swatches, user profile image, and TinyMCE
rich-text uploads.

## How To Test This?
1. Take any valid `.jpg` image and rename the extension to uppercase `.JPG`.
2. Upload it to a product Image attribute → it is now accepted.
3. Repeat with `.JPEG` and `.PNG` → accepted.
4. Confirm `.jpg` (lowercase) still uploads as before.
5. Negative check: rename a non-image file to `.JPG` (mismatched real
   type) → still rejected by the mime/extension check.


## Checklist
- [x] `vendor/bin/pest` passes locally
- [x] `vendor/bin/pint --test` reports no style issues
- [ ] Tailwind classes are reordered
- [ ] New user-facing strings use translation keys (all 33 locales)
- [x] Target branch is `master`

