### PR TITLE
Fix/docker queue scheduler crash

### DIFF
--- a/.github/workflows/pest_tests.yml
+++ b/.github/workflows/pest_tests.yml
@@ -84,9 +84,6 @@ jobs:
       - name: Running UnoPim Installer
         run: php artisan unopim:install --skip-env-check --skip-admin-creation --with-demo-data
 
-      - name: Set Passport OAuth key permissions
-        run: chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
-
       - name: Running Pest Tests
         # Each worker owns a database clone. The suite runs as two halves so
         # every half starts with fresh workers: per-process memory grows over
@@ -195,9 +192,6 @@ jobs:
           curl -s http://127.0.0.1:9200/_cluster/health | python3 -m json.tool
           php artisan unopim:product:index
           php artisan unopim:category:index
-
-      - name: Set Passport OAuth key permissions
-        run: chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
 
       - name: Running Pest Tests
         # Each worker owns a database clone. The suite runs as two halves so
@@ -319,9 +313,6 @@ jobs:
 
       - name: Running UnoPim Installer
         run: php artisan unopim:install --skip-env-check --skip-admin-creation --with-demo-data
-
-      - name: Set Passport OAuth key permissions
-        run: chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
 
       # Coverage recording peaks past the runner's 7 GB (exit 137); swap absorbs
       # the spike. The runner already holds /swapfile open, so the extra file

--- a/.github/workflows/pest_tests_pgsql.yml
+++ b/.github/workflows/pest_tests_pgsql.yml
@@ -85,9 +85,6 @@ jobs:
       - name: Running UnoPim Installer
         run: php artisan unopim:install --skip-env-check --skip-admin-creation --with-demo-data
 
-      - name: Set Passport OAuth key permissions
-        run: chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
-
       - name: Running Pest Tests
         # Each worker owns a database clone. The suite runs as two halves so
         # every half starts with fresh workers: per-process memory grows over
@@ -188,9 +185,6 @@ jobs:
           curl -s http://127.0.0.1:9200/_cluster/health | python3 -m json.tool
           php artisan unopim:product:index
           php artisan unopim:category:index
-
-      - name: Set Passport OAuth key permissions
-        run: chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
 
       - name: Running Pest Tests
         # Each worker owns a database clone. The suite runs as two halves so

--- a/.github/workflows/playwright_test.yml
+++ b/.github/workflows/playwright_test.yml
@@ -142,7 +142,6 @@ jobs:
           INSTALLER_ADMIN_PASSWORD: ${{ secrets.INSTALLER_ADMIN_PASSWORD || 'admin123' }}
         run: |
           php artisan unopim:install --skip-env-check --skip-admin-creation --with-demo-data
-          chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
           php artisan unopim:passport:install-preset
           php artisan db:seed --class=DiscardQaFixtureSeeder
           php artisan tinker tests/e2e-pw/scripts/seed-dpp-e2e.php

--- a/.github/workflows/tia-baseline.yml
+++ b/.github/workflows/tia-baseline.yml
@@ -94,9 +94,6 @@ jobs:
       - name: Running UnoPim Installer
         run: php artisan unopim:install --skip-env-check --skip-admin-creation
 
-      - name: Set Passport OAuth key permissions
-        run: chmod 0600 packages/Webkul/AdminApi/src/Secrets/Oauth/oauth-*.key
-
       # Coverage recording peaks past the runner's 7 GB with several workers
       # (exit 137); swap absorbs the spike and two workers keep it tolerable.
       # The runner already holds /swapfile open, so the extra file goes on /mnt,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,25 @@ Plan for this: after the upgrade, every integration must obtain new tokens.
 Integrations are also migrated to dedicated robot users, and their credentials
 are revealed once in the admin panel.
 
+This is the last upgrade that invalidates tokens. The key pair now lives in
+`storage/app/private/oauth` instead of the application source tree, so it is no
+longer destroyed when the code is replaced. On Docker that means the volume
+keeps it across image upgrades; on a release-archive install it survives
+swapping the release directory.
+
+A file-based install that upgrades in place keeps its existing pair — the
+upgrade command copies it to the new location. If you upgrade by hand and skip
+`unopim:upgrade`, the old pair is still read from where it has always been, so
+the API keeps working until you run the command. A container upgrade cannot do
+either: the old image layer holding the keys is gone before the upgrade runs,
+so a new pair is generated and clients re-authenticate once.
+
+The pair is created by `php artisan unopim:passport:keys`, which
+`unopim:install` and `unopim:upgrade` both run. It never overwrites existing
+keys. Set `UNOPIM_OAUTH_KEY_PATH` to relocate it, or supply
+`PASSPORT_PRIVATE_KEY` and `PASSPORT_PUBLIC_KEY` to load the keys from your
+secret manager instead of from disk.
+
 ### Extensions and custom code
 
 If you maintain custom packages or theme overrides, check them against the

--- a/dockerfiles/lib/setup-app.sh
+++ b/dockerfiles/lib/setup-app.sh
@@ -2,10 +2,17 @@
 # Migrates, seeds on first run, links storage and builds search indexes. Only
 # the application container runs this. Set UNOPIM_SKIP_MIGRATIONS=true where the
 # deployment owns the schema, since scaled replicas would otherwise race it.
+#
+# Signing keys are created ahead of that flag: they are not schema, so a
+# deployment managing migrations elsewhere still needs a pair, and the workers
+# read this one from the shared storage volume.
 
 setup_app() {
     local root="${1:-/var/www/html}"
     local lock_file="${root}/storage/unopim.lock"
+
+    echo "→ Ensuring API signing keys..."
+    php artisan unopim:passport:keys --no-interaction || return 1
 
     if [ "${UNOPIM_SKIP_MIGRATIONS:-false}" = "true" ]; then
         echo "→ UNOPIM_SKIP_MIGRATIONS=true — schema is managed outside the container."

--- a/dockerfiles/q.Dockerfile
+++ b/dockerfiles/q.Dockerfile
@@ -89,6 +89,11 @@ WORKDIR /var/www/html
 COPY . .
 COPY --from=composer /app/vendor ./vendor
 
+# Set permissions. The entrypoints drop to www-data via gosu, so bootstrap/cache
+# has to be owned by it before the package manifest is written on first boot.
+RUN chown -R www-data:www-data storage bootstrap/cache \
+    && chmod -R 775 storage bootstrap/cache
+
 # Healthcheck logic:
 #   1. If the install lock file does not exist yet, the worker is still
 #      waiting for the web/fpm container to finish first-time setup

--- a/packages/Webkul/AdminApi/src/Config/api.php
+++ b/packages/Webkul/AdminApi/src/Config/api.php
@@ -6,6 +6,7 @@ return [
     'rate_limit'        => env('REST_API_RATE_LIMIT', 120),
     'token_rate_limit'  => env('OAUTH_TOKEN_RATE_LIMIT', 10),
     'docs_url'          => env('UNOPIM_API_DOCS_URL', 'https://devdocs.unopim.com/master/api/'),
+    'oauth_key_path'    => env('UNOPIM_OAUTH_KEY_PATH'),
 
     'structure_cache' => [
         'enabled' => env('UNOPIM_API_STRUCTURE_CACHE', true),

--- a/packages/Webkul/AdminApi/src/Console/PassportKeysCommand.php
+++ b/packages/Webkul/AdminApi/src/Console/PassportKeysCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webkul\AdminApi\Console;
+
+use Illuminate\Console\Command;
+use Webkul\AdminApi\Services\OauthKeyStore;
+
+class PassportKeysCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'unopim:passport:keys';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create the Passport signing keypair when the deployment does not already have one';
+
+    /**
+     * Existing keys are never replaced: regenerating invalidates every access
+     * and refresh token already issued, so rotation has to be a deliberate act
+     * rather than a side effect of running the installer again.
+     */
+    public function handle(OauthKeyStore $keys): int
+    {
+        if ($keys->exists()) {
+            $this->info('Passport keys already exist at '.$keys->path().'.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $keys->makeDirectory()) {
+            $this->error('Unable to create '.$keys->path().'.');
+            $this->line('Grant the application write access to that directory, or point UNOPIM_OAUTH_KEY_PATH somewhere writable.');
+
+            return self::FAILURE;
+        }
+
+        if ($keys->adoptLegacyKeys()) {
+            $this->info('Migrated the existing Passport keypair to '.$keys->path().'.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $keys->generate()) {
+            $this->error('Unable to generate a Passport signing keypair.');
+            $this->line('Verify that the OpenSSL extension is installed and that '.$keys->path().' is writable.');
+
+            return self::FAILURE;
+        }
+
+        $this->info('Generated a Passport signing keypair at '.$keys->path().'.');
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/Webkul/AdminApi/src/Providers/AdminApiServiceProvider.php
+++ b/packages/Webkul/AdminApi/src/Providers/AdminApiServiceProvider.php
@@ -14,12 +14,14 @@ use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Webkul\AdminApi\Cache\StructureCache;
 use Webkul\AdminApi\Console\ApiClientCommand;
+use Webkul\AdminApi\Console\PassportKeysCommand;
 use Webkul\AdminApi\Http\Middleware\DeprecatedRoute;
 use Webkul\AdminApi\Http\Middleware\EnsureAcceptsJson;
 use Webkul\AdminApi\Http\Middleware\LocaleMiddleware;
 use Webkul\AdminApi\Http\Middleware\ScopeMiddleware;
 use Webkul\AdminApi\Models\Client;
 use Webkul\AdminApi\Repositories\UserRepository;
+use Webkul\AdminApi\Services\OauthKeyStore;
 use Webkul\Attribute\Models\Attribute;
 use Webkul\Attribute\Models\AttributeFamily;
 use Webkul\Attribute\Models\AttributeFamilyGroupMapping;
@@ -193,22 +195,24 @@ class AdminApiServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ApiClientCommand::class,
+                PassportKeysCommand::class,
             ]);
         }
     }
 
     /**
-     * Register the Installer Commands of this package.
+     * Configures Passport for the admin API.
+     *
+     * Keys are created by unopim:passport:keys rather than here, so a request
+     * never writes to disk and containers booting in parallel cannot race each
+     * other into a mismatched pair. Their permissions vary by host umask, so
+     * league/oauth2-server v9's 600/660 check is skipped to keep the API
+     * bootable.
      */
     protected function activatePassportApiClient(): void
     {
-        $this->ensureOauthKeys(__DIR__.'/../Secrets/Oauth');
+        Passport::loadKeysFrom($this->app->make(OauthKeyStore::class)->resolvedPath());
 
-        Passport::loadKeysFrom(__DIR__.'/../Secrets/Oauth');
-
-        // Keys are generated per environment (see ensureOauthKeys) and are never
-        // committed, so their on-disk permissions can vary by host umask. Skip
-        // league/oauth2-server v9's 600/660 check to keep the API bootable.
         Passport::$validateKeyPermissions = false;
 
         Passport::$passwordGrantEnabled = true;
@@ -229,41 +233,6 @@ class AdminApiServiceProvider extends ServiceProvider
         Passport::refreshTokensExpireIn(CarbonInterval::seconds($refreshTokenTtl));
 
         $this->app->bind(ClientRepository::class, \Webkul\AdminApi\Repositories\ClientRepository::class);
-    }
-
-    /**
-     * Generates a per-environment Passport signing keypair when absent so the
-     * key never has to be committed. Existing keys are left untouched.
-     */
-    protected function ensureOauthKeys(string $path): void
-    {
-        $privateKeyPath = $path.'/oauth-private.key';
-        $publicKeyPath = $path.'/oauth-public.key';
-
-        if (file_exists($privateKeyPath) && file_exists($publicKeyPath)) {
-            return;
-        }
-
-        if (! is_dir($path)) {
-            mkdir($path, 0755, true);
-        }
-
-        $resource = openssl_pkey_new([
-            'private_key_bits' => 4096,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
-
-        if ($resource === false) {
-            return;
-        }
-
-        openssl_pkey_export($resource, $privateKey);
-
-        file_put_contents($privateKeyPath, $privateKey, LOCK_EX);
-        file_put_contents($publicKeyPath, openssl_pkey_get_details($resource)['key'], LOCK_EX);
-
-        chmod($privateKeyPath, 0600);
-        chmod($publicKeyPath, 0600);
     }
 
     /**

--- a/packages/Webkul/AdminApi/src/Services/OauthKeyStore.php
+++ b/packages/Webkul/AdminApi/src/Services/OauthKeyStore.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webkul\AdminApi\Services;
+
+/**
+ * Owns the location and creation of Passport's RSA signing keypair.
+ *
+ * The pair lives on the storage volume rather than in the package source so a
+ * single deployment shares one key across every container and replica, and
+ * replacing the application code no longer invalidates every issued token.
+ *
+ * Generation runs from the installer and the container entrypoint rather than
+ * from a service provider, so it happens once per deployment instead of once
+ * per request and cannot race between containers booting in parallel.
+ */
+class OauthKeyStore
+{
+    /**
+     * Path a release before the keys moved onto the storage volume wrote to.
+     */
+    const LEGACY_PATH = __DIR__.'/../Secrets/Oauth';
+
+    const PRIVATE_KEY = 'oauth-private.key';
+
+    const PUBLIC_KEY = 'oauth-public.key';
+
+    /**
+     * Resolves the directory holding the keypair.
+     *
+     * The default is applied here rather than in the config file because
+     * config:cache would otherwise bake in an absolute path from whichever
+     * machine cached the config, which is not necessarily the one running it.
+     */
+    public function path(): string
+    {
+        $configured = config('api.oauth_key_path');
+
+        return $configured
+            ? rtrim((string) $configured, '/')
+            : storage_path('app/private/oauth');
+    }
+
+    /**
+     * Resolves the directory Passport should read from.
+     *
+     * Equal to path() in every deployment that has run unopim:passport:keys.
+     * An install upgraded by hand, without the installer or the upgrade
+     * command, still has its pair in the previous location, and reading it
+     * there keeps already-issued tokens valid until the command is run. The
+     * fallback is read-only; nothing is ever written back to that directory.
+     */
+    public function resolvedPath(): string
+    {
+        $path = $this->path();
+
+        if ($this->exists()) {
+            return $path;
+        }
+
+        $legacyPath = $this->legacyPath();
+
+        if (
+            file_exists($legacyPath.'/'.self::PRIVATE_KEY)
+            && file_exists($legacyPath.'/'.self::PUBLIC_KEY)
+        ) {
+            return $legacyPath;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Normalises the constant so error messages and Passport's own exceptions
+     * quote a plain directory rather than one containing a parent traversal.
+     */
+    public function legacyPath(): string
+    {
+        return realpath(self::LEGACY_PATH) ?: self::LEGACY_PATH;
+    }
+
+    public function privateKeyPath(): string
+    {
+        return $this->path().'/'.self::PRIVATE_KEY;
+    }
+
+    public function publicKeyPath(): string
+    {
+        return $this->path().'/'.self::PUBLIC_KEY;
+    }
+
+    public function exists(): bool
+    {
+        return file_exists($this->privateKeyPath()) && file_exists($this->publicKeyPath());
+    }
+
+    /**
+     * Creates the key directory, returning false when the filesystem refuses.
+     *
+     * Filesystem warnings are suppressed throughout this class because Laravel
+     * promotes them to ErrorException, which would abort the caller instead of
+     * letting it report the failure and carry on.
+     */
+    public function makeDirectory(): bool
+    {
+        $path = $this->path();
+
+        if (is_dir($path)) {
+            return true;
+        }
+
+        return @mkdir($path, 0700, true) || is_dir($path);
+    }
+
+    /**
+     * Copies a keypair written by an earlier release into the current location.
+     *
+     * Only bare-metal installs benefit: a container upgrade replaces the image
+     * layer holding the old directory before this runs, so there is nothing
+     * left to adopt and a fresh pair is generated instead.
+     */
+    public function adoptLegacyKeys(): bool
+    {
+        $legacyPrivateKey = $this->legacyPath().'/'.self::PRIVATE_KEY;
+        $legacyPublicKey = $this->legacyPath().'/'.self::PUBLIC_KEY;
+
+        if (! file_exists($legacyPrivateKey) || ! file_exists($legacyPublicKey)) {
+            return false;
+        }
+
+        if (
+            ! @copy($legacyPrivateKey, $this->privateKeyPath())
+            || ! @copy($legacyPublicKey, $this->publicKeyPath())
+        ) {
+            return false;
+        }
+
+        $this->restrictPermissions();
+
+        return true;
+    }
+
+    /**
+     * Writes a fresh RSA pair, returning false when OpenSSL is unavailable or
+     * refuses to generate.
+     */
+    public function generate(): bool
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 4096,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        if ($resource === false) {
+            return false;
+        }
+
+        openssl_pkey_export($resource, $privateKey);
+
+        $details = openssl_pkey_get_details($resource);
+
+        if ($details === false) {
+            return false;
+        }
+
+        if (
+            @file_put_contents($this->privateKeyPath(), $privateKey, LOCK_EX) === false
+            || @file_put_contents($this->publicKeyPath(), $details['key'], LOCK_EX) === false
+        ) {
+            return false;
+        }
+
+        $this->restrictPermissions();
+
+        return true;
+    }
+
+    protected function restrictPermissions(): void
+    {
+        chmod($this->privateKeyPath(), 0600);
+        chmod($this->publicKeyPath(), 0600);
+    }
+}

--- a/packages/Webkul/AdminApi/tests/Feature/OauthKeyStoreTest.php
+++ b/packages/Webkul/AdminApi/tests/Feature/OauthKeyStoreTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Laravel\Passport\Passport;
+use Webkul\AdminApi\Providers\AdminApiServiceProvider;
+use Webkul\AdminApi\Services\OauthKeyStore;
+
+beforeEach(function () {
+    $this->keyPath = storage_path('framework/testing/oauth-'.uniqid());
+
+    config()->set('api.oauth_key_path', $this->keyPath);
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->keyPath);
+
+    if ($this->createdLegacyKeys ?? false) {
+        $legacyPath = (new OauthKeyStore)->legacyPath();
+
+        File::delete([
+            $legacyPath.'/oauth-private.key',
+            $legacyPath.'/oauth-public.key',
+        ]);
+    }
+});
+
+/**
+ * Puts a keypair at the location releases before the move wrote to, leaving a
+ * developer's real keys alone when they are already there.
+ */
+function seedLegacyKeys(): string
+{
+    if (! is_dir(OauthKeyStore::LEGACY_PATH)) {
+        File::makeDirectory(OauthKeyStore::LEGACY_PATH, 0755, true);
+    }
+
+    $legacyPath = (new OauthKeyStore)->legacyPath();
+
+    if (! file_exists($legacyPath.'/oauth-private.key')) {
+        test()->createdLegacyKeys = true;
+
+        config()->set('api.oauth_key_path', $legacyPath);
+
+        (new OauthKeyStore)->generate();
+
+        config()->set('api.oauth_key_path', test()->keyPath);
+    }
+
+    return $legacyPath;
+}
+
+it('keeps the signing keys on the storage volume by default', function () {
+    config()->set('api.oauth_key_path', null);
+
+    expect(app(OauthKeyStore::class)->path())->toBe(storage_path('app/private/oauth'));
+});
+
+it('survives the application code being replaced', function () {
+    $this->artisan('unopim:passport:keys')->assertSuccessful();
+
+    $publicKey = file_get_contents($this->keyPath.'/oauth-public.key');
+
+    $this->artisan('unopim:passport:keys')->assertSuccessful();
+
+    expect(file_get_contents($this->keyPath.'/oauth-public.key'))->toBe($publicKey);
+});
+
+it('points passport at the resolved key path', function () {
+    $this->artisan('unopim:passport:keys')->assertSuccessful();
+
+    app()->register(AdminApiServiceProvider::class, true);
+
+    expect(Passport::keyPath('oauth-public.key'))->toBe($this->keyPath.'/oauth-public.key');
+});
+
+it('reads the previous location until the migration command has run', function () {
+    $legacyPath = seedLegacyKeys();
+
+    app()->register(AdminApiServiceProvider::class, true);
+
+    expect(Passport::keyPath('oauth-public.key'))->toBe($legacyPath.'/oauth-public.key');
+
+    $this->artisan('unopim:passport:keys')->assertSuccessful();
+
+    app()->register(AdminApiServiceProvider::class, true);
+
+    expect(Passport::keyPath('oauth-public.key'))->toBe($this->keyPath.'/oauth-public.key');
+});
+
+it('never writes to the previous location', function () {
+    seedLegacyKeys();
+
+    $store = app(OauthKeyStore::class);
+
+    expect($store->path())->toBe($this->keyPath)
+        ->and($store->resolvedPath())->toBe($store->legacyPath());
+});
+
+it('adopts a keypair left behind by an earlier release', function () {
+    $legacyPath = seedLegacyKeys();
+
+    $legacyPublicKey = file_get_contents($legacyPath.'/oauth-public.key');
+
+    $this->artisan('unopim:passport:keys')->assertSuccessful();
+
+    expect(file_get_contents($this->keyPath.'/oauth-public.key'))->toBe($legacyPublicKey);
+});
+
+it('reports a failure instead of throwing when the key path is unwritable', function () {
+    $readOnly = storage_path('framework/testing/oauth-readonly-'.uniqid());
+
+    File::makeDirectory($readOnly, 0500, true);
+
+    config()->set('api.oauth_key_path', $readOnly.'/keys');
+
+    $this->artisan('unopim:passport:keys')->assertFailed();
+
+    chmod($readOnly, 0700);
+
+    File::deleteDirectory($readOnly);
+})->skip(fn () => posix_geteuid() === 0, 'root ignores directory permissions');
+
+it('does not write to disk while booting the provider', function () {
+    $this->artisan('unopim:passport:keys')->assertSuccessful();
+
+    $before = File::allFiles($this->keyPath);
+
+    File::delete($this->keyPath.'/oauth-private.key');
+
+    app()->register(AdminApiServiceProvider::class, true);
+
+    expect(File::exists($this->keyPath.'/oauth-private.key'))->toBeFalse()
+        ->and($before)->toHaveCount(2);
+});

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -123,6 +123,9 @@ class Installer extends Command
         $this->warn('Step: Generating key...');
         $this->call('key:generate');
 
+        $this->warn('Step: Generating API signing keys...');
+        $this->call('unopim:passport:keys');
+
         if (config('elasticsearch.enabled') == 'true') {
             $this->warn('Step: Testing ElasticSearch Connection...');
             if (! ElasticSearch::testConnection()) {

--- a/packages/Webkul/Installer/src/Console/Commands/Upgrade.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Upgrade.php
@@ -184,6 +184,8 @@ class Upgrade extends Command
         $this->call('down', ['--render' => 'errors::503']);
 
         try {
+            $this->runStep('unopim:passport:keys');
+
             $this->runStep('migrate', ['--force' => true]);
 
             $this->runStep('storage:link', ['--relative' => true]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,7 @@ $overrides = [
     'TRUSTED_PROXIES'   => '127.0.0.1',
     // Restore the real low limit that throttle tests need; the e2e .env raises it for Playwright's many logins.
     'ADMIN_LOGIN_RATE_LIMIT' => '5',
+    'UNOPIM_OAUTH_KEY_PATH'  => __DIR__.'/../storage/framework/testing/oauth',
 ];
 
 foreach ($overrides as $key => $value) {
@@ -31,6 +32,32 @@ foreach ($overrides as $key => $value) {
 
     $_ENV[$key] = $value;
     $_SERVER[$key] = $value;
+}
+
+/**
+ * Passport refuses to boot without a signing keypair. Generating it here keeps
+ * the suite independent of whether the installer has ever run on this machine,
+ * and keeps the throwaway pair out of the developer's real storage directory.
+ */
+$oauthKeyPath = $overrides['UNOPIM_OAUTH_KEY_PATH'];
+
+if (! file_exists($oauthKeyPath.'/oauth-private.key')) {
+    if (! is_dir($oauthKeyPath)) {
+        mkdir($oauthKeyPath, 0700, true);
+    }
+
+    $resource = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+
+    openssl_pkey_export($resource, $privateKey);
+
+    file_put_contents($oauthKeyPath.'/oauth-private.key', $privateKey, LOCK_EX);
+    file_put_contents($oauthKeyPath.'/oauth-public.key', openssl_pkey_get_details($resource)['key'], LOCK_EX);
+
+    chmod($oauthKeyPath.'/oauth-private.key', 0600);
+    chmod($oauthKeyPath.'/oauth-public.key', 0600);
 }
 
 require __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
## Issue Reference

## Description
- `dockerfiles/q.Dockerfile` never chowned anything to `www-data` (unlike `web.Dockerfile` / `fpm.Dockerfile`), so the queue+scheduler containers crash-looped under `gosu www-data` on `bootstrap/cache` writes. Added the same `chown`/`chmod` step.
- Passport signing keys were generated into `packages/.../AdminApi/src/Secrets/Oauth` from `AdminApiServiceProvider::boot()` — the container's writable layer — so every image upgrade destroyed and regenerated the pair, silently invalidating all issued tokens (and each replica minted its own pair).
- Moved key generation into a new `unopim:passport:keys` command backed by `OauthKeyStore`, writing to `storage/app/private/oauth` (configurable via `api.oauth_key_path` / `UNOPIM_OAUTH_KEY_PATH`). The command is called from `unopim:install`, `unopim:upgrade`, and `dockerfiles/lib/setup-app.sh` — placed before the `UNOPIM_SKIP_MIGRATIONS` early return since keys aren't schema. The provider is now read-only and falls back to the old path when the new one is empty, so hand-upgraded installs keep serving existing tokens; `PASSPORT_PRIVATE_KEY`/`PASSPORT_PUBLIC_KEY` still take priority.
- Removed 7 CI steps that chmod'd the old key path (no longer needed, and would exit 1 against the new path).

Container upgrades will still invalidate tokens once, since the old image layer holding the keys is gone before the upgrade command can run; file-based installs keep their pair. Documented in `UPGRADE.md`. Note this only affects users of the published Docker images once `docker-publish.yml` runs (on release publish or manual dispatch), not on merge.

## How To Test This?
1. Build the `q` image from this branch and start `docker compose up` — confirm the queue/scheduler container reaches `Up (healthy)` with restart count 0 (previously crash-looped).
2. On a fresh stack, confirm keys land in `storage/app/private/oauth`, owned by `www-data`, mode `0600`, and are identical (same md5) across app/queue/scheduler containers.
3. Run `docker compose up --force-recreate` against an image with no keys baked in — hash should stay the same (existing keys reused, not regenerated).
4. Set `UNOPIM_SKIP_MIGRATIONS=true` and confirm keys are still provisioned.
5. Point `UNOPIM_OAUTH_KEY_PATH` at an unwritable directory — `unopim:passport:keys` should exit 1 with the actionable message, no stack trace.
6. `php artisan test --testsuite="Api Feature Test"` covering `OauthKeyStoreTest` and existing API auth tests.
