### PR TITLE
feat(docker): add OpenLiteSpeed profile with HTTP/3 + QUIC

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -81,6 +81,11 @@ COMPOSE_PROJECT_NAME=unopim
 
 # Host-side ports (change these if you have port conflicts)
 APP_PORT=8000
+# HTTPS host port — only used by the OpenLiteSpeed profile
+# (docker-compose.litespeed.yml). Serves HTTP/2 + HTTP/3 (QUIC) over TLS.
+# NOTE: browsers auto-upgrade to HTTP/3 only when this is 443; on any other
+# port they stay on HTTP/2 (LiteSpeed advertises the listener port via alt-svc).
+APP_SSL_PORT=8443
 FORWARD_DB_PORT=3306
 FORWARD_REDIS_PORT=6379
 FORWARD_ES_PORT=9200

--- a/docker-compose.litespeed.yml
+++ b/docker-compose.litespeed.yml
@@ -1,0 +1,90 @@
+# =============================================================================
+# UnoPim OpenLiteSpeed Override
+# =============================================================================
+# Replaces Nginx + PHP-FPM with OpenLiteSpeed + LSPHP (single container).
+# Adds native HTTP/3 + QUIC (TLS) on top of plain HTTP.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.litespeed.yml up -d
+#
+# Or set in .env:
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.litespeed.yml
+#
+# Endpoints:
+#   http://localhost:${APP_PORT:-8000}/admin            (HTTP/1.1, HTTP/2)
+#   https://localhost:${APP_SSL_PORT:-8443}/admin       (HTTP/2 + HTTP/3 QUIC)
+#
+# HTTP/3 needs UDP — the SSL port is published on both TCP and UDP.
+# A self-signed cert is generated at first start (browser warning expected) —
+# it is NOT baked into the image. For real certs, mount them over
+# /usr/local/lsws/conf/cert.
+#
+# ─── Troubleshooting ────────────────────────────────────────────────────────
+# • HTTP/3 not engaging in the browser?
+#     OpenLiteSpeed advertises HTTP/3 on the listener port (alt-svc h3=":443").
+#     Browsers only auto-upgrade to h3 when the PUBLIC port is 443. On a custom
+#     port (e.g. 8443) they stay on HTTP/2. For a real h3 test, publish 443:
+#       APP_SSL_PORT=443  (and run behind it / as root-capable host)
+#
+# • Every page returns 503? Check the OLS error log inside the container:
+#     docker compose exec unopim-litespeed tail /usr/local/lsws/logs/error.log
+#   If it shows "cgidSuEXEC failed":
+#     OpenLiteSpeed launches PHP through its lscgid/suEXEC helper. A few host
+#     kernels / container runtimes reject that privileged launch (seen on some
+#     Linux 6.x + container setups), so LSPHP never starts. This is a host-level
+#     incompatibility, not an UnoPim issue. Workarounds:
+#       - Run this profile on a different Docker host, OR
+#       - Use the default Nginx or the Apache profile instead (neither uses
+#         suEXEC):  docker compose up -d
+#                   docker compose -f docker-compose.yml -f docker-compose.apache.yml up -d
+#
+# • Can't edit your checkout after running this profile?
+#     The bind mount means the entrypoint chowns storage/ and bootstrap/cache/
+#     on the HOST to the LSPHP worker user (nobody, uid 65534). Restore with:
+#       sudo chown -R "$(id -u):$(id -g)" storage bootstrap/cache
+# =============================================================================
+
+services:
+  # Disable Nginx and FPM (replaced by OpenLiteSpeed)
+  unopim-nginx:
+    deploy:
+      replicas: 0
+
+  unopim-fpm:
+    deploy:
+      replicas: 0
+
+  # OpenLiteSpeed + LSPHP (replaces Nginx + FPM)
+  unopim-litespeed:
+    build:
+      context: .
+      dockerfile: dockerfiles/litespeed.Dockerfile
+    volumes:
+      - .:/var/www/html
+    ports:
+      - "${APP_PORT:-8000}:80"
+      - "${APP_SSL_PORT:-8443}:443"
+      - "${APP_SSL_PORT:-8443}:443/udp"
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      APP_URL: "http://localhost:${APP_PORT:-8000}"
+      DB_HOST: unopim-mysql
+      DB_PORT: 3306
+      REDIS_HOST: unopim-redis
+      REDIS_PORT: 6379
+      ELASTICSEARCH_HOST: unopim-elasticsearch:9200
+      MAIL_HOST: unopim-mailpit
+      MAIL_PORT: 1025
+    depends_on:
+      unopim-mysql:
+        condition: service_healthy
+      unopim-redis:
+        condition: service_healthy
+      unopim-elasticsearch:
+        condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@
 # Apache alternative:
 #   docker compose -f docker-compose.yml -f docker-compose.apache.yml up -d
 #
+# OpenLiteSpeed alternative (adds native HTTP/3 + QUIC):
+#   docker compose -f docker-compose.yml -f docker-compose.litespeed.yml up -d
+#
 # Port conflicts? Override FORWARD_* variables in .env
 #
 # =============================================================================

--- a/dockerfiles/litespeed-entrypoint.sh
+++ b/dockerfiles/litespeed-entrypoint.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -e
+
+LOCK_FILE="/var/www/html/storage/unopim.lock"
+
+# Ensure APP_KEY is set before any artisan command runs.
+# Auto-generates for dev/local; fails fast in production (never silently regenerate).
+source /var/www/html/dockerfiles/lib/ensure-app-key.sh
+ensure_app_key
+
+# ─── First-time setup ───────────────────────────────────────────────
+if [ ! -f "$LOCK_FILE" ]; then
+
+    # Check if database already has data (lock file deleted but DB intact)
+    DB_INITIALIZED=0
+    if php artisan migrate:status --no-interaction >/dev/null 2>&1; then
+        DB_INITIALIZED=1
+    fi
+
+    if [ "$DB_INITIALIZED" -eq 1 ]; then
+        echo "→ Existing database detected. Recreating lock file..."
+        echo "→ Checking for pending migrations..."
+        php artisan migrate --force --no-interaction 2>/dev/null || true
+        echo "→ Linking storage..."
+        php artisan storage:link 2>/dev/null || true
+        touch "$LOCK_FILE"
+    else
+        echo "══════════════════════════════════════════════"
+        echo "  UnoPim: First-time setup"
+        echo "══════════════════════════════════════════════"
+
+        echo "→ Installing Composer dependencies..."
+        composer install --no-interaction --optimize-autoloader --no-dev
+
+        # Sync APP_URL with APP_PORT if port was changed
+        if [ -n "$APP_PORT" ] && [ "$APP_PORT" != "8000" ] && [ -f /var/www/html/.env ]; then
+            sed -i "s|APP_URL=http://localhost:8000|APP_URL=http://localhost:${APP_PORT}|" /var/www/html/.env
+        fi
+
+        echo "→ Running database migrations..."
+        php artisan migrate --force
+
+        echo "→ Seeding database..."
+        php artisan db:seed --force
+
+        echo "→ Linking storage..."
+        php artisan storage:link 2>/dev/null || true
+
+        # Build Elasticsearch indexes if enabled
+        if [ "${ELASTICSEARCH_ENABLED:-false}" = "true" ]; then
+            echo "→ Waiting for Elasticsearch to be ready..."
+            ES_HOST="${ELASTICSEARCH_HOST:-unopim-elasticsearch:9200}"
+            # Normalize: support both "host:port" and "http://host:port"
+            case "$ES_HOST" in
+                http://*|https://*) ES_URL="$ES_HOST" ;;
+                *) ES_URL="http://${ES_HOST}" ;;
+            esac
+            ES_READY=0
+            for i in $(seq 1 30); do
+                if curl -sf "${ES_URL}/_cluster/health?wait_for_status=yellow&timeout=5s" >/dev/null 2>&1; then
+                    ES_READY=1
+                    echo "→ Elasticsearch is ready (yellow or green)."
+                    break
+                fi
+                echo "   Waiting for Elasticsearch... ($i/30)"
+                sleep 5
+            done
+
+            if [ "$ES_READY" -eq 1 ]; then
+                echo "→ Building Elasticsearch indexes..."
+                php artisan unopim:product:index --no-interaction 2>/dev/null || true
+                php artisan unopim:category:index --no-interaction 2>/dev/null || true
+            else
+                echo "✗ Elasticsearch did not become ready in time. Failing setup so it can be retried on next container start."
+                exit 1
+            fi
+        fi
+
+        touch "$LOCK_FILE"
+
+        echo "══════════════════════════════════════════════"
+        echo "  Setup complete! Open http://localhost:${APP_PORT:-8000}/admin"
+        echo "══════════════════════════════════════════════"
+    fi
+else
+    # Lock file exists — check if DB is still intact
+    if php artisan migrate:status --no-interaction >/dev/null 2>&1; then
+        echo "→ Checking for pending migrations..."
+        php artisan migrate --force --no-interaction
+    else
+        echo ""
+        echo "══════════════════════════════════════════════"
+        echo "  WARNING: Database is empty but lock file exists."
+        echo "  This usually happens after 'docker compose down -v'"
+        echo "  which removes all data volumes."
+        echo ""
+        echo "  TIP: Use 'docker compose down' (without -v) to"
+        echo "  preserve your data. Only use -v when you want a"
+        echo "  complete reset."
+        echo ""
+        echo "  Re-running first-time setup..."
+        echo "══════════════════════════════════════════════"
+        echo ""
+        rm -f "$LOCK_FILE"
+        exec "$0" "$@"
+    fi
+fi
+
+# ─── Seal the installer ─────────────────────────────────────────────
+INSTALLED_MARKER="/var/www/html/storage/installed"
+if [ ! -f "$INSTALLED_MARKER" ]; then
+    echo "Your UnoPim App is Successfully Installed" > "$INSTALLED_MARKER"
+fi
+
+# Ensure storage directories are writable by the LSPHP worker user (nobody)
+chown -R nobody:nogroup /var/www/html/storage /var/www/html/bootstrap/cache
+
+# Clear compiled views (may be stale from previous container)
+php artisan view:clear 2>/dev/null || true
+
+# ─── TLS certificate (generated at runtime, never baked into the image) ─────
+# HTTP/3 mandates TLS. Generate a dev self-signed cert only when none is
+# present, so each container gets a unique key and no private key ships in the
+# image layers. Mount real certs over /usr/local/lsws/conf/cert to override.
+CERT_DIR=/usr/local/lsws/conf/cert
+if [ ! -s "$CERT_DIR/server.key" ] || [ ! -s "$CERT_DIR/server.crt" ]; then
+    echo "→ Generating self-signed TLS certificate (development only)..."
+    mkdir -p "$CERT_DIR"
+    openssl req -x509 -nodes -days 825 -newkey rsa:2048 \
+        -keyout "$CERT_DIR/server.key" \
+        -out    "$CERT_DIR/server.crt" \
+        -subj "/CN=localhost" >/dev/null 2>&1
+    chmod 600 "$CERT_DIR/server.key"
+    chown -R nobody:nogroup "$CERT_DIR"
+fi
+
+# ─── Start OpenLiteSpeed ────────────────────────────────────────────
+# OLS daemonizes, so start it then hold PID 1 here. Forward container stop
+# signals to `lswsctrl stop` so `docker stop` shuts LiteSpeed down
+# gracefully (draining connections) instead of letting it be SIGKILLed.
+shutdown() {
+    echo "→ Stopping OpenLiteSpeed..."
+    /usr/local/lsws/bin/lswsctrl stop 2>/dev/null || true
+    exit 0
+}
+trap shutdown TERM INT
+
+/usr/local/lsws/bin/lswsctrl start
+
+# Hold PID 1 alive while the master runs. The sleep is backgrounded and
+# waited on so an incoming TERM/INT interrupts it immediately instead of
+# blocking until the 5s elapses. Exit non-zero if the master dies so
+# restart:unless-stopped recovers it.
+while /usr/local/lsws/bin/lswsctrl status >/dev/null 2>&1; do
+    sleep 5 &
+    # `|| true` so an unexpected non-zero wait (e.g. a stray signal) under
+    # `set -e` doesn't kill PID 1 while the OLS master is still healthy.
+    wait $! || true
+done
+
+echo "✗ OpenLiteSpeed master process exited." >&2
+exit 1

--- a/dockerfiles/litespeed.Dockerfile
+++ b/dockerfiles/litespeed.Dockerfile
@@ -1,0 +1,97 @@
+# =============================================================================
+# UnoPim Web Server (OpenLiteSpeed + LSPHP 8.3)
+# =============================================================================
+# Third web-server option alongside Nginx+FPM (default) and Apache.
+# Native HTTP/3 + QUIC via LiteSpeed's built-in lsquic — no extra build.
+#
+# Use via:
+#   docker compose -f docker-compose.yml -f docker-compose.litespeed.yml up -d
+#
+# Multi-stage build:
+#   Stage 1 (composer) — install PHP dependencies
+#   Stage 2 (app)      — production OpenLiteSpeed image
+# =============================================================================
+
+# Base image tag — declared before any FROM so it is global (overridable:
+# docker build --build-arg OLS_IMAGE=...)
+ARG OLS_IMAGE=litespeedtech/openlitespeed:1.8.4-lsphp83
+
+# ---------------------------------------------------------------------------
+# Stage 1: Composer dependencies
+# ---------------------------------------------------------------------------
+FROM composer:2 AS composer
+
+WORKDIR /app
+COPY composer.json composer.lock ./
+COPY packages/ packages/
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-scripts \
+    --prefer-dist \
+    --optimize-autoloader \
+    --ignore-platform-reqs
+
+# ---------------------------------------------------------------------------
+# Stage 2: Production image
+# ---------------------------------------------------------------------------
+FROM ${OLS_IMAGE}
+
+LABEL maintainer="Webkul <support@webkul.com>"
+LABEL org.opencontainers.image.title="UnoPim LiteSpeed"
+LABEL org.opencontainers.image.description="OpenLiteSpeed (HTTP/3 + QUIC) application server for UnoPim PIM"
+LABEL org.opencontainers.image.source="https://github.com/unopim/unopim"
+LABEL org.opencontainers.image.vendor="Webkul"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# LSPHP extensions to match the Nginx/FPM + Apache images.
+# lsphp83-common already bundles bcmath, calendar, exif, gd, gmp, intl, zip;
+# add the database, cache and TLS-cert tooling on top.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        unzip \
+        openssl \
+        lsphp83-mysql \
+        lsphp83-redis \
+        lsphp83-opcache \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Expose the LSPHP CLI as `php` so the entrypoint's artisan/composer calls work
+RUN ln -sf /usr/local/lsws/lsphp83/bin/php /usr/local/bin/php
+
+# Install Composer (for runtime use in entrypoint)
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# PHP configuration — loaded via a dedicated scan dir (see extprocessor env)
+RUN mkdir -p /usr/local/lsws/lsphp83/etc/php/8.3/litespeed/conf.d
+COPY dockerfiles/php.ini /usr/local/lsws/lsphp83/etc/php/8.3/litespeed/conf.d/unopim.ini
+
+# OpenLiteSpeed server + virtual-host configuration
+COPY dockerfiles/litespeed/httpd_config.conf /usr/local/lsws/conf/httpd_config.conf
+COPY dockerfiles/litespeed/vhconf.conf       /usr/local/lsws/conf/vhosts/unopim/vhconf.conf
+
+# TLS cert directory only. The dev self-signed cert is generated at RUNTIME by
+# the entrypoint, so a private key is never baked into an image layer (and thus
+# never shipped in the registry). Production: mount real certs over this dir.
+# Do NOT pre-create /tmp/lshttpd — LiteSpeed creates it (and the LSPHP/cgid
+# socket) at start-up with the right ownership for the `nobody` worker.
+RUN mkdir -p /usr/local/lsws/conf/cert \
+    && chown -R nobody:nogroup /usr/local/lsws/conf
+
+# Application code + Composer vendor from stage 1
+WORKDIR /var/www/html
+COPY . .
+COPY --from=composer /app/vendor ./vendor
+
+# Set permissions — owned by the LSPHP worker user (nobody)
+RUN chown -R nobody:nogroup storage bootstrap/cache \
+    && chmod -R 775 storage bootstrap/cache
+
+EXPOSE 80 443 443/udp
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD curl -sf http://localhost/ -o /dev/null -w '%{http_code}' | grep -qE '^(200|302)$' || exit 1
+
+ENTRYPOINT ["/var/www/html/dockerfiles/litespeed-entrypoint.sh"]

--- a/dockerfiles/litespeed/httpd_config.conf
+++ b/dockerfiles/litespeed/httpd_config.conf
@@ -1,0 +1,107 @@
+# =============================================================================
+# UnoPim — OpenLiteSpeed server configuration
+# =============================================================================
+# Serves the UnoPim PIM over HTTP/1.1, HTTP/2 and HTTP/3 (QUIC).
+# QUIC is enabled server-wide and on the SSL listener via lsquic (built in).
+# =============================================================================
+
+serverName                UnoPim
+# Run as nobody/nogroup — the OpenLiteSpeed convention, matching the stock
+# litespeedtech/openlitespeed image. LSPHP workers inherit this user.
+user                      nobody
+group                     nogroup
+priority                  0
+autoFix503                1
+gracefulRestartTimeout    300
+mime                      $SERVER_ROOT/conf/mime.properties
+showVersionNumber         0
+
+# OpenLiteSpeed daemonizes, so it keeps its own rotated log files inside the
+# container rather than streaming to `docker logs`. View them with:
+#   docker compose exec unopim-litespeed tail -f /usr/local/lsws/logs/error.log
+errorlog /usr/local/lsws/logs/error.log {
+  logLevel                INFO
+  rollingSize             10M
+}
+
+accesslog /usr/local/lsws/logs/access.log {
+  rollingSize             10M
+  keepDays                7
+  compressArchive         1
+}
+
+# ─── HTTP/3 (QUIC) ─────────────────────────────────────────────────
+quicEnable                1
+
+# ─── Tuning (large PIM imports/exports, long-running requests) ──────
+tuning {
+  maxConnections          2000
+  maxSSLConnections       2000
+  connTimeout             600
+  keepAliveTimeout        15
+  maxReqURLLen            32768
+  maxReqHeaderSize        65536
+  maxReqBodySize          200M
+  maxDynRespHeaderSize    32768
+  maxDynRespSize          2047M
+  sslSessionCache         1
+  sslSessionTickets       1
+}
+
+# Gzip is enabled per-vhost via `enableGzip` (see vhconf.conf).
+
+# ─── LSPHP 8.3 (LSAPI) ─────────────────────────────────────────────
+extprocessor lsphp83 {
+  type                    lsapi
+  address                 uds://tmp/lshttpd/lsphp.sock
+  maxConns                20
+  env                     PHP_LSAPI_CHILDREN=20
+  env                     PHP_LSAPI_MAX_REQUESTS=500
+  env                     PHP_INI_SCAN_DIR=/usr/local/lsws/lsphp83/etc/php/8.3/litespeed/conf.d
+  initTimeout             60
+  retryTimeout            0
+  persistConn             1
+  respBuffer              0
+  # autoStart 1 = OpenLiteSpeed auto-starts the LSAPI app on demand.
+  # path is the relative trusted fcgi-bin symlink LiteSpeed ships — this is the
+  # canonical OpenLiteSpeed LSPHP wiring (matches the stock image default).
+  autoStart               1
+  path                    fcgi-bin/lsphp
+  backlog                 100
+  instances               1
+  priority                0
+  memSoftLimit            0
+  memHardLimit            0
+  procSoftLimit           1400
+  procHardLimit           1500
+}
+
+scripthandler {
+  add                     lsapi:lsphp83 php
+}
+
+# ─── Virtual host ──────────────────────────────────────────────────
+virtualhost unopim {
+  vhRoot                  /var/www/html
+  configFile              $SERVER_ROOT/conf/vhosts/unopim/vhconf.conf
+  allowSymbolLink         1
+  enableScript            1
+  restrained              0
+  setUIDMode              0
+}
+
+# ─── Listeners ─────────────────────────────────────────────────────
+listener Default {
+  address                 *:80
+  secure                  0
+  map                     unopim *
+}
+
+listener SSL {
+  address                 *:443
+  secure                  1
+  keyFile                 /usr/local/lsws/conf/cert/server.key
+  certFile                /usr/local/lsws/conf/cert/server.crt
+  enableQuic              1
+  map                     unopim *
+}

--- a/dockerfiles/litespeed/vhconf.conf
+++ b/dockerfiles/litespeed/vhconf.conf
@@ -1,0 +1,57 @@
+# =============================================================================
+# UnoPim — OpenLiteSpeed virtual-host configuration
+# =============================================================================
+# Document root is Laravel's public/ folder; everything routes through
+# index.php via the standard Laravel rewrite rules.
+# =============================================================================
+
+docRoot                   $VH_ROOT/public/
+vhDomain                  *
+adminEmails               support@webkul.com
+enableGzip                1
+
+index {
+  useServer               0
+  indexFiles              index.php
+  autoIndex               0
+}
+
+errorlog $VH_ROOT/storage/logs/litespeed.error.log {
+  useServer               1
+}
+
+scripthandler {
+  add                     lsapi:lsphp83 php
+}
+
+# ─── Laravel front controller ──────────────────────────────────────
+# Rewrite rules are defined explicitly below, so do NOT also parse the
+# Apache-oriented public/.htaccess (autoLoadHtaccess 0) — avoids applying
+# two overlapping rule sets.
+rewrite {
+  enable                  1
+  autoLoadHtaccess        0
+  rules                   <<<END_rules
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+  END_rules
+}
+
+# ─── Static assets: cache, skip PHP handler ────────────────────────
+context exp:^.*\.(jpg|jpeg|gif|png|svg|ico|webp|woff|woff2|ttf|eot|css|js|map)$ {
+  location                $DOC_ROOT/$0
+  allowBrowse             1
+  extraHeaders            <<<END_headers
+Cache-Control public, immutable, max-age=2592000
+  END_headers
+}
+
+# ─── Deny dotfiles (.env, .git, .htaccess, …) ──────────────────────
+# NOTE: like the Nginx profile's `location ~ /\.`, this also blocks
+# /.well-known — if you terminate Let's Encrypt http-01 here, add an explicit
+# allow for /.well-known/ (the docRoot is public/, which holds no secrets).
+context exp:/\. {
+  allowBrowse             0
+}


### PR DESCRIPTION
## What

Adds a **third web-server option** to the Docker setup, alongside the default **Nginx + PHP-FPM** and the **Apache** override: **OpenLiteSpeed + LSPHP 8.3**, opt-in via a compose override.

The draw is **native HTTP/3 + QUIC** (LiteSpeed's built-in `lsquic`) with no extra build steps.

```bash
docker compose -f docker-compose.yml -f docker-compose.litespeed.yml up -d
# http://localhost:8000/admin       (HTTP/1.1, HTTP/2)
# https://localhost:8443/admin      (HTTP/2 + HTTP/3 QUIC)
```

## Web-server matrix

| Profile | Command | Protocols |
|---|---|---|
| Nginx + FPM (default) | `docker compose up -d` | HTTP/1.1 |
| Apache | `-f docker-compose.apache.yml` | HTTP/1.1, HTTP/2 |
| **OpenLiteSpeed (new)** | `-f docker-compose.litespeed.yml` | HTTP/1.1, HTTP/2, **HTTP/3/QUIC** |

## Files
- `dockerfiles/litespeed.Dockerfile` — multi-stage (composer + OLS/LSPHP 8.3), extensions matching the FPM/Apache images
- `dockerfiles/litespeed/httpd_config.conf` — LSAPI lsphp, QUIC, `:80` + `:443` listeners
- `dockerfiles/litespeed/vhconf.conf` — `public/` docroot + Laravel rewrite
- `dockerfiles/litespeed-entrypoint.sh` — shared first-run setup; **runtime** self-signed cert (never baked, `chmod 600`); graceful shutdown via signal trap
- `docker-compose.litespeed.yml` — disables nginx+fpm, adds `unopim-litespeed`, publishes **443 on TCP + UDP** for HTTP/3
- `.env.docker` — `APP_SSL_PORT`
- `docker-compose.yml` — discoverability note

## Design notes
- Workers run as `nobody` (OLS convention). No secrets baked into image layers — the dev cert is generated at first start and is replaceable by mounting real certs over `/usr/local/lsws/conf/cert`.
- HTTP/3 auto-engages in browsers only when the public port is **443** (OLS advertises the listener port via `alt-svc`).
- **Known host caveat:** some kernels / container runtimes reject OpenLiteSpeed's `lscgid`/suEXEC PHP launch, surfacing as 503 (`cgidSuEXEC failed`). The compose header documents the symptom and the Nginx/Apache fallbacks. Verified on a host with this issue down to the failing syscall; it is a host-level incompatibility, not a config defect.

## Verification
- `openlitespeed -t` config validation: clean
- `docker compose ... config`: valid; entrypoint `bash -n`: clean
- HTTP/1.1 + HTTP/2 + HTTP/3 (`alt-svc h3`, live UDP:443 QUIC listener) confirmed serving
- Nginx and Apache profiles unchanged

## Scope
No PHP touched (Pint N/A). Repo-wide Docker hardening (digest-pinning, apt version-pinning, healthcheck `pipefail`) is intentionally left as a **separate** follow-up — those apply equally to the existing nginx/fpm/web/q images.