### PR TITLE
feat(admin): enlarge datagrid thumbnails on hover

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
@@ -317,3 +317,93 @@
         });
     </script>
 @endpushOnce
+
+{{--
+    Hover a datagrid thumbnail to preview it enlarged, without opening the row.
+    Event-delegated so it works on the AJAX-rendered grid; the preview is
+    position:fixed and appended to <body>, so the grid's overflow never clips it.
+--}}
+@pushOnce('scripts')
+    <style>
+        #datagrid-thumbnail-preview {
+            position: fixed;
+            z-index: 9999;
+            max-width: 340px;
+            max-height: 340px;
+            padding: 4px;
+            border-radius: 12px;
+            border: 1px solid #e5e7eb;
+            background: #fff;
+            box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);
+            object-fit: contain;
+            pointer-events: none;
+        }
+
+        .dark #datagrid-thumbnail-preview {
+            border-color: #4b5563;
+            background: #1f2937;
+        }
+    </style>
+
+    <script>
+        (function () {
+            let preview = null;
+
+            const thumb = (t) =>
+                (t && t.tagName === 'IMG' && t.closest('.table-responsive .row.grid')) ? t : null;
+
+            const place = (img, rect) => {
+                const pad = 12;
+                let x = rect.right + pad;
+                let y = rect.top + rect.height / 2 - img.offsetHeight / 2;
+
+                if (x + img.offsetWidth > window.innerWidth - 8) {
+                    x = rect.left - img.offsetWidth - pad;
+                }
+                if (x < 8) {
+                    x = 8;
+                }
+                y = Math.min(Math.max(8, y), window.innerHeight - img.offsetHeight - 8);
+
+                img.style.left = x + 'px';
+                img.style.top = y + 'px';
+            };
+
+            document.addEventListener('mouseover', (e) => {
+                const t = thumb(e.target);
+                if (!t) {
+                    return;
+                }
+
+                const src = t.currentSrc || t.src;
+                if (!src) {
+                    return;
+                }
+
+                if (preview) {
+                    preview.remove();
+                }
+
+                preview = document.createElement('img');
+                preview.id = 'datagrid-thumbnail-preview';
+                preview.alt = '';
+
+                const rect = t.getBoundingClientRect();
+                preview.addEventListener('load', () => place(preview, rect));
+                preview.src = src;
+                document.body.appendChild(preview);
+
+                if (preview.complete) {
+                    place(preview, rect);
+                }
+            });
+
+            document.addEventListener('mouseout', (e) => {
+                if (thumb(e.target) && preview) {
+                    preview.remove();
+                    preview = null;
+                }
+            });
+        })();
+    </script>
+@endpushOnce


### PR DESCRIPTION
## What
Hover a datagrid thumbnail to preview it enlarged — no need to open the row.

## Why
Datagrid thumbnails are small (~40–60px), so to actually see a product or media image you have to open the row. A hover preview makes scanning a catalogue much faster.

## How
One self-contained block appended to `components/datagrid/table.blade.php`:
- delegated `mouseover`/`mouseout` on `.table-responsive .row.grid img`, so it works on the AJAX-rendered grid with no per-row wiring
- the preview is a `position:fixed` `<img>` appended to `<body>`, so the grid's `overflow-x` never clips it, and it's clamped to the viewport
- dark-mode aware, no new dependencies, no change to the grid's own behaviour

## Demo
Sample SKUs, product names and brand are blurred.

![hover-to-enlarge](https://raw.githubusercontent.com/midego1/unopim/assets/datagrid-padding-screens/.github/pr-assets/hover-enlarge-v3.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
