### PR TITLE
Chore: updated the import on the installer file

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -14,6 +14,7 @@ use Webkul\Installer\Database\Seeders\DatabaseSeeder as UnoPimDatabaseSeeder;
 use Webkul\Installer\Events\ComposerEvents;
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
+use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\multisearch;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -14,8 +14,8 @@ use Webkul\Installer\Database\Seeders\DatabaseSeeder as UnoPimDatabaseSeeder;
 use Webkul\Installer\Events\ComposerEvents;
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
-use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\multisearch;
+use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;


### PR DESCRIPTION
# Updated Installer Import

Added the missing import statement to the `Installer.php` file:

```php
use function Laravel\Prompts\multiselect;
```

This import is required to use the `multiselect()` prompt function within the installer.