### PR TITLE
fix(installer): restore composerProbePaths() — fixes 2 CI Pest failures on master

### DIFF
--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -754,16 +754,32 @@ class InstallerController extends Controller
     }
 
     /**
+     * Locations probed for a composer executable, in priority order.
+     *
+     * @return array<int, string>
+     */
+    protected function composerProbePaths(): array
+    {
+        return [
+            '/usr/local/bin/composer',
+            '/usr/bin/composer',
+            base_path('composer.phar'),
+            base_path('bin/composer/composer.phar'),
+        ];
+    }
+
+    /**
      * Resolve the composer executable as a process-argument prefix.
      *
      * A web process PATH may not include composer, so probe common locations
-     * and a project-local composer.phar before falling back to bare "composer".
+     * and the project-local / bundled composer.phar files before falling
+     * back to bare "composer".
      *
      * @return array<int, string>
      */
     protected function resolveComposerBinary(): array
     {
-        foreach (['/usr/local/bin/composer', '/usr/bin/composer', base_path('composer.phar')] as $path) {
+        foreach ($this->composerProbePaths() as $path) {
             if (is_file($path)) {
                 return str_ends_with($path, '.phar') ? [PHP_BINARY, $path] : [$path];
             }


### PR DESCRIPTION
## Problem

Master's Pest CI is red — **2 failures**, both `InstallerController::resolveComposerBinary`:
- `it probes the bundled bin/composer/composer.phar`
- `it returns a php + phar argument prefix when only the bundled phar exists`

(1981 passed, 2 failed.)

## Cause

The 2.1 convergence merge (#525) brought in 2.1's `InstallerControllerTest`, which asserts:
- a `composerProbePaths()` method exists, and
- it includes `base_path('bin/composer/composer.phar')`.

But the merge kept **master's** `InstallerController`, which inlined the probe list inside `resolveComposerBinary()` and had no `composerProbePaths()` method → the test's `ReflectionMethod($controller, 'composerProbePaths')` blew up. (A test↔code mismatch from resolving that conflict in master's favor.)

## Fix

Extract the probe list into `composerProbePaths()` (adding the bundled `bin/composer/composer.phar` path) and have `resolveComposerBinary()` iterate it — exactly 2.1's shape, which the test was written against. Pure refactor; runtime behaviour unchanged apart from the extra bundled-phar probe.

## Verification
- ✅ `InstallerControllerTest` → **7/7 pass** (the 2 failing tests now green)
- ✅ Pint clean
- ✅ Confirmed via CI log these were the **only** 2 failures in the master Pest run

Greens the Pest job on master.