### PR TITLE
Preselect application locale and currency from .env during reinstallation

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -7,13 +7,13 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Webkul\Core\ElasticSearch;
+use Webkul\Installer\Console\Prompts\PreselectedSearchPrompt;
 use Webkul\Installer\Database\Seeders\DatabaseSeeder as UnoPimDatabaseSeeder;
 use Webkul\Installer\Events\ComposerEvents;
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
 use function Laravel\Prompts\multisearch;
 use function Laravel\Prompts\password;
-use function Laravel\Prompts\search;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
@@ -645,16 +645,39 @@ class Installer extends Command
      */
     protected function updateEnvChoice(string $key, string $question, array $choices)
     {
-        $choice = search(
+        $default = $this->getEnvChoiceDefault($key, $choices);
+
+        $choice = (new PreselectedSearchPrompt(
             label: $question,
             options: fn (string $value) => $this->filterChoices($choices, $value),
             placeholder: 'Type to search...',
             scroll: 10,
-        );
+            hint: $default !== null
+                ? 'Press Enter to keep the current value, or Backspace to clear it and search.'
+                : '',
+            defaultValue: $default,
+        ))->prompt();
 
         $this->envUpdate($key, $choice);
 
         return $choice;
+    }
+
+    /**
+     * Get the current `.env` value to pre-select, or null when it is missing or
+     * no longer one of the available options.
+     */
+    protected function getEnvChoiceDefault(string $key, array $choices): ?string
+    {
+        $current = $this->getEnvAtRuntime($key);
+
+        if (! is_string($current) || $current === '') {
+            return null;
+        }
+
+        $current = trim($current, "\"'");
+
+        return array_key_exists($current, $choices) ? $current : null;
     }
 
     /**

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Webkul\Core\ElasticSearch;
-use Webkul\Installer\Console\Prompts\PreselectedSearchPrompt;
+use Webkul\Installer\Console\Prompts\PreselectedSearchValue;
 use Webkul\Installer\Database\Seeders\DatabaseSeeder as UnoPimDatabaseSeeder;
 use Webkul\Installer\Events\ComposerEvents;
 use Webkul\Installer\Helpers\DemoDataInstaller;
@@ -647,7 +647,7 @@ class Installer extends Command
     {
         $default = $this->getEnvChoiceDefault($key, $choices);
 
-        $choice = (new PreselectedSearchPrompt(
+        $choice = (new PreselectedSearchValue(
             label: $question,
             options: fn (string $value) => $this->filterChoices($choices, $value),
             placeholder: 'Type to search...',

--- a/packages/Webkul/Installer/src/Console/Prompts/PreselectedSearchPrompt.php
+++ b/packages/Webkul/Installer/src/Console/Prompts/PreselectedSearchPrompt.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Webkul\Installer\Console\Prompts;
+
+use Closure;
+use Laravel\Prompts\SearchPrompt;
+
+/**
+ * A searchable prompt that pre-selects an existing value so the user can keep
+ * it by pressing Enter, while the normal search still works on any key press.
+ */
+class PreselectedSearchPrompt extends SearchPrompt
+{
+    public function __construct(
+        string $label,
+        Closure $options,
+        string $placeholder = '',
+        int $scroll = 5,
+        mixed $validate = null,
+        string $hint = '',
+        bool|string $required = true,
+        ?Closure $transform = null,
+        protected int|string|null $defaultValue = null,
+    ) {
+        parent::__construct(
+            label: $label,
+            options: $options,
+            placeholder: $placeholder,
+            scroll: $scroll,
+            validate: $validate,
+            hint: $hint,
+            required: $required,
+            transform: $transform,
+        );
+
+        $this->preselectDefault();
+    }
+
+    protected function preselectDefault(): void
+    {
+        if ($this->defaultValue === null || $this->defaultValue === '') {
+            return;
+        }
+
+        $query = (string) $this->defaultValue;
+
+        $matches = ($this->options)($query);
+
+        $keys = array_is_list($matches) ? $matches : array_keys($matches);
+
+        $index = array_search($this->defaultValue, $keys, true);
+
+        if ($index === false) {
+            return;
+        }
+
+        $this->typedValue = $query;
+        $this->cursorPosition = mb_strlen($query);
+        $this->matches = $matches;
+
+        $this->highlight($index);
+    }
+
+    /**
+     * Prompts keys its renderer registry on the exact class name with no parent
+     * fallback, so reuse the renderer registered for the parent SearchPrompt.
+     */
+    protected function getRenderer(): callable
+    {
+        $renderer = static::$themes[static::$theme][SearchPrompt::class]
+            ?? static::$themes['default'][SearchPrompt::class];
+
+        return new $renderer($this);
+    }
+}

--- a/packages/Webkul/Installer/src/Console/Prompts/PreselectedSearchValue.php
+++ b/packages/Webkul/Installer/src/Console/Prompts/PreselectedSearchValue.php
@@ -9,7 +9,7 @@ use Laravel\Prompts\SearchPrompt;
  * A searchable prompt that pre-selects an existing value so the user can keep
  * it by pressing Enter, while the normal search still works on any key press.
  */
-class PreselectedSearchPrompt extends SearchPrompt
+class PreselectedSearchValue extends SearchPrompt
 {
     public function __construct(
         string $label,

--- a/packages/Webkul/Installer/tests/Feature/InstallerPreselectEnvChoiceTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerPreselectEnvChoiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+use Webkul\Installer\Console\Commands\Installer;
+use Webkul\Installer\Console\Prompts\PreselectedSearchPrompt;
+
+function installerLocalePrompt(?string $default): PreselectedSearchPrompt
+{
+    $locales = [
+        'en_US' => 'English (United States)',
+        'fr_FR' => 'French (France)',
+        'de_DE' => 'German (Germany)',
+    ];
+
+    return new PreselectedSearchPrompt(
+        label: 'Please select the default application locale',
+        options: function (string $value) use ($locales) {
+            $value = strtolower(trim($value));
+
+            if ($value === '') {
+                return $locales;
+            }
+
+            return array_filter(
+                $locales,
+                fn (string $label, string $key) => str_contains(strtolower($label), $value)
+                    || str_contains(strtolower($key), $value),
+                ARRAY_FILTER_USE_BOTH
+            );
+        },
+        scroll: 10,
+        defaultValue: $default,
+    );
+}
+
+afterEach(function () {
+    Prompt::interactive(false);
+});
+
+describe('PreselectedSearchPrompt', function () {
+    it('pre-selects the existing .env value and keeps it when Enter is pressed', function () {
+        PreselectedSearchPrompt::fake([Key::ENTER]);
+
+        expect(installerLocalePrompt('en_US')->prompt())->toBe('en_US');
+    });
+
+    it('lets the user clear the default with Backspace and search a different value', function () {
+        PreselectedSearchPrompt::fake([
+            Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE,
+            'fr_FR',
+            Key::DOWN,
+            Key::ENTER,
+        ]);
+
+        expect(installerLocalePrompt('en_US')->prompt())->toBe('fr_FR');
+    });
+
+    it('shows an empty searchable prompt when no default is configured', function () {
+        PreselectedSearchPrompt::fake(['fr_FR', Key::DOWN, Key::ENTER]);
+
+        expect(installerLocalePrompt(null)->prompt())->toBe('fr_FR');
+    });
+
+    it('falls back to an empty prompt when the .env value is no longer a valid option', function () {
+        PreselectedSearchPrompt::fake(['fr_FR', Key::DOWN, Key::ENTER]);
+
+        expect(installerLocalePrompt('zz_ZZ')->prompt())->toBe('fr_FR');
+    });
+});
+
+describe('Installer::getEnvChoiceDefault', function () {
+    $resolve = function (string $envValue, array $choices): ?string {
+        $cmd = new class extends Installer
+        {
+            public static string $stubValue = '';
+
+            protected static function getEnvAtRuntime(string $key): string|bool
+            {
+                return self::$stubValue;
+            }
+        };
+
+        $cmd::$stubValue = $envValue;
+
+        return (new ReflectionMethod($cmd, 'getEnvChoiceDefault'))
+            ->invoke($cmd, 'APP_LOCALE', $choices);
+    };
+
+    it('returns the existing value when it is a valid option', function () use ($resolve) {
+        expect($resolve('en_US', ['en_US' => 'English (United States)']))->toBe('en_US');
+    });
+
+    it('returns null when the existing value is not a valid option', function () use ($resolve) {
+        expect($resolve('zz_ZZ', ['en_US' => 'English (United States)']))->toBeNull();
+    });
+
+    it('returns null when no value is configured', function () use ($resolve) {
+        expect($resolve('', ['en_US' => 'English (United States)']))->toBeNull();
+    });
+
+    it('strips surrounding quotes before matching options', function () use ($resolve) {
+        expect($resolve('"en_US"', ['en_US' => 'English (United States)']))->toBe('en_US');
+    });
+});

--- a/packages/Webkul/Installer/tests/Feature/InstallerPreselectEnvChoiceTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerPreselectEnvChoiceTest.php
@@ -3,9 +3,9 @@
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Webkul\Installer\Console\Commands\Installer;
-use Webkul\Installer\Console\Prompts\PreselectedSearchPrompt;
+use Webkul\Installer\Console\Prompts\PreselectedSearchValue;
 
-function installerLocalePrompt(?string $default): PreselectedSearchPrompt
+function installerLocalePrompt(?string $default): PreselectedSearchValue
 {
     $locales = [
         'en_US' => 'English (United States)',
@@ -13,7 +13,7 @@ function installerLocalePrompt(?string $default): PreselectedSearchPrompt
         'de_DE' => 'German (Germany)',
     ];
 
-    return new PreselectedSearchPrompt(
+    return new PreselectedSearchValue(
         label: 'Please select the default application locale',
         options: function (string $value) use ($locales) {
             $value = strtolower(trim($value));
@@ -38,15 +38,15 @@ afterEach(function () {
     Prompt::interactive(false);
 });
 
-describe('PreselectedSearchPrompt', function () {
+describe('PreselectedSearchValue', function () {
     it('pre-selects the existing .env value and keeps it when Enter is pressed', function () {
-        PreselectedSearchPrompt::fake([Key::ENTER]);
+        PreselectedSearchValue::fake([Key::ENTER]);
 
         expect(installerLocalePrompt('en_US')->prompt())->toBe('en_US');
     });
 
     it('lets the user clear the default with Backspace and search a different value', function () {
-        PreselectedSearchPrompt::fake([
+        PreselectedSearchValue::fake([
             Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE,
             'fr_FR',
             Key::DOWN,
@@ -57,13 +57,13 @@ describe('PreselectedSearchPrompt', function () {
     });
 
     it('shows an empty searchable prompt when no default is configured', function () {
-        PreselectedSearchPrompt::fake(['fr_FR', Key::DOWN, Key::ENTER]);
+        PreselectedSearchValue::fake(['fr_FR', Key::DOWN, Key::ENTER]);
 
         expect(installerLocalePrompt(null)->prompt())->toBe('fr_FR');
     });
 
     it('falls back to an empty prompt when the .env value is no longer a valid option', function () {
-        PreselectedSearchPrompt::fake(['fr_FR', Key::DOWN, Key::ENTER]);
+        PreselectedSearchValue::fake(['fr_FR', Key::DOWN, Key::ENTER]);
 
         expect(installerLocalePrompt('zz_ZZ')->prompt())->toBe('fr_FR');
     });


### PR DESCRIPTION
Problem

  When re-running the installer on an existing instance, the locale and
  currency prompts always opened empty — users had to reselect values that
  were already configured in .env, risking accidental changes.

  Change

  The installer now reads the existing APP_LOCALE / APP_CURRENCY from .env and
  shows them as the preselected option. Press Enter to keep the current
  value, or Backspace to clear and search for a different one. Search behavior
  is unchanged.

  - New PreselectedSearchPrompt (extends Laravel Prompts' SearchPrompt) —
  seeds the current value as the highlighted default; reverts to normal search
  on any keypress.
  - updateEnvChoice() now resolves the existing .env value via
  getEnvChoiceDefault() and passes it as the default.
  - Missing/stale values fall back gracefully to an empty prompt (no crash).

  Tests

  Added InstallerPreselectEnvChoiceTest covering: keep-on-Enter,
  change-via-Backspace, no-default, invalid/stale value, and .env resolution.
  Verified end-to-end against the real updateEnvChoice flow.