### PR TITLE
Fix/fileless import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fixed the bulk edit select-cell attribute lookup using a column's position instead of its attribute id, so the dropdown never populated and typing found nothing.
 - Fixed the Digital Product Passport settings link pointing at a page that no longer exists, and the datagrid toolbar wrapping onto a second row and stranding pagination when the side panel or sidebar was open.
 - Fixed the product exporter's constructor requiring an extra argument, breaking packages that extended it or the product API data source.
+- Fixed importers that source their data over an API instead of an uploaded file being impossible to create with a valid validation strategy, and impossible to run once created.
 
 # 3.0.0 — July 31st, 2026
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -101,8 +101,9 @@ class ImportController extends Controller
         }
 
         $fileData = [
-            'type'   => self::TYPE,
-            'action' => 'append',
+            'type'                => self::TYPE,
+            'action'              => 'append',
+            'validation_strategy' => Import::VALIDATION_STRATEGY_SKIP_ERRORS,
         ];
 
         if (isset($importerConfig[$data['entity_type']]['has_file_options']) && $importerConfig[$data['entity_type']]['has_file_options'] == 'true') {
@@ -267,7 +268,9 @@ class ImportController extends Controller
         try {
             $import = $this->jobInstancesRepository->findOrFail($id);
 
-            if (empty($import->file_path)) {
+            $requiresFile = (bool) config(self::IMPORTERS.'.'.$import->entity_type.'.has_file_options', false);
+
+            if ($requiresFile && empty($import->file_path)) {
                 return redirect()
                     ->route('admin.settings.data_transfer.imports.import-view', $import->id)
                     ->with('error', trans('admin::app.settings.data-transfer.imports.rerun-no-file'));

--- a/packages/Webkul/DataTransfer/src/Helpers/Import.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Import.php
@@ -226,14 +226,19 @@ class Import
         $state = self::STATE_VALIDATED;
 
         try {
-            $source = $this->getSource();
+            $entityType = $this->resolveEntityType($this->import->jobInstance->entity_type);
 
-            if (! $source) {
-                throw new \RuntimeException('The import source file is missing or unreadable, so this job cannot be validated.');
+            if (config('importers.'.$entityType.'.has_file_options')) {
+                $source = $this->getSource();
+
+                if (! $source) {
+                    throw new \RuntimeException('The import source file is missing or unreadable, so this job cannot be validated.');
+                }
+
+                $this->getTypeImporter()->setSource($source)->validateData();
+            } else {
+                $this->getTypeImporter()->validateData();
             }
-
-            $typeImporter = $this->getTypeImporter()->setSource($source);
-            $typeImporter->validateData();
         } catch (\Throwable $e) {
             $state = self::STATE_FAILED;
             $this->errorHelper->addError(

--- a/packages/Webkul/DataTransfer/tests/Feature/FilelessImportValidationTest.php
+++ b/packages/Webkul/DataTransfer/tests/Feature/FilelessImportValidationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Webkul\DataTransfer\Contracts\JobTrackBatch as JobTrackBatchContract;
+use Webkul\DataTransfer\Helpers\Import;
+use Webkul\DataTransfer\Helpers\Importers\AbstractImporter;
+use Webkul\DataTransfer\Helpers\Sources\AbstractSource;
+use Webkul\DataTransfer\Models\JobInstances;
+use Webkul\DataTransfer\Models\JobTrack;
+use Webkul\DataTransfer\Services\JobLogger;
+use Webkul\User\Models\Admin;
+
+class FilelessTestSource extends AbstractSource
+{
+    protected int $position = 0;
+
+    public function __construct(protected array $rows = [])
+    {
+        $first = reset($this->rows);
+
+        $this->columnNames = is_array($first) ? array_keys($first) : [];
+
+        $this->totalColumns = count($this->columnNames);
+
+        array_unshift($this->rows, $this->columnNames);
+    }
+
+    protected function getNextRow(): array|bool
+    {
+        if (! isset($this->rows[$this->position])) {
+            return false;
+        }
+
+        return $this->rows[$this->position++];
+    }
+
+    public function rewind(): void
+    {
+        $this->position = 0;
+
+        parent::rewind();
+    }
+}
+
+class FilelessTestImporter extends AbstractImporter
+{
+    public static array $rows = [];
+
+    protected array $validColumnNames = ['code', 'status'];
+
+    protected array $permanentAttributes = ['code'];
+
+    protected string $masterAttributeCode = 'code';
+
+    public function getSource(): AbstractSource
+    {
+        if (! $this->source) {
+            $this->source = new FilelessTestSource(self::$rows);
+        }
+
+        return $this->source;
+    }
+
+    public function validateRow(array $rowData, int $rowNumber): bool
+    {
+        $this->validatedRows[$rowNumber] = true;
+
+        return ! $this->errorHelper->isRowInvalid($rowNumber);
+    }
+
+    public function importBatch(JobTrackBatchContract $batch): bool
+    {
+        $this->importBatchRepository->update([
+            'state'   => Import::STATE_PROCESSED,
+            'summary' => ['created' => 0, 'updated' => count($batch->data), 'deleted' => 0],
+        ], $batch->id);
+
+        return true;
+    }
+}
+
+function registerFilelessImporter(array $rows, bool $hasFileOptions = false): void
+{
+    FilelessTestImporter::$rows = $rows;
+
+    $entry = ['title' => 'Fileless Test', 'importer' => FilelessTestImporter::class];
+
+    if ($hasFileOptions) {
+        $entry['has_file_options'] = true;
+    }
+
+    config(['importers.fileless_test' => $entry]);
+}
+
+function makeFilelessJobInstance(?string $filePath = null): JobInstances
+{
+    return JobInstances::create([
+        'code'                => 'fileless-test-'.uniqid(),
+        'entity_type'         => 'fileless_test',
+        'type'                => 'import',
+        'action'              => 'append',
+        'validation_strategy' => Import::VALIDATION_STRATEGY_SKIP_ERRORS,
+        'allowed_errors'      => 0,
+        'file_path'           => $filePath,
+    ]);
+}
+
+function runFilelessValidation(JobInstances $jobInstance): JobTrack
+{
+    $track = JobTrack::create([
+        'type'                => 'import',
+        'state'               => Import::STATE_PENDING,
+        'action'              => $jobInstance->action,
+        'validation_strategy' => $jobInstance->validation_strategy,
+        'allowed_errors'      => $jobInstance->allowed_errors,
+        'file_path'           => $jobInstance->file_path,
+        'meta'                => $jobInstance->toArray(),
+        'job_instances_id'    => $jobInstance->id,
+        'user_id'             => Admin::value('id'),
+    ]);
+
+    $helper = resolve(Import::class);
+    $helper->setImport($track);
+    $helper->setLogger(JobLogger::make($track->id));
+    $helper->validate();
+
+    return $track->fresh();
+}
+
+it('validates a fileless import without an uploaded file', function () {
+    registerFilelessImporter([
+        ['code' => 'alpha', 'status' => '1'],
+        ['code' => 'beta', 'status' => '0'],
+        ['code' => 'gamma', 'status' => '1'],
+    ]);
+
+    $track = runFilelessValidation(makeFilelessJobInstance());
+
+    expect($track->state)->toBe(Import::STATE_VALIDATED)
+        ->and($track->processed_rows_count)->toBe(3)
+        ->and($track->errors_count)->toBe(0);
+});
+
+it('fails a file based import when the file is missing', function () {
+    registerFilelessImporter([['code' => 'alpha', 'status' => '1']], hasFileOptions: true);
+
+    $track = runFilelessValidation(makeFilelessJobInstance());
+
+    expect($track->state)->toBe(Import::STATE_FAILED);
+});


### PR DESCRIPTION
## Description
- Fixed importers that pull data over an API instead of an uploaded file being impossible to create or run.
  - `store()` saves `file_path = null` for them, but `importNow()` refused any job without a file.
- Fixed creating such a profile failing on PostgreSQL and on MySQL in strict mode.
  - The form hides the settings card for these importers, so `validation_strategy` was never posted, and the column is `NOT NULL` with no default.
- Fixed the job still failing once dispatched, because the engine resolved its data source from `file_path` regardless of importer type.