### PR TITLE
fix(admin): denser datagrid rows (align body padding + smaller thumbnails)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
@@ -141,7 +141,7 @@
                     <template v-else>
                         <template v-if="$parent.available.records.length">
                             <div
-                                class="row grid gap-2.5 items-center px-4 py-4 cursor-pointer border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                                class="row grid gap-2.5 items-center px-4 py-2.5 cursor-pointer border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
                                 v-for="record in $parent.available.records"
                                 :key="record[$parent.available.meta.primary_column]"
                                 :style="`grid-template-columns: repeat(${gridsCount}, minmax(80px, 1fr))`"

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
@@ -176,13 +176,13 @@
                                             alt="@lang('admin::app.components.datagrid.table.thumbnail')"
                                             width="74"
                                             height="74"
-                                            class="h-[120px] max-w-[60px] min-w-[60px] max-h-[60px] min-h-[60px] rounded-lg border border-gray-300 shadow-sm object-cover"
+                                            class="h-[80px] max-w-[40px] min-w-[40px] max-h-[40px] min-h-[40px] rounded-lg border border-gray-300 shadow-sm object-cover"
                                         />
                                     </template>
 
                                     <template v-else-if="column.type === 'gallery'">
                                         <template v-if="record[column.index]?.type === 'video'">
-                                            <div class="relative h-[120px] max-w-[60px] min-w-[60px] max-h-[60px] min-h-[60px]">
+                                            <div class="relative h-[80px] max-w-[40px] min-w-[40px] max-h-[40px] min-h-[40px]">
                                                 <video
                                                     :src="record[column.index].url"
                                                     width="74"
@@ -201,7 +201,7 @@
                                                 alt="@lang('admin::app.components.datagrid.table.thumbnail')"
                                                 width="74"
                                                 height="74"
-                                                class="h-[120px] max-w-[60px] min-w-[60px] max-h-[60px] min-h-[60px] rounded-lg border border-gray-300 shadow-sm object-cover"
+                                                class="h-[80px] max-w-[40px] min-w-[40px] max-h-[40px] min-h-[40px] rounded-lg border border-gray-300 shadow-sm object-cover"
                                             />
                                         </template>
                                     </template>


### PR DESCRIPTION
## What
Denser rows across every admin datagrid.

## Why
Body rows render ~93px tall for ~45px of content, from two things in `components/datagrid/table.blade.php`:
- the header row uses `py-2.5` but body rows use `py-4` (32px)
- record/gallery thumbnails render at 60px, from an `h-[120px]` that `max-h-[60px]` immediately clamps (the `h-[120px]` is dead)

## Change (4 lines)
- body row `py-4` → `py-2.5` (matches the header)
- thumbnail box 60px → 40px (`h-[120px]` → `h-[80px]`, the `[60px]` min/max pairs → `[40px]`), in all 3 spots (image column, gallery video, gallery image)

Rows go **~93px → ~60px**. Pure Tailwind class changes — no behaviour, structure, or markup change, symmetric padding (dark-mode / RTL unaffected).

## Before / After
Products datagrid with **only this change** applied. Sample data is redacted.

**Before** — `py-4`, 60px thumbnails:
![before](https://raw.githubusercontent.com/midego1/unopim/assets/datagrid-padding-screens/.github/pr-assets/before.png?v=2)

**After** — `py-2.5`, 40px thumbnails:
![after](https://raw.githubusercontent.com/midego1/unopim/assets/datagrid-padding-screens/.github/pr-assets/after.png?v=2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
