### PR TITLE
fix(admin): surface duplicate SKU error on product edit form

### DIFF
--- a/packages/Webkul/Admin/src/Http/Requests/ProductForm.php
+++ b/packages/Webkul/Admin/src/Http/Requests/ProductForm.php
@@ -2,8 +2,10 @@
 
 namespace Webkul\Admin\Http\Requests;
 
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Webkul\Core\Rules\Sku;
+use Webkul\Product\Contracts\Product;
 use Webkul\Product\Repositories\ProductRepository;
 
 class ProductForm extends FormRequest
@@ -45,10 +47,80 @@ class ProductForm extends FormRequest
 
         $this->rules = $product->getTypeInstance()->getTypeValidationRules();
 
-        $this->rules['sku'] = ['required', 'unique:products,sku,'.$this->id, new Sku];
+        $this->rules['sku'] = ['required', new Sku];
         $this->rules['status'] = ['boolean'];
 
         return $this->rules;
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * The uniqueness of the SKU is checked here (instead of a plain `unique` rule) so
+     * the failure can name the conflicting product and be surfaced on the visible SKU
+     * field rather than the hidden `sku` input, where the error was previously swallowed.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $errors = $validator->errors();
+
+            /**
+             * Re-key the flat `sku` errors (required/format) onto the visible
+             * `values[common][sku]` field so they are actually rendered on screen.
+             */
+            foreach ($errors->get('sku') as $message) {
+                $errors->add('values[common][sku]', $message);
+            }
+
+            $errors->forget('sku');
+
+            $sku = $this->input('sku');
+
+            if (empty($sku)) {
+                return;
+            }
+
+            $existing = $this->productRepository->findOneByField('sku', $sku);
+
+            if ($existing && (int) $existing->id !== (int) $this->id) {
+                $errors->add('values[common][sku]', trans('admin::app.catalog.products.sku-already-used', [
+                    'id'   => $existing->id,
+                    'name' => $this->resolveProductName($existing),
+                ]));
+            }
+        });
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     *
+     * Flash the standard failure notification so the user gets a visible toast on save
+     * (matching the behaviour of the in-controller value validation), in addition to the
+     * field level error that is scrolled into focus.
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        session()->flash('error', trans('admin::app.catalog.products.update-failure'));
+
+        parent::failedValidation($validator);
+    }
+
+    /**
+     * Resolve a human readable product name from the scoped values for the current
+     * channel and locale, falling back to the SKU when no name is available.
+     */
+    protected function resolveProductName(Product $product): string
+    {
+        $values = $product->values ?? [];
+
+        $channel = core()->getRequestedChannelCode();
+        $locale = core()->getRequestedLocaleCode();
+
+        return data_get($values, "channel_locale_specific.$channel.$locale.name")
+            ?? data_get($values, "locale_specific.$locale.name")
+            ?? data_get($values, 'common.name')
+            ?? $product->sku;
     }
 
     public function prepareForValidation()

--- a/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en_US/app.php
@@ -466,6 +466,7 @@ return [
             'saved-inventory-message' => 'Product saved successfully',
             'update-success'          => 'Product updated successfully',
             'unique-validation'       => 'This value is already taken.',
+            'sku-already-used'        => 'This SKU is already used by another product: ":name" (ID: :id). Please choose a different SKU.',
             'invalid-type'            => 'Product type with value ":type" could not be found',
             'product-not-found'       => 'Product with sku ":sku" could not be found',
             'parent-not-found'        => 'Parent with sku ":sku" could not be found',

--- a/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it_IT/app.php
@@ -434,6 +434,7 @@ return [
             'saved-inventory-message' => 'Prodotto salvato con successo',
             'update-success'          => 'Prodotto aggiornato con successo',
             'unique-validation'       => 'Questo valore è già in uso.',
+            'sku-already-used'        => 'Questo SKU è già utilizzato da un altro prodotto: ":name" (ID: :id). Scegli uno SKU diverso.',
             'invalid-type'            => 'Tipo di prodotto ":type" non trovato',
             'product-not-found'       => 'Prodotto con SKU ":sku" non trovato',
             'parent-not-found'        => 'Genitore con SKU ":sku" non trovato',

--- a/packages/Webkul/Admin/src/Resources/views/components/form/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/form/index.blade.php
@@ -37,4 +37,27 @@
 
         {{ $slot }}
     </v-form>
+
+    {{--
+        When the server returns validation errors (e.g. a duplicate SKU that can only be
+        checked server side), scroll to and focus the first invalid field on load, mirroring
+        the client side `onInvalidSubmit` behaviour.
+    --}}
+    @if ($errors->any())
+        @push('scripts')
+            <script type="text/javascript">
+                window.addEventListener('load', () => {
+                    const element = document.querySelector('[name="' + @json($errors->keys()[0]) + '"]');
+
+                    if (! element) {
+                        return;
+                    }
+
+                    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+                    setTimeout(() => element.focus(), 500);
+                });
+            </script>
+        @endpush
+    @endif
 @endif


### PR DESCRIPTION
Editing a product's SKU to a value already used by another product failed silently: the unique-SKU error was bound to the hidden `sku` input while the field users actually edit is `values[common][sku]`, so no message rendered and the save appeared to "revert" to the old SKU after refresh.

- Move the SKU uniqueness check into ProductForm and key the error to the visible `values[common][sku]` field, naming the conflicting product (id + name).
- Re-key the required/format SKU errors to the same visible field.
- Flash the standard "Product could not be updated." toast on validation failure.
- Scroll to and focus the first invalid field on server-side validation errors.

## Issue Reference
<!-- Use a closing keyword so the issue closes automatically on merge, e.g. "Fixes #123". Separate multiple issues with commas. -->

## Description
<!-- Please describe your changes in detail. -->

## How To Test This?
<!-- Please describe in detail how to test the changes made in this pull request. -->

## Screenshots
<!-- For UI changes, add before/after screenshots or a short screen recording. Remove this section otherwise. -->

## Checklist
- [ ] `vendor/bin/pest` passes locally
- [ ] `vendor/bin/pint --test` reports no style issues
- [ ] Tailwind classes are reordered
- [ ] New user-facing strings use translation keys (all 33 locales)
- [ ] Target branch is `master` (unless a maintainer requested a backport)

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!-- If checked, please describe in detail what needs to be changed. -->
