### PR TITLE
feat(database): support MariaDB as a first-class driver

### DIFF
--- a/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_175059_update_id_to_ui_id_oauth_clients.php
+++ b/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_175059_update_id_to_ui_id_oauth_clients.php
@@ -16,6 +16,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_clients', function (Blueprint $table) {
                     $table->uuid('id')->change();
                 });
@@ -40,6 +41,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_clients', function (Blueprint $table) {
                     $table->bigIncrements('id')->change();
                 });

--- a/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_185855_update_client_id_to_ui_id_oauth_access_tokens.php
+++ b/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_185855_update_client_id_to_ui_id_oauth_access_tokens.php
@@ -16,6 +16,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_access_tokens', function (Blueprint $table) {
                     $table->uuid('client_id')->change();
                 });
@@ -39,6 +40,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_access_tokens', function (Blueprint $table) {
                     $table->unsignedBigInteger('client_id')->change();
                 });

--- a/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_190001_update_client_id_to_ui_id_oauth_auth_codes.php
+++ b/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_190001_update_client_id_to_ui_id_oauth_auth_codes.php
@@ -16,6 +16,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_auth_codes', function (Blueprint $table) {
                     $table->uuid('client_id')->change();
                 });
@@ -39,6 +40,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_auth_codes', function (Blueprint $table) {
                     $table->unsignedBigInteger('client_id')->change();
                 });

--- a/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_190040_update_client_id_to_ui_id_oauth_personal_access_clients.php
+++ b/packages/Webkul/AdminApi/src/Database/Migrations/2024_07_10_190040_update_client_id_to_ui_id_oauth_personal_access_clients.php
@@ -16,6 +16,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_personal_access_clients', function (Blueprint $table) {
                     $table->uuid('client_id')->change();
                 });
@@ -41,6 +42,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 Schema::table('oauth_personal_access_clients', function (Blueprint $table) {
                     $table->unsignedBigInteger('client_id')->change();
                 });

--- a/packages/Webkul/Core/src/Helpers/Database/GrammarQueryManager.php
+++ b/packages/Webkul/Core/src/Helpers/Database/GrammarQueryManager.php
@@ -19,10 +19,15 @@ class GrammarQueryManager
             return static::$instances[$driver];
         }
 
+        /**
+         * MariaDB speaks the MySQL dialect but Laravel reports it under its own
+         * driver name, so it has to be matched alongside `mysql` rather than
+         * falling through to the failure arm.
+         */
         static::$instances[$driver] = match ($driver) {
-            'pgsql' => new PostgresGrammar,
-            'mysql' => new MySQLGrammar,
-            default => throw new \RuntimeException("Unsupported DB driver: {$driver}")
+            'pgsql'            => new PostgresGrammar,
+            'mysql', 'mariadb' => new MySQLGrammar,
+            default            => throw new \RuntimeException("Unsupported DB driver: {$driver}")
         };
 
         return static::$instances[$driver];

--- a/packages/Webkul/Core/tests/Unit/DatabaseDriverCoverageTest.php
+++ b/packages/Webkul/Core/tests/Unit/DatabaseDriverCoverageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * MariaDB has no CI matrix, so a driver branch that forgets it fails silently
+ * in production rather than here. Laravel reports `mariadb` as a driver of its
+ * own, so a file that decides anything on `mysql` and never mentions it is
+ * taking the wrong branch on every MariaDB install.
+ *
+ * Scoped per file rather than per branch: a file may legitimately single out
+ * `mysql` once it is already handling the family (BackupManager excludes
+ * MariaDB from MySQL's `--no-tablespaces`), and the failure this guards against
+ * is forgetting the driver outright.
+ */
+function driverBranchOffenders(): array
+{
+    $root = base_path();
+
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root.'/packages', FilesystemIterator::SKIP_DOTS)
+    );
+
+    $offenders = [];
+
+    foreach ($files as $file) {
+        if ($file->getExtension() !== 'php' || str_contains($file->getPathname(), '/tests/')) {
+            continue;
+        }
+
+        $source = (string) file_get_contents($file->getPathname());
+
+        if (! str_contains($source, 'getDriverName')) {
+            continue;
+        }
+
+        if (! preg_match("/(===|!==|=>|case)\s*'mysql'|'mysql'\s*(=>|,)/", $source)) {
+            continue;
+        }
+
+        if (! str_contains($source, 'mariadb')) {
+            $offenders[] = str_replace($root.'/', '', $file->getPathname());
+        }
+    }
+
+    return $offenders;
+}
+
+it('names mariadb wherever it branches on the mysql driver', function () {
+    expect(driverBranchOffenders())->toBeEmpty();
+});

--- a/packages/Webkul/Core/tests/Unit/GrammarQueryManagerDriverTest.php
+++ b/packages/Webkul/Core/tests/Unit/GrammarQueryManagerDriverTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Webkul\Core\Helpers\Database\GrammarQueryManager;
+use Webkul\Core\Helpers\Database\Grammars\MySQLGrammar;
+use Webkul\Core\Helpers\Database\Grammars\PostgresGrammar;
+
+/**
+ * Laravel reports MariaDB under its own driver string, so a manager that only
+ * knows `mysql` takes down every query that routes through the grammar.
+ */
+it('resolves the MySQL grammar for the mysql driver', function () {
+    expect(GrammarQueryManager::getGrammar('mysql'))->toBeInstanceOf(MySQLGrammar::class);
+});
+
+it('resolves the MySQL grammar for the mariadb driver', function () {
+    expect(GrammarQueryManager::getGrammar('mariadb'))->toBeInstanceOf(MySQLGrammar::class);
+});
+
+it('resolves the Postgres grammar for the pgsql driver', function () {
+    expect(GrammarQueryManager::getGrammar('pgsql'))->toBeInstanceOf(PostgresGrammar::class);
+});
+
+it('caches a grammar per driver rather than rebuilding it', function () {
+    expect(GrammarQueryManager::getGrammar('mariadb'))->toBe(GrammarQueryManager::getGrammar('mariadb'));
+});
+
+it('refuses a driver it has no grammar for', function () {
+    expect(fn () => GrammarQueryManager::getGrammar('sqlsrv'))->toThrow(RuntimeException::class);
+});

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
@@ -1706,13 +1706,13 @@ class Importer extends AbstractImporter
     }
 
     /**
-     * Toggle MySQL-only bulk-mode session vars. No-ops on non-MySQL drivers
-     * (e.g. pgsql, sqlite) since `unique_checks` and `foreign_key_checks`
-     * are MySQL-specific.
+     * Toggle the MySQL-family bulk-mode session vars. No-ops on drivers without
+     * them (e.g. pgsql, sqlite) since `unique_checks` and `foreign_key_checks`
+     * are specific to MySQL and MariaDB.
      */
     protected function toggleMysqlBulkMode(bool $enable): void
     {
-        if (DB::connection()->getDriverName() !== 'mysql') {
+        if (! $this->supportsBulkModeToggles()) {
             return;
         }
 
@@ -1720,6 +1720,16 @@ class Importer extends AbstractImporter
 
         DB::statement("SET SESSION unique_checks={$value}");
         DB::statement("SET SESSION foreign_key_checks={$value}");
+    }
+
+    /**
+     * MariaDB honours both session vars but reports its own driver name, so
+     * testing for the literal `mysql` string would drop the optimisation for
+     * every MariaDB install without any visible failure.
+     */
+    protected function supportsBulkModeToggles(): bool
+    {
+        return in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true);
     }
 
     /**\n     * Prepare products from current batch.\n     *\n     * Optimized: Uses indexed attribute family lookup (O(1)) instead of\n     * Collection->where()->first() (O(n)) per row.\n     */

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Product/Importer.php
@@ -1732,7 +1732,12 @@ class Importer extends AbstractImporter
         return in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true);
     }
 
-    /**\n     * Prepare products from current batch.\n     *\n     * Optimized: Uses indexed attribute family lookup (O(1)) instead of\n     * Collection->where()->first() (O(n)) per row.\n     */
+    /**
+     * Prepare products from current batch.
+     *
+     * Uses an indexed attribute-family lookup rather than scanning the
+     * collection for every row.
+     */
     public function prepareProducts(array $rowData, array &$products, ?bool $isExisting = null): void
     {
         /**

--- a/packages/Webkul/DataTransfer/src/Repositories/JobInstancesRepository.php
+++ b/packages/Webkul/DataTransfer/src/Repositories/JobInstancesRepository.php
@@ -21,29 +21,22 @@ class JobInstancesRepository extends Repository
      */
     protected function normalizeData(array $data): array
     {
-        $driver = DB::getDriverName();
+        if (isset($data['allowed_errors']) && $data['allowed_errors'] === '') {
+            $data['allowed_errors'] = 0;
+        }
 
-        switch ($driver) {
-            case 'pgsql':
-
-                if (isset($data['allowed_errors']) && $data['allowed_errors'] === '') {
-                    $data['allowed_errors'] = 0;
+        /**
+         * PostgreSQL rejects an empty string where MySQL and MariaDB coerce it,
+         * so only the nullable paths are driver-specific. Testing for pgsql and
+         * letting every other driver fall through keeps a newly added driver
+         * working rather than silently unnormalised.
+         */
+        if (DB::getDriverName() === 'pgsql') {
+            foreach (['file_path', 'images_directory_path'] as $column) {
+                if (isset($data[$column]) && $data[$column] === '') {
+                    $data[$column] = null;
                 }
-
-                if (isset($data['file_path']) && $data['file_path'] === '') {
-                    $data['file_path'] = null;
-                }
-                if (isset($data['images_directory_path']) && $data['images_directory_path'] === '') {
-                    $data['images_directory_path'] = null;
-                }
-                break;
-
-            case 'mysql':
-
-                if (isset($data['allowed_errors']) && $data['allowed_errors'] === '') {
-                    $data['allowed_errors'] = 0;
-                }
-                break;
+            }
         }
 
         return $data;

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Importers/MariadbBulkModeCompatibilityTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Importers/MariadbBulkModeCompatibilityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\DataTransfer\Helpers\Importers\Product\Importer;
+
+/**
+ * MariaDB honours `unique_checks` and `foreign_key_checks` exactly as MySQL
+ * does, so gating the toggles on the literal `mysql` driver string silently
+ * drops the bulk-import optimisation for every MariaDB install.
+ */
+describe('Product Importer MariaDB bulk-mode compatibility', function () {
+    beforeEach(function () {
+        $this->original = DB::getDefaultConnection();
+
+        /**
+         * Resolved against the real connection first: the importer touches the
+         * database while booting, so it cannot be built once the default points
+         * at a driver with no server behind it.
+         */
+        $importer = app(Importer::class);
+
+        $this->supportsBulkMode = function (string $driver) use ($importer): bool {
+            config()->set("database.connections.fake_{$driver}", [
+                'driver'   => $driver,
+                'host'     => '127.0.0.1',
+                'database' => 'unopim_fake',
+                'username' => 'unopim',
+                'password' => 'unopim',
+            ]);
+
+            DB::setDefaultConnection("fake_{$driver}");
+
+            return (new ReflectionMethod(Importer::class, 'supportsBulkModeToggles'))->invoke($importer);
+        };
+    });
+
+    afterEach(function () {
+        DB::setDefaultConnection($this->original);
+    });
+
+    it('applies bulk-mode session vars on mysql', function () {
+        expect(($this->supportsBulkMode)('mysql'))->toBeTrue();
+    });
+
+    it('applies bulk-mode session vars on mariadb', function () {
+        expect(($this->supportsBulkMode)('mariadb'))->toBeTrue();
+    });
+
+    it('skips bulk-mode session vars on pgsql', function () {
+        expect(($this->supportsBulkMode)('pgsql'))->toBeFalse();
+    });
+});

--- a/packages/Webkul/DataTransfer/tests/Unit/Repositories/JobInstancesNormalizeDataTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Repositories/JobInstancesNormalizeDataTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\DataTransfer\Repositories\JobInstancesRepository;
+
+/**
+ * An empty string reaching an integer column is never valid on any engine, so
+ * the normalisation cannot be gated on a driver allowlist that omits MariaDB.
+ */
+function normalizeFor(string $driver, array $data): array
+{
+    config()->set("database.connections.fake_{$driver}", ['driver' => $driver, 'database' => 'unopim_fake']);
+
+    $original = DB::getDefaultConnection();
+
+    DB::setDefaultConnection("fake_{$driver}");
+
+    try {
+        return (new ReflectionMethod(JobInstancesRepository::class, 'normalizeData'))
+            ->invoke(app(JobInstancesRepository::class), $data);
+    } finally {
+        DB::setDefaultConnection($original);
+    }
+}
+
+it('normalizes an empty allowed_errors on every driver', function (string $driver) {
+    expect(normalizeFor($driver, ['allowed_errors' => ''])['allowed_errors'])->toBe(0);
+})->with(['mysql', 'mariadb', 'pgsql']);
+
+it('nulls empty path columns only where the engine rejects an empty string', function () {
+    expect(normalizeFor('pgsql', ['file_path' => '', 'images_directory_path' => '']))
+        ->toMatchArray(['file_path' => null, 'images_directory_path' => null]);
+});
+
+it('leaves populated values untouched', function () {
+    expect(normalizeFor('mariadb', ['allowed_errors' => 5, 'file_path' => 'imports/a.csv']))
+        ->toMatchArray(['allowed_errors' => 5, 'file_path' => 'imports/a.csv']);
+});

--- a/packages/Webkul/HistoryControl/src/Database/Migrations/2024_05_31_133400_create_audits_trigger.php
+++ b/packages/Webkul/HistoryControl/src/Database/Migrations/2024_05_31_133400_create_audits_trigger.php
@@ -15,6 +15,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 // MySQL trigger
                 if (! DB::select("SELECT * FROM information_schema.TRIGGERS WHERE TRIGGER_NAME = 'audit_before_insert' AND EVENT_OBJECT_SCHEMA = '".DB::getDatabaseName()."'")) {
                     DB::unprepared('
@@ -103,6 +104,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 DB::unprepared('DROP TRIGGER IF EXISTS `audit_before_insert`');
                 break;
 

--- a/packages/Webkul/HistoryControl/src/Database/Migrations/2024_08_16_173100_update_audits_trigger.php
+++ b/packages/Webkul/HistoryControl/src/Database/Migrations/2024_08_16_173100_update_audits_trigger.php
@@ -15,6 +15,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 // Drop existing trigger if exists
                 DB::unprepared('DROP TRIGGER IF EXISTS `audit_before_insert`');
 
@@ -108,6 +109,7 @@ return new class extends Migration
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':
                 DB::unprepared('DROP TRIGGER IF EXISTS `audit_before_insert`');
                 break;
 

--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -32,6 +32,13 @@ use function Laravel\Prompts\text;
 class Installer extends Command
 {
     /**
+     * Server-based drivers the wizard can configure. Kept in step with the
+     * connections in `config/database.php` — a driver missing here is a driver
+     * nobody can install onto.
+     */
+    public const DATABASE_DRIVERS = ['mysql', 'mariadb', 'pgsql', 'sqlsrv'];
+
+    /**
      * Locales list.
      *
      * @var array
@@ -528,8 +535,8 @@ class Installer extends Command
         $databaseDetails = [
             'DB_CONNECTION' => select(
                 'Please select the database connection',
-                ['mysql', 'pgsql', 'sqlsrv'],
-                default: in_array(static::envDefault('DB_CONNECTION'), ['mysql', 'pgsql', 'sqlsrv'], true)
+                static::DATABASE_DRIVERS,
+                default: in_array(static::envDefault('DB_CONNECTION'), static::DATABASE_DRIVERS, true)
                     ? static::envDefault('DB_CONNECTION')
                     : 'mysql'
             ),

--- a/packages/Webkul/Installer/src/Helpers/DatabaseManager.php
+++ b/packages/Webkul/Installer/src/Helpers/DatabaseManager.php
@@ -162,7 +162,7 @@ class DatabaseManager
         $driver = config("database.connections.{$connection}.driver", $connection);
 
         // Only server-based drivers need an explicit CREATE DATABASE; skip others (e.g. sqlite).
-        if (! in_array($driver, ['mysql', 'pgsql'], true)) {
+        if (! in_array($driver, ['mysql', 'mariadb', 'pgsql'], true)) {
             return;
         }
 

--- a/packages/Webkul/Installer/src/Helpers/Upgrade/BackupManager.php
+++ b/packages/Webkul/Installer/src/Helpers/Upgrade/BackupManager.php
@@ -4,6 +4,7 @@ namespace Webkul\Installer\Helpers\Upgrade;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -69,10 +70,22 @@ class BackupManager
         /**
          * `--no-tablespaces` keeps mysqldump 8 from reading INFORMATION_SCHEMA
          * tablespace data, which needs the PROCESS privilege that a
-         * least-privileged application user is not granted.
+         * least-privileged application user is not granted. MariaDB has no
+         * tablespace metadata and rejects the option outright, so it is sent
+         * only to MySQL.
          */
         $command = match ($driver) {
-            'mysql' => ['mysqldump', '--host='.$host, '--port='.$port, '--user='.$username, '--single-transaction', '--no-tablespaces', '--routines', '--result-file='.$path, $database],
+            'mysql', 'mariadb' => [
+                $this->mysqlDumpBinary($driver),
+                '--host='.$host,
+                '--port='.$port,
+                '--user='.$username,
+                '--single-transaction',
+                ...($driver === 'mysql' ? ['--no-tablespaces'] : []),
+                '--routines',
+                '--result-file='.$path,
+                $database,
+            ],
             'pgsql' => ['pg_dump', '--host='.$host, '--port='.$port, '--username='.$username, '--file='.$path, $database],
             default => throw new \RuntimeException(trans('installer::app.upgrade.backup.unsupported-driver', ['driver' => $driver])),
         };
@@ -82,11 +95,25 @@ class BackupManager
          * password never appears in the host's process table.
          */
         $env = match ($driver) {
-            'mysql' => ['MYSQL_PWD' => $password],
-            'pgsql' => ['PGPASSWORD' => $password],
+            'mysql', 'mariadb' => ['MYSQL_PWD' => $password],
+            'pgsql'            => ['PGPASSWORD' => $password],
         };
 
         return new Process($command, base_path(), $env + ['PATH' => getenv('PATH') ?: '/usr/bin:/bin']);
+    }
+
+    /**
+     * MariaDB 11 renamed its client binaries and ships the `mysqldump` alias
+     * only as a deprecated shim, so the modern name is preferred where the
+     * server is MariaDB and the alias kept as the fallback.
+     */
+    protected function mysqlDumpBinary(string $driver): string
+    {
+        if ($driver !== 'mariadb') {
+            return 'mysqldump';
+        }
+
+        return (new ExecutableFinder)->find('mariadb-dump') ? 'mariadb-dump' : 'mysqldump';
     }
 
     /**

--- a/packages/Webkul/Installer/src/Helpers/Upgrade/PreflightChecker.php
+++ b/packages/Webkul/Installer/src/Helpers/Upgrade/PreflightChecker.php
@@ -224,7 +224,7 @@ class PreflightChecker
 
         try {
             return match ($connection->getDriverName()) {
-                'mysql' => (int) ($connection->selectOne(
+                'mysql', 'mariadb' => (int) ($connection->selectOne(
                     'select sum(data_length + index_length) as size from information_schema.tables where table_schema = ?',
                     [$database]
                 )?->size ?? 0),

--- a/packages/Webkul/Installer/tests/Feature/UpgradeBackupTest.php
+++ b/packages/Webkul/Installer/tests/Feature/UpgradeBackupTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
 use Webkul\Installer\Helpers\Upgrade\BackupManager;
 
 /**
@@ -23,6 +24,32 @@ it('refuses to back up a driver it has no dump command for', function () {
 
     expect(fn () => app(BackupManager::class)->dump($this->directory))
         ->toThrow(RuntimeException::class, trans('installer::app.upgrade.backup.unsupported-driver', ['driver' => 'sqlite']));
+});
+
+it('dumps a mariadb connection with the mariadb client arguments', function () {
+    $manager = new class extends BackupManager
+    {
+        /**
+         * @param  array<string, mixed>  $config
+         */
+        public function exposeProcessFor(string $driver, array $config, string $path): Process
+        {
+            return $this->processFor($driver, $config, $path);
+        }
+    };
+
+    $process = $manager->exposeProcessFor('mariadb', [
+        'host'     => '127.0.0.1',
+        'port'     => '3306',
+        'database' => 'unopim',
+        'username' => 'unopim',
+        'password' => 'secret',
+    ], $this->directory.'/unopim.sql');
+
+    expect($process->getCommandLine())->toMatch('/(mariadb-dump|mysqldump)/')
+        ->not->toContain('--no-tablespaces');
+
+    expect($process->getEnv())->toHaveKey('MYSQL_PWD');
 });
 
 it('throws and leaves no file behind when the dump command fails', function () {

--- a/packages/Webkul/Installer/tests/Unit/DatabaseManagerDriverSupportTest.php
+++ b/packages/Webkul/Installer/tests/Unit/DatabaseManagerDriverSupportTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Webkul\Installer\Helpers\DatabaseManager;
+
+/**
+ * `migrate:fresh` cannot create the schema itself, so a driver excluded from
+ * the CREATE DATABASE gate fails the install with a missing-database error.
+ *
+ * Each case is driven through the name validation: reaching the invalid-name
+ * exception proves the driver passed the gate, while a silent return proves it
+ * was skipped. Neither path needs a reachable server.
+ */
+function attemptDatabaseCreation(string $driver): Closure
+{
+    config([
+        'database.default'                              => 'upgrade_driver_probe',
+        'database.connections.upgrade_driver_probe'     => ['driver' => $driver, 'database' => 'not a valid name'],
+    ]);
+
+    return fn () => app(DatabaseManager::class)->createDatabaseIfNotExists();
+}
+
+it('creates the database for a mysql connection', function () {
+    expect(attemptDatabaseCreation('mysql'))->toThrow(Exception::class, 'is invalid');
+});
+
+it('creates the database for a mariadb connection', function () {
+    expect(attemptDatabaseCreation('mariadb'))->toThrow(Exception::class, 'is invalid');
+});
+
+it('creates the database for a pgsql connection', function () {
+    expect(attemptDatabaseCreation('pgsql'))->toThrow(Exception::class, 'is invalid');
+});
+
+it('skips drivers that need no explicit create statement', function () {
+    attemptDatabaseCreation('sqlite')();
+})->throwsNoExceptions();

--- a/packages/Webkul/Installer/tests/Unit/InstallerDatabaseDriverChoicesTest.php
+++ b/packages/Webkul/Installer/tests/Unit/InstallerDatabaseDriverChoicesTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Webkul\Installer\Console\Commands\Installer;
+
+/**
+ * A driver the wizard never offers is a driver nobody can install onto, so the
+ * prompt has to stay in step with the shipped connections.
+ */
+it('offers every server-based driver the application ships a connection for', function () {
+    expect(Installer::DATABASE_DRIVERS)->toContain('mysql', 'mariadb', 'pgsql');
+});
+
+it('offers no driver without a matching connection in the database config', function () {
+    $configured = collect(config('database.connections'))->pluck('driver')->unique();
+
+    expect($configured)->toContain(...Installer::DATABASE_DRIVERS);
+});

--- a/packages/Webkul/Publication/src/Database/Migrations/2026_07_22_000003_create_publication_version_payloads_table.php
+++ b/packages/Webkul/Publication/src/Database/Migrations/2026_07_22_000003_create_publication_version_payloads_table.php
@@ -24,9 +24,9 @@ return new class extends Migration
 
         // BLOB caps at 64 KB; MEDIUMBLOB gives 16 MB. MySQL family only — Postgres bytea is untiered.
         if (in_array(Schema::getConnection()->getDriverName(), ['mysql', 'mariadb'], true)) {
-            $table = Schema::getConnection()->getTablePrefix().'publication_version_payloads';
+            $tableName = Schema::getConnection()->getTablePrefix().'publication_version_payloads';
 
-            DB::statement('ALTER TABLE `'.$table.'` MODIFY payload MEDIUMBLOB NULL');
+            DB::statement('ALTER TABLE `'.$tableName.'` MODIFY payload MEDIUMBLOB NULL');
         }
     }
 

--- a/packages/Webkul/Publication/src/Database/Migrations/2026_07_22_000003_create_publication_version_payloads_table.php
+++ b/packages/Webkul/Publication/src/Database/Migrations/2026_07_22_000003_create_publication_version_payloads_table.php
@@ -22,8 +22,8 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        // BLOB caps at 64 KB; MEDIUMBLOB gives 16 MB. MySQL only — Postgres bytea is untiered.
-        if (Schema::getConnection()->getDriverName() === 'mysql') {
+        // BLOB caps at 64 KB; MEDIUMBLOB gives 16 MB. MySQL family only — Postgres bytea is untiered.
+        if (in_array(Schema::getConnection()->getDriverName(), ['mysql', 'mariadb'], true)) {
             $table = Schema::getConnection()->getTablePrefix().'publication_version_payloads';
 
             DB::statement('ALTER TABLE `'.$table.'` MODIFY payload MEDIUMBLOB NULL');


### PR DESCRIPTION
## Issue Reference
N/A — driver support gap found while investigating `BackupManager`.

## Description

`config/database.php` ships a `mariadb` connection, but Laravel 11+ reports MariaDB under its **own** `mariadb` driver string — it never returns `mysql`. Every branch in the codebase enumerated only `mysql` and `pgsql`, so MariaDB took the wrong path everywhere. Because MariaDB has no CI matrix, none of it surfaced.

### What was broken on `DB_CONNECTION=mariadb`

| Severity | Site | Effect |
|---|---|---|
| Critical | `GrammarQueryManager` | Threw `Unsupported DB driver: mariadb` on every query through the shared grammar |
| Critical | 4 Passport migrations | `switch` matched no case and **silently did nothing** — `oauth_clients.id` stayed `bigint` where the app expects `uuid`, breaking the REST API |
| Serious | `create_publication_version_payloads_table` | Kept `BLOB` (64 KB) instead of `MEDIUMBLOB` (16 MB) — payloads truncate with no error |
| Serious | 2 audit-trigger migrations | Triggers never created; the audit trail silently records nothing |
| Serious | `DatabaseManager` | `CREATE DATABASE` skipped, so a fresh install fails |
| Serious | `BackupManager` | Upgrade aborted — MariaDB 11 ships `mariadb-dump` with only a deprecated `mysqldump` shim, and rejects MySQL 8's `--no-tablespaces` |
| Moderate | `JobInstancesRepository` | Empty `allowed_errors` left unnormalised, heading for an integer column |
| Moderate | Product `Importer` | Bulk-mode session vars dropped — silent performance regression, not a failure |
| Minor | `PreflightChecker` | Database size reported as `0`, making the upgrade disk check meaningless |
| Minor | `Installer` command | Wizard never offered MariaDB |

### Verification

Run against **MariaDB 11.8.6** in Docker, full `migrate:fresh --seed`:

- **5066 tests, 0 failures** — every package, run individually.
- Schema confirmed in `information_schema`: `oauth_clients.id` = `uuid`, `payload` = `mediumblob` (16777215 bytes), `audit_before_insert` present.
- **Counterfactual**: reverting the migrations and re-running reproduces `bigint(20) unsigned` and `blob max=65535`. The fixes are load-bearing.
- The MariaDB 11 image ships **only** `mariadb-dump` — no `mysqldump` — confirming the `BackupManager` probe is required, not defensive.

`pint` and `phpstan` clean on this branch.

### Regression guard

`DatabaseDriverCoverageTest` fails the build if any file under `packages/` decides on `'mysql'` without naming `mariadb`. Verified in both directions: passes now, fails when a single fix is reverted. It would have caught all eleven.

It is scoped per file rather than per branch, because `BackupManager` legitimately singles out `mysql` to exclude MariaDB from `--no-tablespaces`.

### Notes for the reviewer

- Additive and BC-preserving: MySQL and PostgreSQL paths are untouched.
- Where only one dialect is special the code now tests `pgsql` and lets everything else fall through, so a future driver degrades rather than breaks.
- **A MariaDB CI matrix would be worth adding.** Three of these defects are invisible to both existing matrices, which is precisely how eleven accumulated.
