### PR TITLE
chore(ci): route major dependency bumps to master, keep 3.0 on minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,26 @@
 # Dependabot configuration
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Major dependency bumps are breaking, so they target `master`, the next-major
+# integration branch. The current release line `3.0` only accepts minor and
+# patch bumps. Dependabot reads this file from the default branch only.
 
 version: 2
 updates:
-  # Composer (PHP) — backend deps
+  # Composer (PHP) — current release line: minor + patch only
   - package-ecosystem: "composer"
     directory: "/"
+    target-branch: "3.0"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     labels:
       - "dependencies"
       - "php"
@@ -29,15 +38,43 @@ updates:
       dev-dependencies:
         dependency-type: "development"
 
-  # npm — Playwright e2e tests
+  # Composer (PHP) — next major: breaking bumps only
+  - package-ecosystem: "composer"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    labels:
+      - "dependencies"
+      - "php"
+      - "breaking"
+    commit-message:
+      prefix: "chore(deps-major)"
+      include: "scope"
+
+  # npm — Playwright e2e tests, current release line
   - package-ecosystem: "npm"
     directory: "/tests/e2e-pw"
+    target-branch: "3.0"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     labels:
       - "dependencies"
       - "javascript"
@@ -51,18 +88,70 @@ updates:
           - "@playwright/*"
           - "playwright"
 
-  # GitHub Actions
+  # npm — Playwright e2e tests, next major
+  - package-ecosystem: "npm"
+    directory: "/tests/e2e-pw"
+    target-branch: "master"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "e2e"
+      - "breaking"
+    commit-message:
+      prefix: "chore(deps-e2e-major)"
+      include: "scope"
+
+  # GitHub Actions — current release line
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "3.0"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     labels:
       - "dependencies"
       - "ci"
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
+
+  # GitHub Actions — next major
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+      - "breaking"
+    commit-message:
+      prefix: "chore(ci-major)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
## What

Splits each Dependabot ecosystem into two entries so update severity decides the target branch.

| ecosystem | → `3.0` | → `master` |
|---|---|---|
| composer | weekly, minor + patch | monthly, major |
| npm (`/tests/e2e-pw`) | weekly, minor + patch | monthly, major |
| github-actions | weekly, minor + patch | monthly, major |

## Why

Major bumps are breaking, so the current release line should never take them unattended. `3.0` keeps its weekly minor/patch flow; breaking upgrades accumulate on `master` as next-major integration work, on a monthly cadence.

Previously no entry set `target-branch`, so every bump — majors included — landed on the default branch.

## Notes for reviewers

- Dependabot reads `dependabot.yml` **only from the default branch**, so this must merge to `3.0` to take effect. A copy on `master` alone does nothing.
- Existing open Dependabot PRs are not retargeted by this change. Minor/patch ones can stay; any major ones should be closed so Dependabot re-raises them against `master`.
- `master` is currently 12 commits behind `3.0` and carries the `v3.0.0` tag. It should be refreshed from `3.0` before major bumps start landing, otherwise they are tested against a stale tree.
- **Security caveat:** ignore conditions apply to security updates too. A CVE whose only fix is a major release will not raise a PR on `3.0`. The Dependabot alerts tab remains the backstop.