### PR TITLE
Fix/media type attributes

### DIFF
--- a/packages/Webkul/Admin/src/Config/media.php
+++ b/packages/Webkul/Admin/src/Config/media.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Media Download Allow-Listed Roots
+    |--------------------------------------------------------------------------
+    |
+    | Root segments `MediaController::download()` is allowed to serve from.
+    |
+    */
+    'downloadable_roots' => ['product', 'attribute_option', 'category'],
+];

--- a/packages/Webkul/Admin/src/Config/media.php
+++ b/packages/Webkul/Admin/src/Config/media.php
@@ -6,8 +6,13 @@ return [
     | Media Download Allow-Listed Roots
     |--------------------------------------------------------------------------
     |
-    | Root segments `MediaController::download()` is allowed to serve from.
+    | Root segments `MediaController::download()` is allowed to serve from,
+    | mapped to the permission that governs each one.
     |
     */
-    'downloadable_roots' => ['product', 'attribute_option', 'category'],
+    'downloadable_roots' => [
+        'product'          => 'catalog.products',
+        'category'         => 'catalog.categories',
+        'attribute_option' => 'catalog.attributes',
+    ],
 ];

--- a/packages/Webkul/Admin/src/Http/Controllers/MediaController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/MediaController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webkul\Admin\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Webkul\Admin\Http\Requests\MediaDownloadRequest;
+use Webkul\Core\Rules\FileOrImageValidValue;
+
+class MediaController extends Controller
+{
+    /**
+     * Serve a media asset from the default disk as an attachment download.
+     */
+    public function download(MediaDownloadRequest $request): BinaryFileResponse|StreamedResponse
+    {
+        $path = $this->normalize((string) $request->validated('path'));
+
+        $segments = explode('/', $path);
+
+        foreach ($segments as $segment) {
+            abort_if($segment === '.' || $segment === '..' || $segment === '', 404);
+        }
+
+        abort_unless(in_array($segments[0], (array) config('admin.media.downloadable_roots', []), true), 404);
+
+        $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+
+        abort_unless(in_array($extension, $this->allowedExtensions(), true), Response::HTTP_FORBIDDEN);
+
+        abort_unless(Storage::exists($path), 404);
+
+        return Storage::download($path, basename($path));
+    }
+
+    /**
+     * Normalise a logical storage path.
+     */
+    private function normalize(string $path): string
+    {
+        abort_if(str_contains($path, "\0"), 404);
+
+        $path = str_replace('\\', '/', $path);
+
+        return ltrim($path, '/');
+    }
+
+    /**
+     * Extensions the upload validators accept.
+     *
+     * @return array<int, string>
+     */
+    private function allowedExtensions(): array
+    {
+        return array_map('strtolower', array_merge(
+            FileOrImageValidValue::IMAGE_ALLOWED_EXTENSIONS,
+            FileOrImageValidValue::VIDEO_ALLOWED_EXTENSIONS,
+            FileOrImageValidValue::FILE_ALLOWED_EXTENSION,
+        ));
+    }
+}

--- a/packages/Webkul/Admin/src/Http/Controllers/MediaController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/MediaController.php
@@ -27,7 +27,11 @@ class MediaController extends Controller
             abort_if($segment === '.' || $segment === '..' || $segment === '', 404);
         }
 
-        abort_unless(in_array($segments[0], (array) config('admin.media.downloadable_roots', []), true), 404);
+        $roots = (array) config('admin.media.downloadable_roots', []);
+
+        abort_unless(array_key_exists($segments[0], $roots), 404);
+
+        abort_unless(bouncer()->hasPermission($roots[$segments[0]]), Response::HTTP_FORBIDDEN, trans('admin::app.common.unauthorized'));
 
         $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
 

--- a/packages/Webkul/Admin/src/Http/Requests/MediaDownloadRequest.php
+++ b/packages/Webkul/Admin/src/Http/Requests/MediaDownloadRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webkul\Admin\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MediaDownloadRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'path' => ['required', 'string', 'max:512'],
+        ];
+    }
+}

--- a/packages/Webkul/Admin/src/Providers/AdminServiceProvider.php
+++ b/packages/Webkul/Admin/src/Providers/AdminServiceProvider.php
@@ -136,6 +136,11 @@ class AdminServiceProvider extends ServiceProvider
             dirname(__DIR__).'/Config/sso.php',
             'sso'
         );
+
+        $this->mergeConfigFrom(
+            dirname(__DIR__).'/Config/media.php',
+            'admin.media'
+        );
     }
 
     /**

--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
@@ -634,6 +634,8 @@
 
                                     <v-media-image
                                         name="swatch_value"
+                                        :allow-download="true"
+                                        :full-preview="true"
                                         :uploaded-images='swatchValue.image'
                                     >
                                     </v-media-image>
@@ -870,7 +872,7 @@
 
                         this.swatchValue = {
                             image: cloned.swatch_value_url
-                            ? [{ id: cloned.id, url: cloned.swatch_value_url }]
+                            ? [{ id: cloned.id, url: cloned.swatch_value_url, value: cloned.swatch_value }]
                             : [],
                         };
 

--- a/packages/Webkul/Admin/src/Resources/views/components/categories/dynamic-fields.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/categories/dynamic-fields.blade.php
@@ -124,6 +124,8 @@
                 <x-admin::media.image
                     name="{{ $fieldName }}"
                     ::class="[errors && errors['{{ $fieldName }}'] ? 'border !border-red-600 hover:border-red-600' : '']"
+                    :allow-download="true"
+                    :full-preview="true"
                     :id="$field->code"
                     ::rules="{{ $field->getValidationsField() }}"
                     :uploaded-images="! empty($value) ? [$savedImage] : []"
@@ -152,6 +154,7 @@
 
                 <x-admin::media.files
                     type="video"
+                    :allow-download="true"
                     :id="$field->code"
                     :name="$fieldName"
                     ::rules="{{ $field->getValidationsField() }}"

--- a/packages/Webkul/Admin/src/Resources/views/components/media/add-tile.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/add-tile.blade.php
@@ -33,11 +33,11 @@
             :for="readOnly ? null : (triggerModal ? null : inputId)"
             :aria-label="title"
             :title="allowedTypes"
-            @click="! readOnly && triggerModal && $emit('trigger')"
-            @dragover.prevent="! readOnly && (isDragging = true)"
-            @dragenter.prevent="! readOnly && (isDragging = true)"
+            @click="onTrigger"
+            @dragover.prevent="onDragEnter"
+            @dragenter.prevent="onDragEnter"
             @dragleave.prevent="isDragging = false"
-            @drop.prevent="! readOnly && onDrop($event)"
+            @drop.prevent="onDrop"
         >
             <span
                 class="flex items-center justify-center rounded-md border border-gray-200 bg-white text-gray-500 transition-colors group-hover:border-unopim-primary/30 group-hover:text-unopim-primary dark:border-cherry-700 dark:bg-cherry-900 dark:text-gray-300"
@@ -88,8 +88,29 @@
                 onChange(event) {
                     this.$emit('change', event.target.files);
                 },
+
+                onTrigger() {
+                    if (this.readOnly || ! this.triggerModal) {
+                        return;
+                    }
+
+                    this.$emit('trigger');
+                },
+
+                onDragEnter() {
+                    if (this.readOnly) {
+                        return;
+                    }
+
+                    this.isDragging = true;
+                },
+
                 onDrop(event) {
                     this.isDragging = false;
+
+                    if (this.readOnly) {
+                        return;
+                    }
 
                     const files = event.dataTransfer ? event.dataTransfer.files : null;
 

--- a/packages/Webkul/Admin/src/Resources/views/components/media/add-tile.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/add-tile.blade.php
@@ -8,6 +8,7 @@
     'multiple'     => false,
     'compact'      => false,
     'triggerModal' => false,
+    'readOnly'     => false,
 ])
 
 <v-media-add-tile
@@ -20,22 +21,23 @@
     :multiple="@json($multiple)"
     :compact="@json($compact)"
     :trigger-modal="@json($triggerModal)"
+    :read-only="@json($readOnly)"
     {{ $attributes }}
 ></v-media-add-tile>
 
 @pushOnce('scripts')
     <script type="text/x-template" id="v-media-add-tile-template">
         <label
-            class="group flex min-h-[176px] w-full cursor-pointer flex-col items-center justify-center rounded-md border border-dashed border-gray-300 bg-gray-50 p-3.5 text-center transition-colors hover:border-unopim-primary hover:bg-gray-100 dark:border-gray-600 dark:bg-cherry-800 dark:hover:border-unopim-primary dark:hover:bg-cherry-700"
-            :class="isDragging ? '!border-primary-500 !bg-primary-50 dark:!bg-cherry-700 shadow-md' : ''"
-            :for="triggerModal ? null : inputId"
+            class="group flex min-h-[176px] w-full flex-col items-center justify-center rounded-md border border-dashed border-gray-300 bg-gray-50 p-3.5 text-center transition-colors dark:border-gray-600 dark:bg-cherry-800"
+            :class="[isDragging ? '!border-primary-500 !bg-primary-50 dark:!bg-cherry-700 shadow-md' : '', readOnly ? 'cursor-not-allowed' : 'cursor-pointer hover:border-unopim-primary hover:bg-gray-100 dark:hover:border-unopim-primary dark:hover:bg-cherry-700']"
+            :for="readOnly ? null : (triggerModal ? null : inputId)"
             :aria-label="title"
             :title="allowedTypes"
-            @click="triggerModal && $emit('trigger')"
-            @dragover.prevent="isDragging = true"
-            @dragenter.prevent="isDragging = true"
+            @click="! readOnly && triggerModal && $emit('trigger')"
+            @dragover.prevent="! readOnly && (isDragging = true)"
+            @dragenter.prevent="! readOnly && (isDragging = true)"
             @dragleave.prevent="isDragging = false"
-            @drop.prevent="onDrop"
+            @drop.prevent="! readOnly && onDrop($event)"
         >
             <span
                 class="flex items-center justify-center rounded-md border border-gray-200 bg-white text-gray-500 transition-colors group-hover:border-unopim-primary/30 group-hover:text-unopim-primary dark:border-cherry-700 dark:bg-cherry-900 dark:text-gray-300"
@@ -49,7 +51,7 @@
             <slot></slot>
 
             <input
-                v-if="! triggerModal"
+                v-if="! triggerModal && ! readOnly"
                 ref="input"
                 type="file"
                 class="hidden"
@@ -74,6 +76,7 @@
                 multiple: Boolean,
                 compact: Boolean,
                 triggerModal: Boolean,
+                readOnly: Boolean,
             },
             emits: ['change', 'drop', 'trigger'],
             data() {

--- a/packages/Webkul/Admin/src/Resources/views/components/media/card.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/card.blade.php
@@ -5,6 +5,7 @@
     'height'             => null,
     'allowReplace'       => false,
     'allowRemove'        => false,
+    'allowDownload'      => false,
     'allowPreview'       => true,
     'allowDrag'          => false,
     'allowSelect'        => false,
@@ -25,6 +26,7 @@
     :height='@json($height)'
     :allow-replace="@json($allowReplace)"
     :allow-remove="@json($allowRemove)"
+    :allow-download="@json($allowDownload)"
     :allow-preview="@json($allowPreview)"
     :allow-drag="@json($allowDrag)"
     :allow-select="@json($allowSelect)"
@@ -84,15 +86,22 @@
                 </div>
 
                 <div
-                    class="absolute flex items-center justify-center gap-2 opacity-0 transition-opacity group-hover:opacity-100"
+                    class="absolute flex flex-wrap items-center justify-center gap-1.5 px-1 opacity-0 transition-opacity group-hover:opacity-100"
                     :class="actionsLayout === 'center'
                         ? 'inset-0 bg-black/80 dark:bg-cherry-800/90'
                         : 'inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2'"
                 >
-                    <button v-if="allowDrag && showDragHandle" type="button" class="icon-drag rounded bg-white/20 p-1.5 text-white" @click.stop="$emit('drag-handle', media)"></button>
-                    <button v-if="allowPreview" type="button" class="icon-view rounded bg-white/20 p-1.5 text-white" aria-label="@lang('admin::app.components.media.images.preview-image')" @click.stop="$emit('preview', media)"></button>
-                    <button v-if="allowReplace" type="button" class="icon-edit rounded bg-white/20 p-1.5 text-white" aria-label="@lang('admin::app.components.media.images.replace-image')" @click.stop="$emit('replace', media)"></button>
-                    <button v-if="allowRemove" type="button" class="icon-delete rounded bg-white/20 p-1.5 text-white" aria-label="@lang('admin::app.components.media.images.delete-image')" @click.stop="$emit('remove', media)"></button>
+                    <button v-if="allowDrag && showDragHandle" type="button" class="icon-drag rounded bg-black/55 p-1.5 text-white ring-1 ring-white/70 shadow-sm" @click.stop="$emit('drag-handle', media)"></button>
+                    <button v-if="allowPreview" type="button" class="icon-view rounded bg-black/55 p-1.5 text-white ring-1 ring-white/70 shadow-sm" aria-label="@lang('admin::app.components.media.images.preview-image')" @click.stop="$emit('preview', media)"></button>
+                    <button v-if="allowReplace" type="button" class="icon-edit rounded bg-black/55 p-1.5 text-white ring-1 ring-white/70 shadow-sm" aria-label="@lang('admin::app.components.media.images.replace-image')" @click.stop="$emit('replace', media)"></button>
+                    <button v-if="allowRemove" type="button" class="icon-delete rounded bg-black/55 p-1.5 text-white ring-1 ring-white/70 shadow-sm" aria-label="@lang('admin::app.components.media.images.delete-image')" @click.stop="$emit('remove', media)"></button>
+                    <a
+                        v-if="allowDownload && downloadHref"
+                        :href="downloadHref"
+                        class="icon-down-stat rounded bg-black/55 p-1.5 text-white ring-1 ring-white/70 shadow-sm"
+                        aria-label="@lang('admin::app.export.download')"
+                        @click.stop
+                    ></a>
                     <slot name="actions" :media="media"></slot>
                 </div>
             </div>
@@ -124,6 +133,8 @@
     </script>
 
     <script type="module">
+        const mediaDownloadRoute = @json(route('admin.media.download'));
+
         app.component('v-media-card', {
             template: '#v-media-card-template',
             props: {
@@ -133,6 +144,7 @@
                 height: { type: [String, Number], default: null },
                 allowReplace: Boolean,
                 allowRemove: Boolean,
+                allowDownload: Boolean,
                 allowPreview: { type: Boolean, default: true },
                 allowDrag: Boolean,
                 allowSelect: Boolean,
@@ -204,6 +216,13 @@
                         width: this.width || undefined,
                         height: this.height || undefined,
                     };
+                },
+                downloadHref() {
+                    if (this.media.is_new || ! this.media.value) {
+                        return null;
+                    }
+
+                    return mediaDownloadRoute + '?path=' + encodeURIComponent(this.media.value);
                 },
             },
         });

--- a/packages/Webkul/Admin/src/Resources/views/components/media/files.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/files.blade.php
@@ -5,6 +5,8 @@
     'height'             => '120px',
     'acceptedExtensions' => \Webkul\Core\Rules\FileOrImageValidValue::FILE_ALLOWED_EXTENSION,
     'instructions'         => '',
+    'readOnly'           => false,
+    'allowDownload'      => false,
 ])
 
 <x-admin::media.field type="files" :name="$name" :instructions="$instructions">
@@ -16,6 +18,8 @@
     height="{{ $height }}"
     :accepted-extensions='@json($acceptedExtensions)'
     :errors="errors"
+    v-bind:read-only="{{ $readOnly ? 'true' : 'false' }}"
+    v-bind:allow-download="{{ $allowDownload ? 'true' : 'false' }}"
     class="{{ $attributes->get('class') }}"
 >
 </v-media-files>
@@ -37,6 +41,7 @@
                     :accept="acceptAttribute"
                     :input-id="$.uid + '_fileInput'"
                     icon="icon-file"
+                    :read-only="readOnly"
                     @change="add"
                     @drop="onDrop"
                 ></v-media-add-tile>
@@ -47,6 +52,7 @@
                     v-bind="{animation: 200}"
                     :list="inputFiles"
                     item-key="id"
+                    :disabled="readOnly"
                 >
                     <template #item="{ element, index }">
                         <v-media-files-item
@@ -56,6 +62,8 @@
                             :width="width"
                             :height="height"
                             :accepted-extensions="acceptedExtensions"
+                            :read-only="readOnly"
+                            :allow-download="allowDownload"
                             @onRemove="remove($event)"
                             @onChange="change($event)"
                         >
@@ -74,27 +82,20 @@
                 width="100%"
                 height="176px"
                 :allow-preview="true"
-                :allow-replace="true"
-                :allow-remove="true"
+                :allow-replace="! readOnly"
+                :allow-remove="! readOnly"
+                :allow-download="allowDownload"
+                :show-drag-handle="! readOnly"
                 :show-badge="true"
                 :show-extension="false"
                 @preview="preview"
                 @replace="replace"
                 @remove="remove"
-            >
-                <template #actions="{ media }">
-                    <a
-                        :href="media.url"
-                        target="_blank"
-                        class="icon-down-stat rounded bg-white/20 p-1.5 text-white"
-                        aria-label="@lang('admin::app.export.download')"
-                        @click.stop
-                    ></a>
-                </template>
-            </v-media-card>
+            ></v-media-card>
 
-            <input type="hidden" :name="name" v-if="! inputFile.is_new && inputFile.value" :value="inputFile.value"/>
+            <input type="hidden" :name="name" v-if="! readOnly && ! inputFile.is_new && inputFile.value" :value="inputFile.value"/>
             <input
+                v-if="! readOnly"
                 type="file"
                 :name="name + '[]'"
                 class="hidden"
@@ -148,7 +149,17 @@
                 errors: {
                     type: Object,
                     default: () => {}
-                }
+                },
+
+                readOnly: {
+                    type: Boolean,
+                    default: false,
+                },
+
+                allowDownload: {
+                    type: Boolean,
+                    default: false,
+                },
             },
 
             data() {
@@ -262,7 +273,7 @@
         app.component('v-media-files-item', {
             template: '#v-media-files-item-template',
 
-            props: ['index', 'inputFile', 'name', 'width', 'height', 'acceptedExtensions'],
+            props: ['index', 'inputFile', 'name', 'width', 'height', 'acceptedExtensions', 'readOnly', 'allowDownload'],
 
             computed: {
                 cardMedia() {
@@ -273,6 +284,8 @@
                         name: fileName,
                         type: this.inputFile?.file?.type ?? 'application/pdf',
                         extension: (fileName.split('.').pop() || 'pdf').toLowerCase(),
+                        value: this.inputFile?.value,
+                        is_new: this.inputFile?.is_new,
                     };
                 },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/media/gallery.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/gallery.blade.php
@@ -8,6 +8,8 @@
     'acceptedTypes'    => ['image/*', 'video/*'],
     'acceptedExtensions' => [],
     'instructions'       => '',
+    'readOnly'           => false,
+    'allowDownload'      => false,
 ])
 
 @php
@@ -22,6 +24,8 @@
     name="{{ $name }}"
     v-bind:allow-multiple="{{ $allowMultiple ? true : false }}"
     v-bind:show-placeholders="{{ $showPlaceholders ? 'true' : 'false' }}"
+    v-bind:read-only="{{ $readOnly ? 'true' : 'false' }}"
+    v-bind:allow-download="{{ $allowDownload ? 'true' : 'false' }}"
     @if ($dynamicUploadedImages)
         :uploaded-images="{{ $dynamicUploadedImages }}"
     @else
@@ -52,6 +56,7 @@
                     title="@lang('admin::app.components.media.images.add-media-btn')"
                     hint="@lang('admin::app.components.media.images.drag-drop-hint')"
                     allowed-types="@lang('admin::app.components.media.images.allowed-types'), @lang('admin::app.components.media.videos.allowed-types')"
+                    :read-only="readOnly"
                     @trigger="resetAIModal(); $refs.choiceImageModal.open()"
                     @drop="onDrop"
                 ></v-media-add-tile>
@@ -66,6 +71,7 @@
                     allowed-types="@lang('admin::app.components.media.images.allowed-types'), @lang('admin::app.components.media.videos.allowed-types')"
                     :accept="acceptAttribute"
                     :input-id="$.uid + '_imageInput'"
+                    :read-only="readOnly"
                     @change="add"
                     @drop="onDrop"
                 ></v-media-add-tile>
@@ -78,6 +84,7 @@
                     :list="images"
                     item-key="id"
                     handle=".icon-drag"
+                    :disabled="readOnly"
                 >
                     <template #item="{ element, index }">
                         <v-media-gallery-item
@@ -89,6 +96,8 @@
                             :height="height"
                             :accepted-types="acceptedTypes"
                             :accepted-extensions="acceptedExtensions"
+                            :read-only="readOnly"
+                            :allow-download="allowDownload"
                             @onRemove="remove($event)"
                         >
                         </v-media-gallery-item>
@@ -439,10 +448,11 @@
                 height="176px"
                 object-fit="cover"
                 :allow-preview="true"
-                :allow-replace="true"
-                :allow-remove="true"
+                :allow-replace="! readOnly"
+                :allow-remove="! readOnly"
+                :allow-download="allowDownload"
                 :allow-drag="true"
-                :show-drag-handle="true"
+                :show-drag-handle="! readOnly"
                 :show-extension="false"
                 :invalid="isInvalid"
                 @preview="previewMedia"
@@ -450,9 +460,10 @@
                 @remove="remove"
             ></v-media-card>
 
-            <input type="hidden" :name="name + '[' + image.id + ']'" v-if="allowMultiple && ! image.is_new && image.value" :value="image.value"/>
-            <input type="hidden" :name="name" v-if="! allowMultiple && ! image.is_new && image.value" :value="image.value"/>
+            <input type="hidden" :name="name + '[' + image.id + ']'" v-if="! readOnly && allowMultiple && ! image.is_new && image.value" :value="image.value"/>
+            <input type="hidden" :name="name" v-if="! readOnly && ! allowMultiple && ! image.is_new && image.value" :value="image.value"/>
             <input
+                v-if="! readOnly"
                 type="file"
                 :name="name + '[]'"
                 class="hidden"
@@ -536,7 +547,17 @@
                 errors: {
                     type: Object,
                     default: () => {}
-                }
+                },
+
+                readOnly: {
+                    type: Boolean,
+                    default: false,
+                },
+
+                allowDownload: {
+                    type: Boolean,
+                    default: false,
+                },
             },
 
             data() {
@@ -950,7 +971,7 @@
         app.component('v-media-gallery-item', {
             template: '#v-media-gallery-item-template',
 
-            props: ['allowMultiple', 'index', 'image', 'name', 'width', 'height', 'acceptedTypes', 'acceptedExtensions'],
+            props: ['allowMultiple', 'index', 'image', 'name', 'width', 'height', 'acceptedTypes', 'acceptedExtensions', 'readOnly', 'allowDownload'],
 
             computed: {
                 acceptAttribute() {

--- a/packages/Webkul/Admin/src/Resources/views/components/media/gallery.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/gallery.blade.php
@@ -85,6 +85,7 @@
                     item-key="id"
                     handle=".icon-drag"
                     :disabled="readOnly"
+                    @change="signalChange"
                 >
                     <template #item="{ element, index }">
                         <v-media-gallery-item
@@ -460,7 +461,7 @@
                 @remove="remove"
             ></v-media-card>
 
-            <input type="hidden" :name="name + '[' + image.id + ']'" v-if="! readOnly && allowMultiple && ! image.is_new && image.value" :value="image.value"/>
+            <input type="hidden" :name="name + '[' + index + ']'" v-if="! readOnly && allowMultiple && ! image.is_new && image.value" :value="image.value"/>
             <input type="hidden" :name="name" v-if="! readOnly && ! allowMultiple && ! image.is_new && image.value" :value="image.value"/>
             <input
                 v-if="! readOnly"

--- a/packages/Webkul/Admin/src/Resources/views/components/media/image.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/media/image.blade.php
@@ -12,6 +12,8 @@
     'fullPreview'        => true,
     'acceptedExtensions' => [],
     'instructions'         => '',
+    'readOnly'           => false,
+    'allowDownload'      => false,
 ])
 
 @php
@@ -38,6 +40,8 @@
     v-bind:responsive="{{ $responsive ? 'true' : 'false' }}"
     v-bind:has-context="{{ $hasContext ? 'true' : 'false' }}"
     v-bind:full-preview="{{ $fullPreview ? 'true' : 'false' }}"
+    v-bind:read-only="{{ $readOnly ? 'true' : 'false' }}"
+    v-bind:allow-download="{{ $allowDownload ? 'true' : 'false' }}"
     :accepted-extensions='@json($acceptedExtensions)'
     :errors="errors"
 >
@@ -72,6 +76,7 @@
                         title="@lang('admin::app.components.media.images.add-image-btn')"
                         :hint="showUploadHint ? @js(trans('admin::app.components.media.images.drag-drop-hint')) : ''"
                         :allowed-types="allowedTypesLabel"
+                        :read-only="readOnly"
                         @trigger="resetAIModal(); $refs.choiceImageModal.open()"
                         @drop="onDrop"
                     ></v-media-add-tile>
@@ -85,6 +90,7 @@
                         :allowed-types="allowedTypesLabel"
                         :accept="acceptAttribute"
                         :input-id="$.uid + '_imageInput'"
+                        :read-only="readOnly"
                         @change="add"
                         @drop="onDrop"
                     ></v-media-add-tile>
@@ -96,6 +102,7 @@
                     v-bind="{animation: 200}"
                     :list="images"
                     item-key="id"
+                    :disabled="readOnly"
                 >
                     <template #item="{ element, index }">
                         <v-media-image-item
@@ -108,6 +115,8 @@
                             :responsive="responsive"
                             :fullPreview="fullPreview"
                             :accepted-extensions="acceptedExtensions"
+                            :read-only="readOnly"
+                            :allow-download="allowDownload"
                             @onRemove="remove($event)"
                         >
                         </v-media-image-item>
@@ -443,8 +452,10 @@
                 :height="responsive ? '176px' : `calc(${height} + 36px)`"
                 :object-fit="objectFit"
                 :allow-preview="true"
-                :allow-replace="true"
-                :allow-remove="true"
+                :allow-replace="! readOnly"
+                :allow-remove="! readOnly"
+                :allow-download="allowDownload"
+                :show-drag-handle="! readOnly"
                 :show-extension="false"
                 :invalid="isInvalid"
                 @preview="preview"
@@ -452,8 +463,9 @@
                 @remove="remove"
             ></v-media-card>
 
-            <input type="hidden" :name="name" v-if="! image.is_new && image.value" :value="image.value"/>
+            <input type="hidden" :name="name" v-if="! readOnly && ! image.is_new && image.value" :value="image.value"/>
             <input
+                v-if="! readOnly"
                 type="file"
                 :name="name + '[]'"
                 class="hidden"
@@ -479,16 +491,18 @@
                 </x-slot>
             </x-admin::modal>
 
-            <x-admin::modal ref="imagePreviewModalFull" no-class="true">
-                <x-slot:content>
-                    <v-image-viewer
-                        v-if="image"
-                        :src="image.url"
-                        :file-name="getDisplayFileName(image)"
-                        @close="closeFullPreview"
-                    ></v-image-viewer>
-                </x-slot>
-            </x-admin::modal>
+            <Teleport to="body">
+                <x-admin::modal ref="imagePreviewModalFull" no-class="true">
+                    <x-slot:content>
+                        <v-image-viewer
+                            v-if="image"
+                            :src="image.url"
+                            :file-name="getDisplayFileName(image)"
+                            @close="closeFullPreview"
+                        ></v-image-viewer>
+                    </x-slot>
+                </x-admin::modal>
+            </Teleport>
 
         </div>
     </script>
@@ -560,6 +574,16 @@
                 },
 
                 fullPreview: {
+                    type: Boolean,
+                    default: false,
+                },
+
+                readOnly: {
+                    type: Boolean,
+                    default: false,
+                },
+
+                allowDownload: {
                     type: Boolean,
                     default: false,
                 },
@@ -1001,7 +1025,7 @@
         app.component('v-media-image-item', {
             template: '#v-media-image-item-template',
 
-            props: ['index', 'image', 'name', 'width', 'height', 'objectFit', 'responsive', 'fullPreview', 'acceptedExtensions'],
+            props: ['index', 'image', 'name', 'width', 'height', 'objectFit', 'responsive', 'fullPreview', 'acceptedExtensions', 'readOnly', 'allowDownload'],
 
             computed: {
                 acceptAttribute() {

--- a/packages/Webkul/Admin/src/Resources/views/components/products/dynamic-attribute-fields.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/products/dynamic-attribute-fields.blade.php
@@ -91,6 +91,8 @@
 
         $isLocked = isset($lockedFields[$field->code]);
 
+        $isReadOnlyMedia = $isLocked && in_array($field->type, ['image', 'gallery', 'file'], true);
+
         $lockLevel = $isLocked ? ($lockedFields[$field->code]['level'] ?? null) : null;
 
         $isAxisLock = $isLocked && ! empty($lockedFields[$field->code]['axis']);
@@ -203,8 +205,8 @@
             </div>
         </div>
 
-        <fieldset @disabled($isLocked) class="border-0 p-0 m-0 min-w-0 {{ $isLocked ? 'opacity-60 cursor-not-allowed' : '' }}">
-        @if ($isLocked)
+        <fieldset @disabled($isLocked && ! $isReadOnlyMedia) class="border-0 p-0 m-0 min-w-0 {{ $isLocked && ! $isReadOnlyMedia ? 'opacity-60 cursor-not-allowed' : '' }}">
+        @if ($isLocked && ! $isReadOnlyMedia)
             <div class="pointer-events-none">
         @endif
 
@@ -272,7 +274,7 @@
                     ] : [];
                 @endphp
 
-                @if (! empty($value))
+                @if (! empty($value) && ! $isReadOnlyMedia)
                     <input type="hidden" name="{{ $fieldName }}" value="">
                 @endIf
 
@@ -287,6 +289,8 @@
                     height="140px"
                     :has-context="true"
                     :full-preview="true"
+                    :read-only="$isReadOnlyMedia"
+                    :allow-download="true"
                 />
                 @break
             @case('gallery')
@@ -305,7 +309,7 @@
                     }, (array)$value, array_keys((array)$value)) : [];
                 @endphp
 
-                @if (! empty($value))
+                @if (! empty($value) && ! $isReadOnlyMedia)
                     <input type="hidden" name="{{ $fieldName }}" value="">
                 @endIf
 
@@ -319,6 +323,8 @@
                     :allow-multiple=true
                     width="270px"
                     height="140px"
+                    :read-only="$isReadOnlyMedia"
+                    :allow-download="true"
                 />
                 @break
             @case('file')
@@ -334,7 +340,7 @@
                     ] : [];
                 @endphp
 
-                @if (! empty($value))
+                @if (! empty($value) && ! $isReadOnlyMedia)
                     <input type="hidden" name="{{ $fieldName }}" value="">
                 @endIf
 
@@ -348,6 +354,8 @@
                     :instructions="$fieldInstructions"
                     value="{{$value}}"
                     class="mt-3"
+                    :read-only="$isReadOnlyMedia"
+                    :allow-download="true"
                 />
                 @break
             @case('price')
@@ -526,7 +534,7 @@
                 </x-admin::form.control-group.control>
 
         @endswitch
-        @if ($isLocked)
+        @if ($isLocked && ! $isReadOnlyMedia)
             </div>
         @endif
         </fieldset>

--- a/packages/Webkul/Admin/src/Routes/rest-routes.php
+++ b/packages/Webkul/Admin/src/Routes/rest-routes.php
@@ -8,6 +8,7 @@ use Webkul\Admin\Http\Controllers\MagicAI\MagicAIController;
 use Webkul\Admin\Http\Controllers\MagicAI\MagicAIPlatformController;
 use Webkul\Admin\Http\Controllers\MagicAI\MagicAISystemPromptController;
 use Webkul\Admin\Http\Controllers\ManageColumnController;
+use Webkul\Admin\Http\Controllers\MediaController;
 use Webkul\Admin\Http\Controllers\TinyMCEController;
 use Webkul\Admin\Http\Controllers\User\AccountController;
 use Webkul\Admin\Http\Controllers\User\AclVersionController;
@@ -20,6 +21,8 @@ use Webkul\HistoryControl\Http\Controllers\HistoryController;
  */
 Route::group(['middleware' => ['admin'], 'prefix' => config('app.admin_url')], function () {
     Route::get('acl-version', [AclVersionController::class, 'show'])->name('admin.acl.version');
+
+    Route::get('media/download', [MediaController::class, 'download'])->name('admin.media.download');
 
     /**
      * Dashboard routes.

--- a/packages/Webkul/Admin/tests/Feature/Catalog/LockedMediaFieldRenderTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/LockedMediaFieldRenderTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Str;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeFamily;
+use Webkul\Product\Models\Product;
+use Webkul\Product\Models\VariantStructure;
+use Webkul\Product\Models\VariantStructureAttribute;
+use Webkul\Product\Models\VariantStructureAxis;
+use Webkul\Product\Repositories\ProductRepository;
+
+uses(DatabaseTransactions::class);
+
+/**
+ * Builds a configurable -> simple(variant) tree with a locked gallery, an
+ * owned gallery and a locked text attribute.
+ */
+function lockedMediaFieldFixture(): array
+{
+    $axisCode = 'axis_'.Str::random(8);
+    $lockedGalleryCode = 'lgal_'.Str::random(8);
+    $ownedGalleryCode = 'ogal_'.Str::random(8);
+    $lockedTextCode = 'ltxt_'.Str::random(8);
+
+    $axis = Attribute::factory()->create(['code' => $axisCode, 'type' => 'select']);
+
+    $lockedGallery = Attribute::factory()->create([
+        'code'              => $lockedGalleryCode,
+        'type'              => 'gallery',
+        'value_per_locale'  => 0,
+        'value_per_channel' => 0,
+    ]);
+
+    $ownedGallery = Attribute::factory()->create([
+        'code'              => $ownedGalleryCode,
+        'type'              => 'gallery',
+        'value_per_locale'  => 0,
+        'value_per_channel' => 0,
+    ]);
+
+    Attribute::factory()->create([
+        'code'              => $lockedTextCode,
+        'type'              => 'text',
+        'value_per_locale'  => 0,
+        'value_per_channel' => 0,
+    ]);
+
+    $family = AttributeFamily::factory()->create();
+
+    AttributeFamily::factory()->linkAttributeGroupToFamily($family);
+    AttributeFamily::factory()->linkAttributesToFamily($family, Attribute::whereIn('code', [
+        $axisCode,
+        $lockedGalleryCode,
+        $ownedGalleryCode,
+        $lockedTextCode,
+    ])->get());
+
+    $structure = VariantStructure::create([
+        'attribute_family_id' => $family->id,
+        'code'                => 'vs_'.Str::random(8),
+        'name'                => 'VS',
+        'levels'              => 1,
+    ]);
+
+    VariantStructureAxis::insert([
+        ['variant_structure_id' => $structure->id, 'attribute_id' => $axis->id, 'level' => 'level_1', 'position' => 0],
+    ]);
+
+    VariantStructureAttribute::create([
+        'variant_structure_id' => $structure->id,
+        'attribute_id'         => $ownedGallery->id,
+        'level'                => 'variant',
+    ]);
+
+    $configurable = app(ProductRepository::class)->create([
+        'type'                 => 'configurable',
+        'attribute_family_id'  => $family->id,
+        'sku'                  => 'CFG-'.Str::random(8),
+        'variant_structure_id' => $structure->id,
+        'super_attributes'     => [$axisCode],
+    ]);
+
+    $configurable->values = [
+        'common' => [
+            'sku'                => $configurable->sku,
+            $lockedGalleryCode   => ['product/parent/locked-cover.jpg', 'product/parent/locked-detail.jpg'],
+            $lockedTextCode      => 'PARENT-LOCKED-TEXT-VALUE',
+        ],
+    ];
+
+    $configurable->save();
+
+    $child = $configurable->getTypeInstance()->createVariant($configurable, $configurable->super_attributes, [
+        'parent_id' => $configurable->id,
+        'sku'       => $configurable->sku.'-v1',
+        'values'    => ['common' => [$axisCode => $axis->options->first()->code]],
+    ]);
+
+    $child = Product::find($child->id);
+
+    $childCommonValues = $child->values['common'] ?? [];
+    $childCommonValues[$ownedGalleryCode] = ['product/child/owned-cover.jpg'];
+
+    $child->values = array_merge($child->values ?? [], ['common' => $childCommonValues]);
+    $child->save();
+
+    return [
+        'configurable'      => $configurable->fresh(),
+        'child'             => Product::find($child->id),
+        'axisCode'          => $axisCode,
+        'lockedGalleryCode' => $lockedGalleryCode,
+        'ownedGalleryCode'  => $ownedGalleryCode,
+        'lockedTextCode'    => $lockedTextCode,
+    ];
+}
+
+/**
+ * Returns the opening tag of the media component for the given attribute.
+ */
+function mediaComponentOpenTag(string $html, string $tag, string $attributeCode): string
+{
+    $pattern = '/<'.preg_quote($tag, '/').'\s+id="'.preg_quote($attributeCode, '/').'"/';
+
+    $matched = preg_match($pattern, $html, $matches, PREG_OFFSET_CAPTURE);
+
+    expect($matched)->toBe(1);
+
+    $start = $matches[0][1];
+
+    $end = strpos($html, '>', $start);
+
+    return substr($html, $start, $end - $start + 1);
+}
+
+/**
+ * Returns [offset, tag] for the fieldset opening tag preceding a position.
+ */
+function fieldsetOpenTagBefore(string $html, int $position): array
+{
+    $fieldsetStart = strrpos(substr($html, 0, $position), '<fieldset');
+
+    expect($fieldsetStart)->not->toBeFalse();
+
+    $tagEnd = strpos($html, '>', $fieldsetStart);
+
+    return [$fieldsetStart, substr($html, $fieldsetStart, $tagEnd - $fieldsetStart + 1)];
+}
+
+describe('read-only rendering of locked media attribute fields', function () {
+    it('renders v-bind:read-only="true" on a gallery field locked at an ancestor level', function () {
+        $this->loginAsAdmin();
+
+        $fixture = lockedMediaFieldFixture();
+
+        $content = $this->get(route('admin.catalog.products.edit', $fixture['child']->id))
+            ->assertOk()
+            ->getContent();
+
+        $lockedTag = mediaComponentOpenTag($content, 'v-media-gallery', $fixture['lockedGalleryCode']);
+
+        expect($lockedTag)->toContain('v-bind:read-only="true"');
+    });
+
+    it('renders v-bind:read-only="false" on a gallery field the product owns at its own level', function () {
+        $this->loginAsAdmin();
+
+        $fixture = lockedMediaFieldFixture();
+
+        $content = $this->get(route('admin.catalog.products.edit', $fixture['child']->id))
+            ->assertOk()
+            ->getContent();
+
+        $ownedTag = mediaComponentOpenTag($content, 'v-media-gallery', $fixture['ownedGalleryCode']);
+
+        expect($ownedTag)->toContain('v-bind:read-only="false"');
+    });
+
+    it('does not wrap the locked media field in the disabled fieldset or pointer-events-none div', function () {
+        $this->loginAsAdmin();
+
+        $fixture = lockedMediaFieldFixture();
+
+        $content = $this->get(route('admin.catalog.products.edit', $fixture['child']->id))
+            ->assertOk()
+            ->getContent();
+
+        $lockedTag = mediaComponentOpenTag($content, 'v-media-gallery', $fixture['lockedGalleryCode']);
+
+        $lockedTagPosition = strpos($content, $lockedTag);
+
+        [$fieldsetStart, $fieldsetTag] = fieldsetOpenTagBefore($content, $lockedTagPosition);
+
+        expect($fieldsetTag)->not->toContain('disabled')
+            ->and($fieldsetTag)->not->toContain('opacity-60')
+            ->and($fieldsetTag)->not->toContain('cursor-not-allowed');
+
+        $wrapperSegment = substr($content, $fieldsetStart, $lockedTagPosition - $fieldsetStart);
+
+        expect($wrapperSegment)->not->toContain('pointer-events-none');
+    });
+
+    it('still wraps a non-media locked attribute in the disabled fieldset and pointer-events-none div', function () {
+        $this->loginAsAdmin();
+
+        $fixture = lockedMediaFieldFixture();
+
+        $content = $this->get(route('admin.catalog.products.edit', $fixture['child']->id))
+            ->assertOk()
+            ->getContent();
+
+        $inputPosition = strpos($content, 'name="values[common]['.$fixture['lockedTextCode'].']"');
+
+        expect($inputPosition)->not->toBeFalse();
+
+        [$fieldsetStart, $fieldsetTag] = fieldsetOpenTagBefore($content, $inputPosition);
+
+        expect($fieldsetTag)->toContain('disabled')
+            ->and($fieldsetTag)->toContain('opacity-60')
+            ->and($fieldsetTag)->toContain('cursor-not-allowed');
+
+        $wrapperSegment = substr($content, $fieldsetStart, $inputPosition - $fieldsetStart);
+
+        expect($wrapperSegment)->toContain('pointer-events-none');
+    });
+});

--- a/packages/Webkul/Admin/tests/Feature/MediaDownloadTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MediaDownloadTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Storage;
+use Webkul\User\Models\Admin;
+use Webkul\User\Models\Role;
 
 use function Pest\Laravel\get;
 
@@ -57,4 +59,35 @@ it('returns a 404 for an allow-listed, allowed-extension path that does not exis
 
     get(route('admin.media.download', ['path' => 'product/1/image/missing.jpg']))
         ->assertNotFound();
+});
+
+it('rejects a media download for an admin without the owning module permission', function () {
+    $role = Role::factory()->create([
+        'permission_type' => 'custom',
+        'permissions'     => ['catalog.categories'],
+    ]);
+
+    $this->loginAsAdmin(Admin::factory()->create(['role_id' => $role->id]));
+
+    Storage::fake();
+    Storage::put('product/1/image/photo.jpg', 'fake-image-bytes');
+
+    get(route('admin.media.download', ['path' => 'product/1/image/photo.jpg']))
+        ->assertForbidden()
+        ->assertSee(trans('admin::app.common.unauthorized'));
+});
+
+it('allows a media download for an admin holding the owning module permission', function () {
+    $role = Role::factory()->create([
+        'permission_type' => 'custom',
+        'permissions'     => ['catalog.categories'],
+    ]);
+
+    $this->loginAsAdmin(Admin::factory()->create(['role_id' => $role->id]));
+
+    Storage::fake();
+    Storage::put('category/1/banner/photo.jpg', 'fake-image-bytes');
+
+    get(route('admin.media.download', ['path' => 'category/1/banner/photo.jpg']))
+        ->assertOk();
 });

--- a/packages/Webkul/Admin/tests/Feature/MediaDownloadTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MediaDownloadTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\get;
+
+it('redirects a guest to login', function () {
+    get(route('admin.media.download', ['path' => 'product/1/image/photo.jpg']))
+        ->assertRedirect(route('admin.session.create'));
+});
+
+it('downloads an allow-listed product media file for an authenticated admin', function () {
+    $this->loginAsAdmin();
+
+    Storage::fake();
+    Storage::put('product/1/image/photo.jpg', 'fake-image-bytes');
+
+    $response = get(route('admin.media.download', ['path' => 'product/1/image/photo.jpg']))
+        ->assertOk();
+
+    expect($response->headers->get('Content-Disposition'))->toContain('attachment');
+});
+
+it('rejects a path traversal attempt with a 404', function () {
+    $this->loginAsAdmin();
+
+    Storage::fake();
+
+    get(route('admin.media.download', ['path' => 'product/../../.env']))
+        ->assertNotFound();
+});
+
+it('rejects a path outside the allow-listed roots with a 404', function () {
+    $this->loginAsAdmin();
+
+    Storage::fake();
+    Storage::put('framework/cache/x.php', 'not-media');
+
+    get(route('admin.media.download', ['path' => 'framework/cache/x.php']))
+        ->assertNotFound();
+});
+
+it('rejects an allow-listed root with a disallowed extension with a 403', function () {
+    $this->loginAsAdmin();
+
+    Storage::fake();
+    Storage::put('product/1/f/x.php', '<?php echo "no"; ?>');
+
+    get(route('admin.media.download', ['path' => 'product/1/f/x.php']))
+        ->assertForbidden();
+});
+
+it('returns a 404 for an allow-listed, allowed-extension path that does not exist', function () {
+    $this->loginAsAdmin();
+
+    Storage::fake();
+
+    get(route('admin.media.download', ['path' => 'product/1/image/missing.jpg']))
+        ->assertNotFound();
+});

--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -525,6 +525,8 @@ abstract class AbstractType
                                 : $val;
                         }, $fieldValue);
 
+                        ksort($values[$field]);
+
                         $values[$field] = array_values($values[$field]);
                     } elseif ($fieldValue !== [] && current($fieldValue) instanceof UploadedFile) {
                         $uploadedFile = current($fieldValue);

--- a/tests/e2e-pw/tests/01-catalog/galleryReorderUnsavedChanges.spec.js
+++ b/tests/e2e-pw/tests/01-catalog/galleryReorderUnsavedChanges.spec.js
@@ -1,0 +1,249 @@
+const path = require('path');
+const { test, expect } = require('../../utils/fixtures');
+const { clickSave, navigateTo, generateUid, fillLocalizedField } = require('../../utils/helpers');
+const { gotoTab, assignAttributesToGroup, saveFamilyEdit } = require('../../utils/family-helpers');
+
+/**
+ * Reordering gallery media marks the product form dirty.
+ */
+
+const FAMILY_ID = 1;
+const IMAGE_1 = path.resolve(__dirname, '../../utils/berlin.jpeg');
+const IMAGE_2 = path.resolve(__dirname, '../../utils/bikes.jpeg');
+
+test.describe.configure({ timeout: 240_000 });
+
+/** Fill a TinyMCE editor by textarea ID and sync it for VeeValidate. */
+async function fillTinyMCE(page, editorId, text) {
+  const iframe = page.locator(`#${editorId}_ifr`);
+  await iframe.scrollIntoViewIfNeeded();
+  await iframe.waitFor({ state: 'visible', timeout: 10000 });
+  const frame = page.frameLocator(`#${editorId}_ifr`);
+  await frame.locator('body[contenteditable="true"]').waitFor({ state: 'visible', timeout: 10000 });
+  await frame.locator('body').click();
+  await page.keyboard.type(text);
+  await page.evaluate((id) => {
+    const editor = tinymce.get(id);
+    if (editor) {
+      editor.fire('change');
+      editor.save();
+    }
+  }, editorId);
+}
+
+/** Select a value from a Vue-multiselect dropdown by field name. */
+async function selectMultiselect(page, fieldName, optionLabel) {
+  const wrapper = page.locator(`input[name="${fieldName}"]`)
+    .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " multiselect ")][1]');
+  await wrapper.locator('.multiselect__tags').click();
+  await wrapper.locator('.multiselect__content-wrapper').first().waitFor({ state: 'visible', timeout: 5000 });
+  if (optionLabel) {
+    await wrapper.locator(`input[name="${fieldName}"][type="text"]`).fill(optionLabel).catch(() => {});
+    await page.getByRole('option', { name: optionLabel }).first().click();
+  } else {
+    await wrapper
+      .locator('.multiselect__element:not(.multiselect__element--disabled) .multiselect__option:not(.multiselect__option--disabled)')
+      .first()
+      .click();
+  }
+  await page.keyboard.press('Escape');
+}
+
+/** Create a Gallery-type attribute and land on its edit page. */
+async function createGalleryAttribute(adminPage, code, name) {
+  await navigateTo(adminPage, 'attributes');
+  await adminPage.getByRole('button', { name: 'Create Attribute' }).click();
+  await adminPage.waitForLoadState('networkidle');
+  await adminPage.getByRole('textbox', { name: 'Code' }).fill(code);
+  await adminPage.locator('input[name="type"]').locator('..').locator('.multiselect__placeholder').click();
+  await adminPage.locator('input[name="type"][type="text"]').fill('Gallery');
+  await adminPage.getByRole('option', { name: 'Gallery' }).first().click();
+  await fillLocalizedField(adminPage, name);
+  await Promise.all([
+    adminPage.waitForURL(/\/attributes\/edit\//, { timeout: 20000 }),
+    clickSave(adminPage, 'Save Attribute'),
+  ]);
+  await expect(adminPage.locator('#app').getByText('Edit Attribute').first()).toBeVisible();
+}
+
+/** Assign an attribute into the family's Media group and persist it. */
+async function assignAttributeToMediaGroup(adminPage, code) {
+  await gotoTab(adminPage, FAMILY_ID);
+  await adminPage.locator('.group_node').first().waitFor({ state: 'visible', timeout: 30000 });
+  await assignAttributesToGroup(adminPage, [code], 'Media');
+  await saveFamilyEdit(adminPage);
+}
+
+/** Delete an attribute by code, safe if already absent. */
+async function deleteAttributeByCode(adminPage, code) {
+  await navigateTo(adminPage, 'attributes');
+  await adminPage.getByRole('textbox', { name: 'Search', exact: true }).fill(code);
+  await adminPage.keyboard.press('Enter');
+  await adminPage.waitForLoadState('networkidle');
+  const deleteBtn = adminPage.locator('div', { hasText: code }).locator('span[title="Delete"]').first();
+  if (await deleteBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await deleteBtn.click();
+    await adminPage.locator('.max-w-\\[400px\\]').getByRole('button', { name: 'Delete', exact: true }).click();
+    await adminPage.waitForLoadState('networkidle');
+  }
+}
+
+/** Delete a product by SKU, safe if already absent. */
+async function deleteProductBySku(adminPage, sku) {
+  await navigateTo(adminPage, 'products');
+  await adminPage.getByPlaceholder('Search').first().fill(sku);
+  await adminPage.keyboard.press('Enter');
+  await adminPage.waitForLoadState('load');
+  const deleteIcon = adminPage.locator('span[title="Delete"]').first();
+  const visible = await deleteIcon.isVisible({ timeout: 3000 }).catch(() => false);
+  if (!visible) return;
+  await deleteIcon.click();
+  await adminPage.getByRole('button', { name: 'Delete' }).click();
+  await adminPage.locator('#app').getByText(/Product deleted successfully/i).waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+}
+
+/** Create a Simple product on the default family and land on its edit page. */
+async function createSimpleProduct(adminPage, sku) {
+  await navigateTo(adminPage, 'products');
+  await adminPage.getByRole('button', { name: 'Create Product' }).click();
+  await adminPage.waitForLoadState('networkidle');
+  await selectMultiselect(adminPage, 'type', 'Simple');
+  await selectMultiselect(adminPage, 'attribute_family_id', 'Default');
+  await adminPage.locator('input[name="sku"]').fill(sku);
+  await clickSave(adminPage, 'Save Product');
+  await adminPage.waitForURL(/\/admin\/catalog\/products\/edit\//, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await adminPage.waitForLoadState('networkidle').catch(() => {});
+}
+
+/** The Media attribute-group accordion panel. */
+function mediaGroupPanel(page) {
+  return page.locator('[data-attribute-group="media"]');
+}
+
+/** Expand the Media accordion group. */
+async function ensureMediaGroupOpen(page) {
+  const group = mediaGroupPanel(page);
+  await group.waitFor({ state: 'attached', timeout: 20000 });
+  const header = group.getByRole('button', { name: 'Media', exact: true });
+  const expanded = await header.getAttribute('aria-expanded').catch(() => null);
+  if (expanded === 'false') {
+    await header.click();
+  }
+}
+
+/** The control-group wrapper for one attribute field, located by its visible label. */
+function fieldGroup(page, label) {
+  return page.locator('[data-control-group]').filter({ hasText: label }).first();
+}
+
+/** Read the gallery's order-carrying hidden input values in DOM order. */
+async function readGalleryOrder(group) {
+  const inputs = group.locator('input[type="hidden"]');
+  const count = await inputs.count();
+  const values = [];
+  for (let i = 0; i < count; i++) {
+    const value = await inputs.nth(i).getAttribute('value');
+    if (value) values.push(value);
+  }
+  return values;
+}
+
+/** Drag the first gallery tile onto the second via its drag handle. */
+async function dragFirstTileToSecond(tiles) {
+  const toBox = await tiles.nth(1).boundingBox();
+  await tiles.first().locator('.icon-drag').dragTo(tiles.nth(1), {
+    targetPosition: { x: toBox.width - 5, y: toBox.height / 2 },
+  });
+}
+
+test.describe('Gallery reorder marks the product form dirty', () => {
+  test.use({ viewport: { width: 1920, height: 1080 } });
+
+  test('dragging a gallery image to a new position surfaces the unsaved-changes bar', async ({ adminPage }) => {
+    test.setTimeout(240000);
+
+    const uid = generateUid();
+    const code = `gallery_e2e_${uid}`;
+    const label = `Gallery Reorder QA ${uid}`;
+    const sku = `gal-reorder-${uid}`;
+
+    let attributeCreated = false;
+    let productCreated = false;
+
+    try {
+      await test.step('provision a multi-valued gallery attribute on the Media group', async () => {
+        await createGalleryAttribute(adminPage, code, label);
+        attributeCreated = true;
+        await assignAttributeToMediaGroup(adminPage, code);
+      });
+
+      await test.step('create a product and upload two gallery images', async () => {
+        await createSimpleProduct(adminPage, sku);
+        productCreated = true;
+
+        await ensureMediaGroupOpen(adminPage);
+
+        const group = fieldGroup(adminPage, label);
+        await expect(group).toBeVisible({ timeout: 15000 });
+
+        await group.locator('input[type="file"]').first().setInputFiles([IMAGE_1, IMAGE_2]);
+
+        await adminPage.locator('#name').fill(`Gallery Reorder ${sku}`);
+        await adminPage.locator('#url_key').fill(`gallery-reorder-${sku}`);
+        const priceInputs = adminPage.locator('[id^="price_"], #price');
+        const priceCount = await priceInputs.count();
+        for (let i = 0; i < priceCount; i++) {
+          await priceInputs.nth(i).fill('100');
+        }
+        await fillTinyMCE(adminPage, 'short_description', 'Gallery reorder E2E fixture');
+        await fillTinyMCE(adminPage, 'description', 'Gallery reorder E2E fixture');
+
+        await clickSave(adminPage, 'Save Product');
+        await expect(adminPage.locator('#app').getByText(/Product updated successfully/i)).toBeVisible({ timeout: 20000 });
+      });
+
+      let beforeOrder;
+      let afterOrder;
+
+      await test.step('reload to the persisted state, then drag-reorder the two images', async () => {
+        await adminPage.reload({ waitUntil: 'domcontentloaded' });
+        await adminPage.waitForLoadState('networkidle').catch(() => {});
+        await ensureMediaGroupOpen(adminPage);
+
+        const group = fieldGroup(adminPage, label);
+        const tiles = group.locator('.group.relative');
+        await expect(tiles).toHaveCount(2, { timeout: 15000 });
+
+        beforeOrder = await readGalleryOrder(group);
+        expect(beforeOrder).toHaveLength(2);
+
+        await dragFirstTileToSecond(tiles);
+
+        afterOrder = await readGalleryOrder(group);
+      });
+
+      await test.step('the drag actually reordered the images', async () => {
+        expect(afterOrder).toHaveLength(2);
+        expect(afterOrder).not.toEqual(beforeOrder);
+        expect([...afterOrder].sort()).toEqual([...beforeOrder].sort());
+      });
+
+      await test.step('the unsaved-changes bar and field badge appear (the regression guard)', async () => {
+        await expect(adminPage.getByText('You have unsaved changes')).toBeVisible({ timeout: 10000 });
+        await expect(adminPage.getByRole('button', { name: 'Discard' })).toBeVisible();
+        await expect(adminPage.getByRole('button', { name: 'Save changes' })).toBeVisible();
+
+        const group = fieldGroup(adminPage, label);
+        await expect(group.locator('.unsaved-badge')).toBeVisible({ timeout: 5000 });
+        await expect(group.locator('.unsaved-badge')).toHaveText('Unsaved');
+      });
+    } finally {
+      if (productCreated) {
+        await deleteProductBySku(adminPage, sku);
+      }
+      if (attributeCreated) {
+        await deleteAttributeByCode(adminPage, code);
+      }
+    }
+  });
+});

--- a/tests/e2e-pw/tests/01-catalog/mediaDownloadAndLockedFields.spec.js
+++ b/tests/e2e-pw/tests/01-catalog/mediaDownloadAndLockedFields.spec.js
@@ -1,0 +1,291 @@
+const path = require('path');
+const { test, expect } = require('../../utils/fixtures');
+const { navigateTo, clickSave, generateUid, searchInDataGrid } = require('../../utils/helpers');
+
+/**
+ * Media download button and read-only locked media fields on product edit.
+ */
+
+const IMAGE_FIXTURE = path.resolve(__dirname, '../../utils/berlin.jpeg');
+const FAMILY_ID = 1; // `default` — guaranteed on any install, mirrors product-variant-structure.spec.js
+const STRUCTURE_CODE = 'e2e_media_download_color_structure';
+const STRUCTURE_NAME = 'Media Download E2E Structure';
+const AXIS_VALUE = 'Red'; // seed `color` option; its code equals its label (see api/14-variants/variants.spec.js)
+
+/** Fill a TinyMCE editor by textarea ID and sync it for VeeValidate. */
+async function fillTinyMCE(page, editorId, text) {
+  const iframe = page.locator(`#${editorId}_ifr`);
+  await iframe.scrollIntoViewIfNeeded();
+  await iframe.waitFor({ state: 'visible', timeout: 10000 });
+  const frame = page.frameLocator(`#${editorId}_ifr`);
+  await frame.locator('body[contenteditable="true"]').waitFor({ state: 'visible', timeout: 10000 });
+  await frame.locator('body').click();
+  await page.keyboard.type(text);
+  await page.evaluate((id) => {
+    const editor = tinymce.get(id);
+    if (editor) {
+      editor.fire('change');
+      editor.save();
+    }
+  }, editorId);
+}
+
+/** Select a value from a Vue-multiselect dropdown by field name. */
+async function selectMultiselect(page, fieldName, optionLabel) {
+  const wrapper = page.locator(`input[name="${fieldName}"]`)
+    .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " multiselect ")][1]');
+  await wrapper.locator('.multiselect__tags').click();
+  await wrapper.locator('.multiselect__content-wrapper').first().waitFor({ state: 'visible', timeout: 5000 });
+  if (optionLabel) {
+    await wrapper.locator(`input[name="${fieldName}"][type="text"]`).fill(optionLabel).catch(() => {});
+    await page.getByRole('option', { name: optionLabel }).first().click();
+  } else {
+    await wrapper
+      .locator('.multiselect__element:not(.multiselect__element--disabled) .multiselect__option:not(.multiselect__option--disabled)')
+      .first()
+      .click();
+  }
+  await page.keyboard.press('Escape');
+}
+
+/**
+ * Ensure the `default` family carries a single-axis (Color) variant structure,
+ * preserving any structures other specs already created.
+ */
+async function ensureColorVariantStructure(adminPage) {
+  const result = await adminPage.evaluate(async ({ familyId, code, name }) => {
+    const xsrf = decodeURIComponent((document.cookie.match(/XSRF-TOKEN=([^;]+)/) || [])[1] || '');
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+      'X-XSRF-TOKEN': xsrf,
+    };
+
+    const listRes = await fetch(`/admin/catalog/attribute-families/edit/${familyId}/variant-structures`, { headers });
+    const listBody = await listRes.json();
+    const existing = listBody.data ?? [];
+
+    if (existing.some((structure) => structure.code === code)) {
+      return { status: 200, body: 'already exists' };
+    }
+
+    const structures = [
+      ...existing.map(({ code: c, name: n, levels, axes, placements }) => ({ code: c, name: n, levels, axes, placements })),
+      {
+        code,
+        name,
+        levels: 1,
+        axes: { level_1: ['color'] },
+        placements: {},
+      },
+    ];
+
+    const res = await fetch(`/admin/catalog/attribute-families/edit/${familyId}/variant-structures`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ _method: 'PUT', structures }),
+    });
+
+    return { status: res.status, body: await res.text() };
+  }, { familyId: FAMILY_ID, code: STRUCTURE_CODE, name: STRUCTURE_NAME });
+
+  if (result.status >= 300) {
+    throw new Error(`variant structure setup failed: ${result.body}`);
+  }
+}
+
+async function deleteProductBySku(adminPage, sku) {
+  await navigateTo(adminPage, 'products');
+  await searchInDataGrid(adminPage, sku);
+  const deleteIcon = adminPage.locator('span[title="Delete"]').first();
+  const visible = await deleteIcon.isVisible({ timeout: 3000 }).catch(() => false);
+  if (!visible) return;
+  await deleteIcon.click();
+  await adminPage.getByRole('button', { name: 'Delete' }).click();
+  await adminPage.locator('#app').getByText(/Product deleted successfully/i).waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+}
+
+/** The `media` attribute-group accordion panel. */
+function mediaGroup(page) {
+  return page.locator('[data-attribute-group="media"]');
+}
+
+/** Expand the group defensively. */
+async function ensureMediaGroupOpen(page) {
+  const group = mediaGroup(page);
+  await group.waitFor({ state: 'attached', timeout: 20000 });
+  const header = group.getByRole('button', { name: 'Media', exact: true });
+  const expanded = await header.getAttribute('aria-expanded').catch(() => null);
+  if (expanded === 'false') {
+    await header.click();
+  }
+  await expect(group.locator('label').filter({ hasText: 'Add Image' }).first().or(group.locator('.group.relative').first()))
+    .toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Media download button and read-only locked media fields', () => {
+  test('owned image field has full hover actions and a live add-tile; a locked (inherited) field on a variant child is read-only, download-only, and its add-tile is inert', async ({ adminPage }) => {
+    test.setTimeout(180000);
+
+    const parentSku = `mdl-cfg-${generateUid()}`;
+    const childSku = `${parentSku}-${AXIS_VALUE.toLowerCase()}`;
+
+    await navigateTo(adminPage, 'products');
+    await ensureColorVariantStructure(adminPage);
+    await adminPage.getByRole('button', { name: 'Create Product' }).click();
+    await adminPage.waitForLoadState('networkidle');
+
+    await selectMultiselect(adminPage, 'type', 'Configurable');
+    await selectMultiselect(adminPage, 'attribute_family_id', 'Default');
+    await adminPage.locator('input[name="sku"]').fill(parentSku);
+
+    const createModal = adminPage.locator('.fixed').filter({ hasText: 'Create New Product' }).first();
+    await createModal.getByRole('button', { name: 'Next', exact: true }).click();
+
+    await expect(adminPage.locator('#app').getByText('Variant Structure').first()).toBeVisible({ timeout: 10000 });
+    await selectMultiselect(adminPage, 'variant_structure_id', STRUCTURE_NAME);
+    await adminPage.getByRole('button', { name: 'Save Product', exact: true }).click();
+
+    await adminPage.waitForURL(/\/admin\/catalog\/products\/edit\/(\d+)/, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await adminPage.waitForLoadState('networkidle').catch(() => {});
+    const parentId = Number(adminPage.url().match(/\/edit\/(\d+)/)[1]);
+    const parentEditUrl = `/admin/catalog/products/edit/${parentId}`;
+
+    await ensureMediaGroupOpen(adminPage);
+
+    await test.step('owned, empty image field: add-tile is live', async () => {
+      const addTile = mediaGroup(adminPage).locator('label').filter({ hasText: 'Add Image' }).first();
+      await expect(addTile).toBeVisible();
+      await expect(addTile.locator('input[type="file"]')).toHaveCount(1);
+
+      const cursor = await addTile.evaluate((el) => getComputedStyle(el).cursor);
+      expect(cursor).toBe('pointer');
+    });
+
+    let childId;
+    await test.step('create a variant child under the color axis', async () => {
+      await adminPage.getByRole('button', { name: /Select Color/i }).click();
+      await adminPage.getByRole('button', { name: 'Add New', exact: true }).click();
+
+      const addModal = adminPage.locator('.fixed').filter({ hasText: /Add a new Color/i }).first();
+      await addModal.waitFor({ state: 'visible', timeout: 10000 });
+
+      await addModal.locator('.multiselect__tags').first().click();
+      await addModal.locator('.multiselect__content-wrapper').first().waitFor({ state: 'visible', timeout: 5000 });
+      await addModal.locator('.multiselect__option', { hasText: AXIS_VALUE }).first().click();
+
+      const createButton = addModal.getByRole('button', { name: 'Create', exact: true });
+      await expect(createButton).toBeEnabled({ timeout: 5000 });
+      await createButton.click();
+
+      await adminPage.waitForURL(/\/admin\/catalog\/products\/edit\/(\d+)/, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await adminPage.waitForLoadState('networkidle').catch(() => {});
+      childId = Number(adminPage.url().match(/\/edit\/(\d+)/)[1]);
+      expect(childId).not.toBe(parentId);
+    });
+
+    await test.step('locked, empty image field on the child: add-tile is inert', async () => {
+      await ensureMediaGroupOpen(adminPage);
+
+      const addTile = mediaGroup(adminPage).locator('label').filter({ hasText: 'Add Image' }).first();
+      await expect(addTile).toBeVisible();
+
+      expect(await addTile.getAttribute('for')).toBeNull();
+      await expect(addTile.locator('input[type="file"]')).toHaveCount(0);
+
+      const cursor = await addTile.evaluate((el) => getComputedStyle(el).cursor);
+      expect(cursor).toBe('not-allowed');
+
+      const styleBefore = await addTile.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return { bg: s.backgroundColor, border: s.borderColor };
+      });
+
+      await addTile.hover();
+
+      const styleAfter = await addTile.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return { bg: s.backgroundColor, border: s.borderColor };
+      });
+
+      expect(styleAfter).toEqual(styleBefore);
+    });
+
+    await test.step('upload an image on the owning (parent) product', async () => {
+      await adminPage.goto(parentEditUrl, { waitUntil: 'domcontentloaded' });
+      await adminPage.waitForLoadState('networkidle').catch(() => {});
+      await ensureMediaGroupOpen(adminPage);
+
+      const addTile = mediaGroup(adminPage).locator('label').filter({ hasText: 'Add Image' }).first();
+      await addTile.locator('input[type="file"]').setInputFiles(IMAGE_FIXTURE);
+
+      await adminPage.locator('#name').fill(`Media DL Parent ${parentSku}`);
+      await adminPage.locator('#url_key').fill(`media-dl-parent-${parentSku}`);
+      const priceInputs = adminPage.locator('[id^="price_"], #price');
+      const priceCount = await priceInputs.count();
+      for (let i = 0; i < priceCount; i++) {
+        await priceInputs.nth(i).fill('100');
+      }
+      await fillTinyMCE(adminPage, 'short_description', 'Media download E2E fixture');
+      await fillTinyMCE(adminPage, 'description', 'Media download E2E fixture');
+
+      await clickSave(adminPage, 'Save Product');
+      await expect(adminPage.locator('#app').getByText(/Product updated successfully/i)).toBeVisible({ timeout: 20000 });
+    });
+
+    await test.step('owned tile hover reveals preview, replace, delete and download', async () => {
+      await adminPage.reload({ waitUntil: 'domcontentloaded' });
+      await adminPage.waitForLoadState('networkidle').catch(() => {});
+      await ensureMediaGroupOpen(adminPage);
+
+      const card = mediaGroup(adminPage).locator('.group.relative').first();
+      await card.hover();
+
+      await expect(card.getByRole('button', { name: 'Preview image' })).toBeVisible();
+      await expect(card.getByRole('button', { name: 'Replace image' })).toBeVisible();
+      await expect(card.getByRole('button', { name: 'Delete image' })).toBeVisible();
+
+      const download = card.getByRole('link', { name: 'Download' });
+      await expect(download).toBeVisible();
+
+      const href = await download.getAttribute('href');
+      expect(href).toContain('/admin/media/download?path=');
+    });
+
+    await test.step('locked tile hover reveals only preview and download; the download works', async () => {
+      await adminPage.goto(`/admin/catalog/products/edit/${childId}`, { waitUntil: 'domcontentloaded' });
+      await adminPage.waitForLoadState('networkidle').catch(() => {});
+      await ensureMediaGroupOpen(adminPage);
+
+      const card = mediaGroup(adminPage).locator('.group.relative').first();
+      await card.hover();
+
+      await expect(card.getByRole('button', { name: 'Preview image' })).toBeVisible();
+      await expect(card.getByRole('button', { name: 'Replace image' })).toHaveCount(0);
+      await expect(card.getByRole('button', { name: 'Delete image' })).toHaveCount(0);
+      await expect(card.locator('.icon-drag')).toHaveCount(0);
+
+      const download = card.getByRole('link', { name: 'Download' });
+      await expect(download).toBeVisible();
+
+      const href = await download.getAttribute('href');
+      expect(href).toContain('/admin/media/download?path=');
+
+      const storedPath = decodeURIComponent(new URL(href, adminPage.url()).searchParams.get('path'));
+      const expectedFilename = storedPath.split('/').pop();
+
+      const [downloadEvent, response] = await Promise.all([
+        adminPage.waitForEvent('download'),
+        adminPage.waitForResponse((res) => res.url().includes('/admin/media/download')),
+        download.click(),
+      ]);
+
+      expect(response.ok()).toBeTruthy();
+      expect(downloadEvent.suggestedFilename()).toBe(expectedFilename);
+    });
+
+    await deleteProductBySku(adminPage, childSku);
+    await deleteProductBySku(adminPage, parentSku);
+  });
+});


### PR DESCRIPTION
## Description
- Add an authenticated `GET {admin_url}/media/download` endpoint with a strict allow-list (path segments, extensions, no traversal), used by a download control on image/gallery/file media, replacing the old file-type `target="_blank"` link.
- Locked media on variant groups/children now renders read-only (preview + download stay, edit controls removed) instead of a disabled fieldset with `pointer-events-none`; write authorization still goes through `guardVariantLevelWrite()`.
- Attribute option swatches and category media now open the shared full-screen image viewer, teleported to `body` so it isn't trapped inside a modal's transform context.
- Fix: gallery reorder wasn't marking the form dirty and the new order didn't persist — hidden inputs are now keyed by position and `AbstractType::processValues()` sorts by key before flattening.

## How To Test This?
1. Open a product with image/gallery/file attributes and an attribute option swatch or category media; hover a media card and confirm the download icon downloads the correct file.
2. Open a variant child with an inherited (locked) media attribute — confirm the value previews/downloads but has no edit/delete/upload controls.
3. Open the image viewer from an attribute option swatch or category media and confirm it renders full-screen, not clipped inside the parent modal.
4. On a gallery attribute, drag an image to reorder, save, and reload — confirm the new order persisted and the unsaved-changes indicator triggered before saving.