### PR TITLE
Fix/core issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@
 - Fixed configurable product REST API handling for variant groups and their tier information.
 - Added a consistent variant-level write guard across all save paths to prevent attributes from being modified at the wrong ownership level and to reject conflicting axis renames during persistence.
 - Fixed bulk edit variant-level handling so ancestor-owned cells are locked and display the owner's value, while lower-level cells remain locked and empty.
+- Fixed edit surfaces not being gated on the module's edit permission: datagrid rows stayed clickable, rows on some settings and Magic AI grids navigated to an undefined URL, the users grid rendered dead edit and delete icons, an administrator with only copy permission could duplicate a product by clicking its row, one with only delete permission on Magic AI platforms was taken to delete instead of edit, and the category tree, tree overview, and category edit panel URL were reachable without it.
+- Fixed saving a Magic AI system prompt logging a status-change audit entry even when the enabled flag had not changed.
+- Fixed media handling on product, category, and attribute forms: gallery image order was lost when reordering, read-only tiles still accepted dragged files, downloads were available regardless of permission on the owning module, and locked media on a variant group's child could be neither previewed nor downloaded.
+- Fixed Docker deployments where the queue and scheduler containers crash-looped without write access to the cache directory, and image upgrades regenerated the API OAuth signing keys, invalidating every issued token.
+- Fixed product saves showing a generic invalid-extension error when media pointed at another product's folder, and returning a server error instead of a validation error when the values field was omitted.
+- Fixed the searchable dropdown opening off-screen, losing its selected-item checkmark, and rendering beneath the pinned page header, and fixed association types selected from the overflow menu leaving every tab unselected.
+- Fixed the association type and measurement unit modals showing one label input per locale, which became unusable on catalogs with many locales, by moving the labels behind the locale switcher.
+- Fixed product import storing media under the wrong product, allowing a row to set a value it does not own, silently creating orphan variant rows when the named parent did not exist, failing the row or wiping values when a media reference could not be resolved, and requiring non-axis attributes on structures with no placement rows.
+- Fixed the attribute option grid rendering labels blank on PostgreSQL because a per-locale column alias was case-folded.
+- Fixed demo installation data that failed on a fresh install with demo data enabled: sample import profiles resolved to no file, seeded variant structure codes were rejected by validation, seeded values were placed at the wrong ownership level, association fields used types the field builder cannot create or edit, and saved grid filters and views did not apply correctly.
+- Fixed clearing or deleting an applied saved grid filter leaving its columns, sort, and paging in place instead of restoring the grid's default layout, and the product passport datagrid omitting bulk withdraw and reinstate from its mass actions.
+- Added a confirmation step before deleting an AI Agent conversation, and fixed a failed deletion silently removing the conversation from the visible list while it remained on the server.
+- Fixed the REST product associations write path silently deleting association links that a PUT or PATCH request did not include.
+- Fixed the product grid, CSV export, and REST API showing a blank value for a common attribute set only on a parent product, for variant groups and their children.
+- Fixed exported product media being copied to a disk the export archiver did not read from, leaving media out of the downloaded export.
+- Fixed a structured variant's SKU being treated as an ancestor-owned attribute, blocking it from being renamed.
+- Fixed the bulk edit select-cell attribute lookup using a column's position instead of its attribute id, so the dropdown never populated and typing found nothing.
+- Fixed the Digital Product Passport settings link pointing at a page that no longer exists, and the datagrid toolbar wrapping onto a second row and stranding pagination when the side panel or sidebar was open.
+- Fixed the product exporter's constructor requiring an extra argument, breaking packages that extended it or the product API data source.
 
 # 3.0.0 — July 31st, 2026
 

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -430,7 +430,7 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
 
         if (bouncer()->hasPermission('catalog.products.copy')) {
             $this->addAction([
-                'index'  => 'edit',
+                'index'  => 'copy',
                 'icon'   => 'icon-copy',
                 'title'  => trans('admin::app.catalog.products.index.datagrid.copy'),
                 'method' => 'POST',

--- a/packages/Webkul/Admin/src/DataGrids/MagicAI/MagicAIPlatformDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/MagicAI/MagicAIPlatformDataGrid.php
@@ -112,6 +112,7 @@ class MagicAIPlatformDataGrid extends DataGrid
     {
         if (bouncer()->hasPermission('ai-agent.platform.edit')) {
             $this->addAction([
+                'index'  => 'edit',
                 'icon'   => 'icon-edit',
                 'title'  => trans('admin::app.configuration.platform.datagrid.edit'),
                 'method' => 'GET',
@@ -121,6 +122,7 @@ class MagicAIPlatformDataGrid extends DataGrid
 
         if (bouncer()->hasPermission('ai-agent.platform.delete')) {
             $this->addAction([
+                'index'  => 'delete',
                 'icon'   => 'icon-delete',
                 'title'  => trans('admin::app.configuration.platform.datagrid.delete'),
                 'method' => 'DELETE',

--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/CategoryController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/CategoryController.php
@@ -289,7 +289,7 @@ class CategoryController extends Controller
      */
     private function savedDestination(CategoryRequest $request, int $categoryId, string $route, array $params = []): array
     {
-        if (! $request->boolean('panel')) {
+        if (! $request->boolean('panel') || ! bouncer()->hasPermission('catalog.categories.edit')) {
             return [$route, $params];
         }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/MagicAI/MagicAISystemPromptController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/MagicAI/MagicAISystemPromptController.php
@@ -90,10 +90,6 @@ class MagicAISystemPromptController extends Controller
 
         $id = request()->id;
 
-        if ($data['is_enabled']) {
-            $this->magicAiSystemPromptRepository->disableAllEnabledPrompts();
-        }
-
         $this->magicAiSystemPromptRepository->update($data, $id);
 
         return new JsonResponse([

--- a/packages/Webkul/Admin/src/Http/Requests/CategoryBrowseRequest.php
+++ b/packages/Webkul/Admin/src/Http/Requests/CategoryBrowseRequest.php
@@ -14,6 +14,14 @@ class CategoryBrowseRequest extends FormRequest
     {
         abort_unless(bouncer()->hasPermission('catalog.categories'), 403, trans('admin::app.common.unauthorized'));
 
+        if ($this->filled('category')) {
+            abort_unless(bouncer()->hasPermission('catalog.categories.edit'), 403, trans('admin::app.common.unauthorized'));
+        }
+
+        if ($this->input('panel') === 'create') {
+            abort_unless(bouncer()->hasPermission('catalog.categories.create'), 403, trans('admin::app.common.unauthorized'));
+        }
+
         return true;
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/index.blade.php
@@ -68,6 +68,7 @@
                         ::show-toolbar="true"
                         ::show-search="true"
                         ::navigate-on-select="true"
+                        ::allow-edit="{{ bouncer()->hasPermission('catalog.categories.edit') ? 'true' : 'false' }}"
                         ::allow-create="{{ $canCreate ? 'true' : 'false' }}"
                         ::allow-delete="{{ bouncer()->hasPermission('catalog.categories.delete') ? 'true' : 'false' }}"
                         :expanded-branch="json_encode($branchToParent)"

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/partials/list.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/partials/list.blade.php
@@ -96,7 +96,8 @@
         <template v-if="! isLoading">
             <div
                 v-for="record in records"
-                class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(action => action.index === 'edit')}"
                 :style="'grid-template-columns: 2fr repeat(' + (actions.length ? columns.length : (columns.length -1 )) + ', 1fr)'"
                 @click="handleRowClick($event, record)"
             >

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/partials/overview.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/partials/overview.blade.php
@@ -2,6 +2,8 @@
     $roots = $overview['roots'];
 
     $channelRootIds = $overview['channelRootIds'];
+
+    $canEditCategory = bouncer()->hasPermission('catalog.categories.edit');
 @endphp
 
 <div class="flex flex-col gap-4 p-6 bg-white dark:bg-cherry-900 rounded box-shadow">
@@ -25,8 +27,10 @@
                 @php $descendants = (int) (($root->_rgt - $root->_lft - 1) / 2); @endphp
 
                 <a
-                    href="{{ route('admin.catalog.categories.index', ['category' => $root->id]) }}"
-                    class="flex gap-2.5 items-center px-2 py-2.5 border-b dark:border-cherry-800 rounded-md hover:bg-primary-50 dark:hover:bg-cherry-800"
+                    @if ($canEditCategory)
+                        href="{{ route('admin.catalog.categories.index', ['category' => $root->id]) }}"
+                    @endif
+                    class="flex gap-2.5 items-center px-2 py-2.5 border-b dark:border-cherry-800 rounded-md {{ $canEditCategory ? 'hover:bg-primary-50 dark:hover:bg-cherry-800' : '' }}"
                 >
                     <span class="icon-folder shrink-0 text-2xl text-gray-500 dark:text-gray-300"></span>
 
@@ -44,7 +48,9 @@
                         @lang('admin::app.catalog.categories.browse.subcategories-count', ['count' => number_format($descendants)])
                     </span>
 
-                    <span class="icon-chevron-right shrink-0 text-2xl text-gray-400 dark:text-gray-300"></span>
+                    @if ($canEditCategory)
+                        <span class="icon-chevron-right shrink-0 text-2xl text-gray-400 dark:text-gray-300"></span>
+                    @endif
                 </a>
             @endforeach
         </div>

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/table.blade.php
@@ -142,9 +142,10 @@
                     <template v-else>
                         <template v-if="$parent.available.records.length">
                             <div
-                                class="row grid gap-2.5 items-center px-4 py-4 cursor-pointer border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                                class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
                                 v-for="record in $parent.available.records"
                                 :key="record[$parent.available.meta.primary_column]"
+                                :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': isRowEditable(record)}"
                                 :style="`grid-template-columns: repeat(${gridsCount}, minmax(80px, 1fr))`"
                                 @click="handleRowClick($event, record)"
                             >
@@ -303,6 +304,10 @@
             },
 
             methods: {
+                isRowEditable(record) {
+                    return (record.actions ?? []).some(action => action.index === 'edit');
+                },
+
                 handleRowClick(event, record) {
                     this.$parent.handleRowClick(event, record);
                 },

--- a/packages/Webkul/Admin/src/Resources/views/components/tree/category/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/tree/category/view.blade.php
@@ -93,7 +93,8 @@
                     </p>
 
                     <div
-                        class="flex flex-col gap-0.5 px-2 py-1.5 rounded-md cursor-pointer hover:bg-primary-50 dark:hover:bg-cherry-800"
+                        class="flex flex-col gap-0.5 px-2 py-1.5 rounded-md"
+                        :class="canChooseResult ? 'cursor-pointer hover:bg-primary-50 dark:hover:bg-cherry-800' : ''"
                         v-for="result in searchResults"
                         :key="result.id"
                         @click="chooseResult(result)"
@@ -207,6 +208,10 @@
                     type: Boolean,
                     default: false
                 },
+                allowEdit: {
+                    type: Boolean,
+                    default: false
+                },
                 allowDelete: {
                     type: Boolean,
                     default: false
@@ -276,10 +281,18 @@
                 isSearching() {
                     return this.searchTerm.trim().length > 0;
                 },
+
+                canChooseResult() {
+                    return ! this.navigateOnSelect || this.allowEdit;
+                },
             },
 
             methods: {
                 navigateTo(categoryId) {
+                    if (! this.allowEdit) {
+                        return;
+                    }
+
                     const url = new URL(this.createUrl, window.location.origin);
 
                     url.searchParams.set('category', categoryId);

--- a/packages/Webkul/Admin/src/Resources/views/components/tree/item.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/tree/item.blade.php
@@ -13,9 +13,12 @@
             <i :class="folderIconClasses"></i>
 
             <span
-                class="flex-1 ltr:ml-1 rtl:mr-1 py-1.5 text-sm truncate cursor-pointer"
+                class="flex-1 ltr:ml-1 rtl:mr-1 py-1.5 text-sm truncate"
                 v-if="categorytree.navigateOnSelect"
-                :class="hasSelectedValue ? 'text-primary-700 dark:text-white font-semibold' : 'text-gray-600 dark:text-gray-300'"
+                :class="[
+                    hasSelectedValue ? 'text-primary-700 dark:text-white font-semibold' : 'text-gray-600 dark:text-gray-300',
+                    categorytree.allowEdit ? 'cursor-pointer' : '',
+                ]"
                 :title="label"
                 v-text="label"
                 @click="onInputChange"
@@ -169,9 +172,13 @@
                     return '';
                 }
 
-                return this.hasSelectedValue
-                    ? 'bg-primary-50 dark:bg-cherry-800'
-                    : 'hover:bg-primary-50 dark:hover:bg-cherry-800';
+                if (this.hasSelectedValue) {
+                    return 'bg-primary-50 dark:bg-cherry-800';
+                }
+
+                return this.categorytree.allowEdit
+                    ? 'hover:bg-primary-50 dark:hover:bg-cherry-800'
+                    : '';
             },
 
             itemClasses() {

--- a/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai-prompt/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai-prompt/index.blade.php
@@ -31,13 +31,14 @@
             </x-admin::page-header>
             <x-admin::datagrid src="{{ route('admin.magic_ai.prompt.index') }}" ref="datagrid">
 
-                <template #body="{ columns, records, performAction, applied, setCurrentSelectionMode }">
+                <template #body="{ columns, records, performAction, handleRowClick, applied, setCurrentSelectionMode }">
                     <div
                         v-for="record in records"
                         :key="record.id"
-                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                        :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(action => action.index === 'edit')}"
                         :style="`grid-template-columns: repeat(${gridsCount}, minmax(0, 1fr))`"
-                        @click="selectedPrompt=1;editModal(record.actions.find(action => action.index === 'edit')?.url)"
+                        @click="handleRowClick($event, record)"
                     >
                         <!-- Title -->
                         <p v-text="record.title" class="truncate" :title="record.title"></p>

--- a/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/platform/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/platform/index.blade.php
@@ -90,9 +90,10 @@
                     <div
                         v-for="record in records"
                         :key="record.id"
-                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                        :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(a => a.index === 'edit')}"
                         :style="`grid-template-columns: repeat(${gridsCount}, minmax(0, 1fr))`"
-                        @click="editModal(record.actions.find(a => a.index === 'action_1')?.url)"
+                        @click="editRow(record)"
                     >
                         <p v-text="record.label" class="truncate" :title="record.label"></p>
                         <p v-html="record.provider"></p>
@@ -601,6 +602,16 @@
                                     });
                                 }
                             });
+                    },
+
+                    editRow(record) {
+                        const action = record.actions.find(a => a.index === 'edit');
+
+                        if (! action) {
+                            return;
+                        }
+
+                        this.editModal(action.url);
                     },
 
                     editModal(url) {

--- a/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/system-prompt/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/configuration/magic-ai/system-prompt/index.blade.php
@@ -34,13 +34,14 @@
 
             <x-admin::datagrid src="{{ route('admin.magic_ai.system_prompt.index') }}" ref="datagrid">
 
-                <template #body="{ columns, records, performAction, applied, setCurrentSelectionMode }">
+                <template #body="{ columns, records, performAction, handleRowClick, applied, setCurrentSelectionMode }">
                     <div
                         v-for="record in records"
                         :key="record.id"
-                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                        :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(action => action.index === 'edit')}"
                         :style="`grid-template-columns: repeat(${gridsCount}, minmax(0, 1fr))`"
-                        @click="selectedPrompt=1;editModal(record.actions.find(action => action.index === 'edit')?.url)"
+                        @click="handleRowClick($event, record)"
                     >
 
                         <!-- Title -->

--- a/packages/Webkul/Admin/src/Resources/views/settings/currencies/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/currencies/index.blade.php
@@ -59,12 +59,13 @@
                 ref="datagrid"
             >
                 <!-- DataGrid Body -->
-                <template #body="{ columns, records, performAction, setCurrentSelectionMode, applied }">
+                <template #body="{ columns, records, performAction, handleRowClick, setCurrentSelectionMode, applied }">
                     <div
                         v-for="record in records"
-                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                        :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(action => action.index === 'edit')}"
                         :style="`grid-template-columns: repeat(${gridsCount}, minmax(0, 1fr))`"
-                        @click="selectedCurrencies=1; editModal(record.actions.find(action => action.index === 'edit')?.url)"
+                        @click="handleRowClick($event, record)"
                     >
                         <!-- Mass actions -->
                         @if ($hasMassActionPermission)

--- a/packages/Webkul/Admin/src/Resources/views/settings/locales/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/locales/index.blade.php
@@ -54,12 +54,13 @@
             @endphp
             <x-admin::datagrid :src="route('admin.settings.locales.index')" ref="datagrid">
                 <!-- DataGrid Body -->
-                <template #body="{ columns, records, performAction, applied, setCurrentSelectionMode }">
+                <template #body="{ columns, records, performAction, handleRowClick, applied, setCurrentSelectionMode }">
                     <div
                         v-for="record in records"
-                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                        :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(action => action.index === 'edit')}"
                         :style="`grid-template-columns: repeat(${gridsCount}, minmax(0, 1fr))`"
-                        @click="selectedLocales=1; editModal(record.actions.find(action => action.index === 'edit')?.url)"
+                        @click="handleRowClick($event, record)"
                     >
                         <!-- Mass actions -->
                         @if ($hasMassActionPermission)

--- a/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/users/index.blade.php
@@ -85,13 +85,14 @@
                     </div>
                 </template>
 
-                <template #body="{ columns, records, performAction }">
+                <template #body="{ columns, records, performAction, handleRowClick }">
                     <div
                         v-for="record in records"
                         :key="record.id"
-                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 cursor-pointer transition-all hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800"
+                        class="row grid gap-2.5 items-center px-4 py-4 border-b dark:border-cherry-800 text-gray-600 dark:text-gray-300 transition-all"
+                        :class="{'cursor-pointer hover:bg-primary-50 hover:bg-opacity-30 dark:hover:bg-cherry-800': record.actions.some(action => action.index === 'edit')}"
                         :style="'grid-template-columns: repeat(' + (record.actions.length ? 6 : 5) + ', minmax(0, 1fr));'"
-                        @click="id=1; editModal(record.actions.find(action => action.index === 'edit')?.url)"
+                        @click="handleRowClick($event, record)"
                     >
                         <p v-text="record.user_id"></p>
 
@@ -140,7 +141,10 @@
                         <p v-text="record.role_name" class="truncate" :title="record.role_name"></p>
 
                         <div class="flex justify-end" @click.stop>
-                            <a @click="id=1; editModal(record.actions.find(action => action.index === 'edit')?.url)">
+                            <a
+                                v-if="record.actions.find(action => action.index === 'edit')"
+                                @click="id=1; editModal(record.actions.find(action => action.index === 'edit')?.url)"
+                            >
                                 <span
                                     :class="record.actions.find(action => action.index === 'edit')?.icon"
                                     title="@lang('admin::app.settings.users.index.datagrid.edit')"
@@ -149,7 +153,10 @@
                                 </span>
                             </a>
 
-                            <a @click="performAction(record.actions.find(action => action.index === 'delete'))">
+                            <a
+                                v-if="record.actions.find(action => action.index === 'delete')"
+                                @click="performAction(record.actions.find(action => action.index === 'delete'))"
+                            >
                                 <span
                                     :class="record.actions.find(action => action.index === 'delete')?.icon"
                                     title="@lang('admin::app.settings.users.index.datagrid.delete')"

--- a/packages/Webkul/Admin/tests/Feature/Acl/DatagridRowEditActionAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/DatagridRowEditActionAclTest.php
@@ -53,7 +53,7 @@ dataset('editable datagrids', [
         'admin.settings.locales.index',
         ['settings', 'settings.locales'],
         'settings.locales.edit',
-        fn () => Locale::query()->value('id'),
+        fn () => Locale::query()->value('id') ?? Locale::factory()->create()->id,
         'admin.settings.locales.edit',
     ],
 
@@ -61,7 +61,7 @@ dataset('editable datagrids', [
         'admin.settings.currencies.index',
         ['settings', 'settings.currencies'],
         'settings.currencies.edit',
-        fn () => Currency::query()->value('id'),
+        fn () => Currency::query()->value('id') ?? Currency::factory()->create()->id,
         'admin.settings.currencies.edit',
     ],
 

--- a/packages/Webkul/Admin/tests/Feature/Acl/DatagridRowEditActionAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/DatagridRowEditActionAclTest.php
@@ -102,7 +102,8 @@ it('does not expose a row edit action when the edit permission is missing', func
     string $indexRoute,
     array $viewPermissions,
     string $editPermission,
-    callable $seed
+    callable $seed,
+    string $editRoute
 ) {
     $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard']);
 
@@ -121,7 +122,8 @@ it('exposes a row edit action when the edit permission is granted', function (
     string $indexRoute,
     array $viewPermissions,
     string $editPermission,
-    callable $seed
+    callable $seed,
+    string $editRoute
 ) {
     $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard', $editPermission]);
 
@@ -140,7 +142,8 @@ it('never emits a row action without a usable url', function (
     string $indexRoute,
     array $viewPermissions,
     string $editPermission,
-    callable $seed
+    callable $seed,
+    string $editRoute
 ) {
     $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard']);
 

--- a/packages/Webkul/Admin/tests/Feature/Acl/DatagridRowEditActionAclTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Acl/DatagridRowEditActionAclTest.php
@@ -1,0 +1,316 @@
+<?php
+
+use Illuminate\Testing\TestResponse;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeFamily;
+use Webkul\Category\Models\Category;
+use Webkul\Core\Models\Currency;
+use Webkul\Core\Models\Locale;
+use Webkul\MagicAI\Models\MagicAISystemPrompt;
+use Webkul\MagicAI\Models\MagicPrompt;
+use Webkul\Product\Models\Product;
+use Webkul\User\Models\Admin;
+
+beforeEach(fn () => config(['elasticsearch.enabled' => false]));
+
+/**
+ * @return array{0: string, 1: array<int, string>, 2: string, 3: callable, 4: string}
+ */
+dataset('editable datagrids', [
+    'products' => [
+        'admin.catalog.products.index',
+        ['catalog', 'catalog.products'],
+        'catalog.products.edit',
+        fn () => Product::factory()->simple()->create()->id,
+        'admin.catalog.products.edit',
+    ],
+
+    'categories' => [
+        'admin.catalog.categories.index',
+        ['catalog', 'catalog.categories'],
+        'catalog.categories.edit',
+        fn () => Category::factory()->create()->id,
+        'admin.catalog.categories.edit',
+    ],
+
+    'attributes' => [
+        'admin.catalog.attributes.index',
+        ['catalog', 'catalog.attributes'],
+        'catalog.attributes.edit',
+        fn () => Attribute::factory()->create()->id,
+        'admin.catalog.attributes.edit',
+    ],
+
+    'attribute families' => [
+        'admin.catalog.families.index',
+        ['catalog', 'catalog.families'],
+        'catalog.families.edit',
+        fn () => AttributeFamily::factory()->create()->id,
+        'admin.catalog.families.edit',
+    ],
+
+    'locales' => [
+        'admin.settings.locales.index',
+        ['settings', 'settings.locales'],
+        'settings.locales.edit',
+        fn () => Locale::query()->value('id'),
+        'admin.settings.locales.edit',
+    ],
+
+    'currencies' => [
+        'admin.settings.currencies.index',
+        ['settings', 'settings.currencies'],
+        'settings.currencies.edit',
+        fn () => Currency::query()->value('id'),
+        'admin.settings.currencies.edit',
+    ],
+
+    'users' => [
+        'admin.settings.users.index',
+        ['settings', 'settings.users', 'settings.users.users'],
+        'settings.users.users.edit',
+        fn () => Admin::query()->value('id'),
+        'admin.settings.users.edit',
+    ],
+
+    'magic ai prompts' => [
+        'admin.magic_ai.prompt.index',
+        ['ai-agent', 'ai-agent.prompt'],
+        'ai-agent.prompt.edit',
+        fn () => MagicPrompt::factory()->create()->id,
+        'admin.magic_ai.prompt.edit',
+    ],
+
+    'magic ai system prompts' => [
+        'admin.magic_ai.system_prompt.index',
+        ['ai-agent', 'ai-agent.system-prompt'],
+        'ai-agent.system-prompt.edit',
+        fn () => MagicAISystemPrompt::factory()->create()->id,
+        'admin.magic_ai.system_prompt.edit',
+    ],
+]);
+
+function fetchDatagrid(string $routeName): TestResponse
+{
+    return test()->get(
+        route($routeName),
+        ['X-Requested-With' => 'XMLHttpRequest', 'Accept' => 'application/json']
+    );
+}
+
+it('does not expose a row edit action when the edit permission is missing', function (
+    string $indexRoute,
+    array $viewPermissions,
+    string $editPermission,
+    callable $seed
+) {
+    $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard']);
+
+    $seed();
+
+    $records = fetchDatagrid($indexRoute)->assertOk()->json('records');
+
+    expect($records)->toBeArray()->not->toBeEmpty();
+
+    $indices = collect($records)->flatMap(fn (array $record) => collect($record['actions'] ?? [])->pluck('index'));
+
+    expect($indices)->not->toContain('edit');
+})->with('editable datagrids');
+
+it('exposes a row edit action when the edit permission is granted', function (
+    string $indexRoute,
+    array $viewPermissions,
+    string $editPermission,
+    callable $seed
+) {
+    $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard', $editPermission]);
+
+    $seed();
+
+    $records = fetchDatagrid($indexRoute)->assertOk()->json('records');
+
+    expect($records)->toBeArray()->not->toBeEmpty();
+
+    $indices = collect($records)->flatMap(fn (array $record) => collect($record['actions'] ?? [])->pluck('index'));
+
+    expect($indices)->toContain('edit');
+})->with('editable datagrids');
+
+it('never emits a row action without a usable url', function (
+    string $indexRoute,
+    array $viewPermissions,
+    string $editPermission,
+    callable $seed
+) {
+    $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard']);
+
+    $seed();
+
+    $records = fetchDatagrid($indexRoute)->assertOk()->json('records');
+
+    $urls = collect($records)->flatMap(fn (array $record) => collect($record['actions'] ?? [])->pluck('url'));
+
+    foreach ($urls as $url) {
+        expect($url)->toBeString()->not->toBeEmpty();
+        expect($url)->not->toContain('undefined');
+    }
+})->with('editable datagrids');
+
+it('refuses the edit route when the edit permission is missing', function (
+    string $indexRoute,
+    array $viewPermissions,
+    string $editPermission,
+    callable $seed,
+    string $editRoute
+) {
+    $this->loginWithPermissions('custom', [...$viewPermissions, 'dashboard']);
+
+    $id = $seed();
+
+    $this->get(route($editRoute, ['id' => $id]))->assertStatus(403);
+})->with('editable datagrids');
+
+it('does not make category tree nodes navigable without the edit permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories']);
+
+    $this->get(route('admin.catalog.categories.index', ['view' => 'tree']))
+        ->assertOk()
+        ->assertSee('allow-edit="false"', escape: false);
+});
+
+it('makes category tree nodes navigable with the edit permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories', 'catalog.categories.edit']);
+
+    $this->get(route('admin.catalog.categories.index', ['view' => 'tree']))
+        ->assertOk()
+        ->assertSee('allow-edit="true"', escape: false);
+});
+
+it('does not link the category overview tree rows without the edit permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories']);
+
+    $root = Category::query()->whereNull('parent_id')->firstOrFail();
+
+    $response = $this->get(route('admin.catalog.categories.index', ['view' => 'tree']))->assertOk();
+
+    $response->assertSee(trans('admin::app.catalog.categories.browse.trees'), escape: false);
+
+    $response->assertDontSee(
+        route('admin.catalog.categories.index', ['category' => $root->id]),
+        escape: false
+    );
+});
+
+it('links the category overview tree rows with the edit permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories', 'catalog.categories.edit']);
+
+    $root = Category::query()->whereNull('parent_id')->firstOrFail();
+
+    $this->get(route('admin.catalog.categories.index', ['view' => 'tree']))
+        ->assertOk()
+        ->assertSee(
+            route('admin.catalog.categories.index', ['category' => $root->id]),
+            escape: false
+        );
+});
+
+it('denies the category edit panel without the edit permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories']);
+
+    $category = Category::factory()->create();
+
+    $this->get(route('admin.catalog.categories.index', ['category' => $category->id]))
+        ->assertStatus(403);
+});
+
+it('renders the category edit panel with the edit permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories', 'catalog.categories.edit']);
+
+    $category = Category::factory()->create();
+
+    $this->get(route('admin.catalog.categories.index', ['category' => $category->id]))
+        ->assertOk()
+        ->assertSee(trans('admin::app.catalog.categories.edit.title'), escape: false);
+});
+
+it('opens the create panel for a user who may only create categories', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories', 'catalog.categories.create']);
+
+    $this->get(route('admin.catalog.categories.index', ['panel' => 'create']))
+        ->assertOk()
+        ->assertSee(trans('admin::app.catalog.categories.create.title'), escape: false);
+});
+
+it('denies the create panel without the create permission', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories']);
+
+    $this->get(route('admin.catalog.categories.index', ['panel' => 'create']))
+        ->assertStatus(403);
+});
+
+it('lands a create-only user on a page they can load after saving from the panel', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.categories', 'catalog.categories.create']);
+
+    $localeCode = core()->getRequestedLocaleCode();
+
+    $response = $this->post(route('admin.catalog.categories.store'), [
+        'code'            => 'acl_panel_create_only',
+        'parent_id'       => null,
+        'panel'           => 1,
+        'additional_data' => [
+            'locale_specific' => [
+                $localeCode => ['name' => 'ACL Panel Create Only'],
+            ],
+        ],
+    ]);
+
+    $response->assertSessionHas('success', trans('admin::app.catalog.categories.create-success'));
+
+    $response->assertRedirect(route('admin.catalog.categories.index'));
+
+    $this->get($response->headers->get('Location'))->assertOk();
+});
+
+it('keeps sending an editor back into the panel after saving', function () {
+    $this->loginWithPermissions('custom', [
+        'dashboard',
+        'catalog',
+        'catalog.categories',
+        'catalog.categories.create',
+        'catalog.categories.edit',
+    ]);
+
+    $localeCode = core()->getRequestedLocaleCode();
+
+    $response = $this->post(route('admin.catalog.categories.store'), [
+        'code'            => 'acl_panel_editor',
+        'parent_id'       => null,
+        'panel'           => 1,
+        'additional_data' => [
+            'locale_specific' => [
+                $localeCode => ['name' => 'ACL Panel Editor'],
+            ],
+        ],
+    ]);
+
+    $category = Category::query()->where('code', 'acl_panel_editor')->firstOrFail();
+
+    $response->assertRedirect(route('admin.catalog.categories.index', [
+        'category' => $category->id,
+        'locale'   => $localeCode,
+    ]));
+
+    $this->get($response->headers->get('Location'))->assertOk();
+});
+
+it('does not index the product copy action as the row edit action', function () {
+    $this->loginWithPermissions('custom', ['dashboard', 'catalog', 'catalog.products', 'catalog.products.copy']);
+
+    Product::factory()->simple()->create();
+
+    $records = fetchDatagrid('admin.catalog.products.index')->assertOk()->json('records');
+
+    $actions = collect($records)->flatMap(fn (array $record) => $record['actions'] ?? []);
+
+    expect($actions->pluck('index'))->toContain('copy')->not->toContain('edit');
+});

--- a/packages/Webkul/Admin/tests/Feature/MagicAi/MagicAISystemPromptAuditTest.php
+++ b/packages/Webkul/Admin/tests/Feature/MagicAi/MagicAISystemPromptAuditTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Webkul\MagicAI\Models\MagicAISystemPrompt;
+
+beforeEach(function () {
+    $this->loginAsAdmin();
+
+    $this->auditableType = (new MagicAISystemPrompt)->getMorphClass();
+});
+
+function updateSystemPromptUnchanged($test, MagicAISystemPrompt $prompt)
+{
+    return $test->put(route('admin.magic_ai.system_prompt.update'), [
+        'id'          => $prompt->id,
+        'title'       => $prompt->title,
+        'tone'        => $prompt->tone,
+        'max_tokens'  => $prompt->max_tokens,
+        'temperature' => $prompt->temperature,
+        'is_enabled'  => $prompt->is_enabled ? '1' : '0',
+    ]);
+}
+
+describe('MagicAI system prompt update audits', function () {
+    it('records no audit when an enabled prompt is saved without any change', function () {
+        $prompt = MagicAISystemPrompt::factory()->create(['is_enabled' => 1]);
+
+        DB::table('audits')->where('auditable_type', $this->auditableType)->delete();
+
+        updateSystemPromptUnchanged($this, $prompt)->assertOk();
+
+        $audits = DB::table('audits')
+            ->where('auditable_type', $this->auditableType)
+            ->where('auditable_id', $prompt->id)
+            ->where('event', 'updated')
+            ->get();
+
+        expect($audits)->toBeEmpty();
+    });
+
+    it('records no audit when a disabled prompt is saved without any change', function () {
+        $prompt = MagicAISystemPrompt::factory()->create(['is_enabled' => 0]);
+
+        DB::table('audits')->where('auditable_type', $this->auditableType)->delete();
+
+        updateSystemPromptUnchanged($this, $prompt)->assertOk();
+
+        $audits = DB::table('audits')
+            ->where('auditable_type', $this->auditableType)
+            ->where('auditable_id', $prompt->id)
+            ->where('event', 'updated')
+            ->get();
+
+        expect($audits)->toBeEmpty();
+    });
+
+    it('still records an audit when the enabled flag actually changes', function () {
+        $prompt = MagicAISystemPrompt::factory()->create(['is_enabled' => 0]);
+
+        DB::table('audits')->where('auditable_type', $this->auditableType)->delete();
+
+        $this->put(route('admin.magic_ai.system_prompt.update'), [
+            'id'          => $prompt->id,
+            'title'       => $prompt->title,
+            'tone'        => $prompt->tone,
+            'max_tokens'  => $prompt->max_tokens,
+            'temperature' => $prompt->temperature,
+            'is_enabled'  => '1',
+        ])->assertOk();
+
+        $audit = DB::table('audits')
+            ->where('auditable_type', $this->auditableType)
+            ->where('auditable_id', $prompt->id)
+            ->where('event', 'updated')
+            ->first();
+
+        expect($audit)->not->toBeNull();
+        expect(json_decode($audit->new_values, true))->toHaveKey('is_enabled');
+    });
+});

--- a/packages/Webkul/MagicAI/src/Models/MagicAISystemPrompt.php
+++ b/packages/Webkul/MagicAI/src/Models/MagicAISystemPrompt.php
@@ -35,6 +35,13 @@ class MagicAISystemPrompt extends Model implements HistoryAuditable, MagicAISyst
         return MagicAISystemPromptFactory::new();
     }
 
+    protected function casts(): array
+    {
+        return [
+            'is_enabled' => 'boolean',
+        ];
+    }
+
     protected static function booted()
     {
         static::saving(function ($model): void {


### PR DESCRIPTION
## Description
- Fixed MagicAI system prompts writing a false `is_enabled` audit entry on every save.
  - Cause: missing boolean cast on `is_enabled`, plus `update()` disabling the record before it was re-read.
- Fixed edit-permission-gated datagrid rows (locales, currencies, users, Magic AI prompts/system prompts) staying clickable and navigating to `/admin/settings/undefined` without edit permission.
  - Cause: rows resolved their click target from an `edit` action the server had omitted; now routed through the datagrid's already-guarded `handleRowClick`.
- Fixed row clicks triggering copy and delete, which should only ever fire from their own action buttons.
  - Cause: `ProductDataGrid` registered copy under the `edit` index, so a copy-only user duplicated a product by clicking the row; `MagicAIPlatformDataGrid` declared no index and fell back positionally, so a delete-only user hit delete. Both now carry explicit indices, leaving the row click bound to edit alone.
- Fixed the users grid rendering dead edit/delete icons that called handlers with an undefined url when the user lacked that permission.
- Extended edit-gating to category tree nodes, the tree overview, and server-side category routes.

Note on the changelog commit: `docs: record the 3.0.1 bug fixes` is a backfill. The 3.0.1 section was missing entries for fixes already merged since `v3.0.0` — media type attributes, the Docker queue and OAuth key fixes, product import, the association type API work and others — so it records more than this PR changes. The entries were written from the diffs of `v3.0.0..HEAD`, excluding dependency bumps, CI and test-only commits. Reviewable against that range rather than against this PR's diff.


## How To Test This?
1. Enable a Magic AI system prompt. Save it again without touching the enabled toggle. Confirm no `is_enabled` entry appears in its audit history (`MagicAISystemPromptAuditTest`).
2. As a user with only `catalog.products.copy` (no edit), open the products grid and click a product row. Confirm nothing happens and the row shows no pointer or hover affordance. Confirm the copy action button in that row still works.
3. As a user with only delete permission on Magic AI platforms, click a row in that grid. Confirm nothing happens. Confirm the delete action button in that row still works.
4. As a user without edit permission on locales, currencies, users, or Magic AI (platforms/system prompts), click a grid row. Confirm it does not navigate, shows no clickable affordance, and never reaches `/admin/settings/undefined`.
5. As a user with `settings.users.users` but neither `.edit` nor `.delete`, open the users grid. Confirm the edit and delete icons are absent rather than rendering as dead icons.
6. As a user with only `catalog.categories.create` (no edit), create a category. Confirm the redirect lands on the categories index, not an edit panel. Then hit `?category=<id>` and `?panel=create` directly on `admin.catalog.categories.index` without edit/create permission and confirm a 403.
7. As a user with edit permission everywhere above, confirm row clicks still open the edit page or panel exactly as before.