### PR TITLE
Fixed the CI

### DIFF
--- a/.github/workflows/tia-baseline.yml
+++ b/.github/workflows/tia-baseline.yml
@@ -123,14 +123,15 @@ jobs:
           # runs late enough to overwrite whatever php.ini carries.
           PEST_MEMORY_LIMIT: '-1'
         run: |
-          # Nothing survives the kill to report the peak, so sample it alongside.
+          # A 15s cadence left the kill inside an unsampled gap: the last reading
+          # was 800M against 14G free, which only rules out a slow climb.
           ( while true; do
               printf '%s rss=%sk avail=%s swapfree=%s\n' \
                 "$(date -u +%H:%M:%S)" \
                 "$(ps -eo rss,comm --sort=-rss | awk '$2 ~ /php/ {s+=$1} END {print s+0}')" \
                 "$(awk '/MemAvailable/ {print $2}' /proc/meminfo)" \
                 "$(awk '/SwapFree/ {print $2}' /proc/meminfo)"
-              sleep 15
+              sleep 1
             done ) > "$RUNNER_TEMP/memory.log" 2>&1 &
           sampler=$!
 
@@ -145,13 +146,17 @@ jobs:
           sort -t= -k2 -n "$RUNNER_TEMP/memory.log" | tail -5
 
           # Pest re-execs PHP for pcov and returns `proc_close()` verbatim, which
-          # for a signalled child is the raw wait status rather than 128+signal.
-          # A bare 9 is therefore SIGKILL — the OOM killer — and says nothing
-          # about the tests, so name it before the log scrolls away.
+          # for a signalled child is the raw wait status rather than 128+signal,
+          # so a bare 9 means the child was signalled rather than that the tests
+          # failed. Whether that signal came from the OOM killer is what the
+          # kernel ring buffer settles — the sampled memory has never supported it.
           if [ "$status" -eq 9 ]; then
-            echo "::error::the recording process was SIGKILLed (out of memory), not a test failure"
+            echo "::error::the recording process was killed by a signal, not by a failing test"
             free -h || true
             swapon --show || true
+
+            echo '--- kernel log (an OOM kill is recorded here) ---'
+            sudo dmesg | tail -50 || true
             exit "$status"
           fi
 

--- a/.github/workflows/tia-baseline.yml
+++ b/.github/workflows/tia-baseline.yml
@@ -132,19 +132,22 @@ jobs:
           echo '--- peak memory during recording ---'
           sort -t= -k2 -n "$RUNNER_TEMP/memory.log" | tail -5
 
-          # proc_close() is returned verbatim, so a bare 9 is a signalled child
-          # rather than a failing test.
-          if [ "$status" -eq 9 ]; then
-            echo "::error::the recording process was killed by a signal, not by a failing test"
+          if [ "$status" -ne 0 ]; then
+            # A signalled child reaches here two ways: proc_close() hands back a
+            # bare 9 from the pcov re-exec, the shell reports 137 for the process
+            # it started itself. Neither means a test failed.
+            case "$status" in
+              9|13[0-9]) echo "::error::the recording process was killed by a signal, not by a failing test" ;;
+              *)         echo "::error::the recording run exited with $status" ;;
+            esac
+
             free -h || true
             swapon --show || true
+            df -h /mnt / || true
 
             echo '--- kernel log (an OOM kill is recorded here) ---'
             sudo dmesg | tail -50 || true
-            exit "$status"
-          fi
 
-          if [ "$status" -ne 0 ]; then
             exit "$status"
           fi
 

--- a/.github/workflows/tia-baseline.yml
+++ b/.github/workflows/tia-baseline.yml
@@ -19,8 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  # Pest resolves the baseline through `gh run list --status success --limit 1`, so a run that
-  # records nothing must not report success: it would mask the newest run that did publish one.
+  # A run that records nothing must not report success: Pest takes the newest
+  # successful run, so an empty one masks the last that published a graph.
   baseline:
     runs-on: ubuntu-24.04
     name: Record the test impact baseline
@@ -53,14 +53,8 @@ jobs:
         with:
           php-version: '8.4'
           extensions: curl, fileinfo, gd, intl, mbstring, openssl, pdo, pdo_mysql, tokenizer, zip
-          # Pest re-execs PHP to pin `pcov.directory` (see PcovRestarter), and
-          # that child is rebuilt from the pest arguments alone — every `-d` flag
-          # on the original command line is dropped. Anything the recording run
-          # needs has to live in php.ini, which is what `ini-values` writes.
-          #
-          # pcov instruments every file it loads, and the graph only cares about
-          # our own source, so keeping vendor out of it is what keeps the
-          # recording inside the runner's memory.
+          # PcovRestarter rebuilds the child from Pest's argv, dropping every `-d`,
+          # so anything the recording needs has to come from php.ini.
           ini-values: error_reporting=E_ALL, memory_limit=-1, pcov.exclude="~(vendor|node_modules|storage)~"
           tools: composer:v2
           coverage: pcov
@@ -99,10 +93,7 @@ jobs:
       - name: Running UnoPim Installer
         run: php artisan unopim:install --skip-env-check --skip-admin-creation
 
-      # Recording the whole suite has been SIGKILLed at ~8m in with 16G of RAM
-      # and 11G of swap, so the ceiling is well past what a spike explains. The
-      # runner already holds /swapfile open, so the extra file goes on /mnt,
-      # which is both free and the larger disk.
+      # The runner already holds /swapfile open, so the extra file goes on /mnt.
       - name: Add swap headroom for coverage recording
         run: |
           sudo rm -f /mnt/swapfile
@@ -114,17 +105,13 @@ jobs:
           free -h
           df -h /mnt /
 
-      # Pest disables impact analysis for partial runs — a path argument or a
-      # `--testsuite` filter records nothing at all — so the graph has to come
-      # from one run over the whole suite.
+      # Pest records nothing for a partial run, so this cannot be split up.
       - name: Record the baseline
         env:
-          # tests/Pest.php caps memory at 1024M unless this says otherwise, and it
-          # runs late enough to overwrite whatever php.ini carries.
+          # tests/Pest.php caps memory at 1024M unless this says otherwise.
           PEST_MEMORY_LIMIT: '-1'
         run: |
-          # A 15s cadence left the kill inside an unsampled gap: the last reading
-          # was 800M against 14G free, which only rules out a slow climb.
+          # 1s, or the kill lands inside an unsampled gap.
           ( while true; do
               printf '%s rss=%sk avail=%s swapfree=%s\n' \
                 "$(date -u +%H:%M:%S)" \
@@ -145,11 +132,8 @@ jobs:
           echo '--- peak memory during recording ---'
           sort -t= -k2 -n "$RUNNER_TEMP/memory.log" | tail -5
 
-          # Pest re-execs PHP for pcov and returns `proc_close()` verbatim, which
-          # for a signalled child is the raw wait status rather than 128+signal,
-          # so a bare 9 means the child was signalled rather than that the tests
-          # failed. Whether that signal came from the OOM killer is what the
-          # kernel ring buffer settles — the sampled memory has never supported it.
+          # proc_close() is returned verbatim, so a bare 9 is a signalled child
+          # rather than a failing test.
           if [ "$status" -eq 9 ]; then
             echo "::error::the recording process was killed by a signal, not by a failing test"
             free -h || true


### PR DESCRIPTION
The first instrumented nightly finally reported numbers, and they do not support the out-of-memory reading the job has been chasing:

```
03:29:19  rss=814604k  avail=14029456  swapfree=28311544   <- last sample
03:29:33  PASS Settings\ChannelActivationTest
03:29:34  killed, exit 9
```

800M of PHP against 14G free and 28G of swap never touched. The recording is nowhere near the runner's limits, so the swap headroom was aimed at the wrong thing.

It also dies in the same place every run — right after `Settings/ChannelActivationTest`, about nine minutes in. A memory ceiling does not land on the same test five times.

What the evidence cannot yet settle is whether a spike hid between samples: the cadence was 15s and the kill fell 15s after the last reading. This drops it to 1s so nothing can hide there, and prints `dmesg` on failure — the OOM killer leaves a record in the ring buffer and nothing else does, which is the yes/no the sampled memory cannot give.

If the ring buffer is clean, `exit 9` is not the OOM killer and the cause is something in that test neighbourhood, which is a different investigation from the one that has been running.

Swap stays at 24G for this run so only one variable changes; it looks unnecessary and can come out once the cause is known.