### PR TITLE
Fixed - Import job fails with SQL 1064 on JSON_EXTRACT reserved-word column (values)

### DIFF
--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/MySQLGrammar.php
@@ -47,7 +47,9 @@ class MySQLGrammar implements Grammar
 
         $jsonPath = '$.'.implode('.', $segments);
 
-        return "JSON_UNQUOTE(JSON_EXTRACT({$column}, '{$jsonPath}'))";
+        $escapedColumn = implode('.', array_map(fn ($part) => "`{$part}`", explode('.', $column)));
+
+        return "JSON_UNQUOTE(JSON_EXTRACT({$escapedColumn}, '{$jsonPath}'))";
     }
 
     /**

--- a/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
+++ b/packages/Webkul/Core/src/Helpers/Database/Grammars/PostgresGrammar.php
@@ -50,9 +50,11 @@ class PostgresGrammar implements Grammar
 
         $lastKey = array_pop($operators);
 
+        $quotedColumn = implode('.', array_map(fn ($part) => '"'.$part.'"', explode('.', $column)));
+
         $jsonString = ! empty($operators)
-            ? "{$column}->".implode('->', $operators)."->>{$lastKey}"
-            : "{$column}->>'{$lastKey}'";
+            ? "{$quotedColumn}->".implode('->', $operators)."->>{$lastKey}"
+            : "{$quotedColumn}->>'{$lastKey}'";
 
         return $jsonString;
     }

--- a/packages/Webkul/Core/tests/Unit/JsonExtractColumnEscapeTest.php
+++ b/packages/Webkul/Core/tests/Unit/JsonExtractColumnEscapeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Webkul\Core\Helpers\Database\Grammars\MySQLGrammar;
+use Webkul\Core\Helpers\Database\Grammars\PostgresGrammar;
+
+it('escapes a reserved-word column in MySQL json extraction', function () {
+    $sql = (new MySQLGrammar)->jsonExtract('values', 'common', 'url_key');
+
+    // `values` is a MySQL reserved word; it must be back-quoted or the query
+    // fails with SQLSTATE 1064 during product imports.
+    expect($sql)->toContain('`values`')
+        ->and($sql)->not->toContain('JSON_EXTRACT(values,');
+});
+
+it('escapes a table-qualified column in MySQL json extraction', function () {
+    $sql = (new MySQLGrammar)->jsonExtract('products.values', 'common', 'url_key');
+
+    expect($sql)->toContain('`products`.`values`');
+});
+
+it('escapes a reserved-word column in Postgres json extraction', function () {
+    $sql = (new PostgresGrammar)->jsonExtract('values', 'common', 'url_key');
+
+    expect($sql)->toContain('"values"')
+        ->and($sql)->not->toContain('values->');
+});

--- a/packages/Webkul/Core/tests/Unit/JsonExtractColumnEscapeTest.php
+++ b/packages/Webkul/Core/tests/Unit/JsonExtractColumnEscapeTest.php
@@ -24,3 +24,9 @@ it('escapes a reserved-word column in Postgres json extraction', function () {
     expect($sql)->toContain('"values"')
         ->and($sql)->not->toContain('values->');
 });
+
+it('escapes a table-qualified column in Postgres json extraction', function () {
+    $sql = (new PostgresGrammar)->jsonExtract('products.values', 'common', 'url_key');
+
+    expect($sql)->toContain('"products"."values"');
+});


### PR DESCRIPTION
## Issue Reference
Import job fails immediately with a MySQL 1064 syntax error during product URL-key / attribute JSON extraction.

## Description
The product importer's `loadUniqueValuesForPath()` builds `JSON_UNQUOTE(JSON_EXTRACT(values, '$.common.url_key'))`, but `values` is a **reserved word** in MySQL (and Postgres). `Grammar::jsonExtract()` interpolated the column name **unquoted**, so the generated query failed with:

```
SQLSTATE[42000]: 1064 ... near ', '$.common.url_key')) as attr_value from `pfproducts` where JSON_UNQUOTE(JSON_E...
```

**Fix:** back-quote the column in `MySQLGrammar::jsonExtract()` and double-quote it in `PostgresGrammar::jsonExtract()`, handling both `values` and `table.values` forms. (The 2.1 and master branches already escape the column, so they are unaffected — this closes the gap on 2.0.)

## How To Test This?
```
vendor/bin/pest packages/Webkul/Core/tests/Unit/JsonExtractColumnEscapeTest.php packages/Webkul/DataTransfer
```
New unit tests assert the column is escaped for both drivers; the generated query now runs cleanly (`JSON_EXTRACT(\`values\`, ...)`). DataTransfer suite (100 tests) passes.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.0

## Pint
Passed.

## Tailwind Reordering
N/A.