### PR TITLE
fix: import Log facade instead of global alias

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/ConfigurationController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/ConfigurationController.php
@@ -5,6 +5,7 @@ namespace Webkul\Admin\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -202,7 +203,7 @@ class ConfigurationController extends Controller
 
             return redirect()->back();
         } catch (\Throwable $th) {
-            \Log::info($th);
+            Log::error($th->getMessage());
             session()->flash('error', trans('admin::app.catalog.products.index.magic-ai-validate-error'));
 
             return redirect()->back();

--- a/packages/Webkul/Admin/src/Http/Controllers/ConfigurationController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/ConfigurationController.php
@@ -203,7 +203,7 @@ class ConfigurationController extends Controller
 
             return redirect()->back();
         } catch (\Throwable $th) {
-            Log::error($th->getMessage());
+            Log::error($th->getMessage(), ['exception' => $th]);
             session()->flash('error', trans('admin::app.catalog.products.index.magic-ai-validate-error'));
 
             return redirect()->back();

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
@@ -283,7 +283,7 @@ class ExportController extends Controller
             return redirect()->route('admin.settings.data_transfer.tracker.view', $jobTrackInstance->id);
         } catch (\Exception $e) {
             // Log the error and redirect with an error message
-            \Log::error('Import failed for job instance '.$id.': '.$e->getMessage());
+            Log::error('Import failed for job instance '.$id.': '.$e->getMessage());
 
             return redirect()->route('admin.settings.data_transfer.tracker.view', $id)
                 ->with('error', 'Failed to start the export process. Please try again.');

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ExportController.php
@@ -283,7 +283,7 @@ class ExportController extends Controller
             return redirect()->route('admin.settings.data_transfer.tracker.view', $jobTrackInstance->id);
         } catch (\Exception $e) {
             // Log the error and redirect with an error message
-            Log::error('Import failed for job instance '.$id.': '.$e->getMessage());
+            Log::error('Export failed for job instance '.$id.': '.$e->getMessage());
 
             return redirect()->route('admin.settings.data_transfer.tracker.view', $id)
                 ->with('error', 'Failed to start the export process. Please try again.');

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -5,6 +5,7 @@ namespace Webkul\Admin\Http\Controllers\Settings\DataTransfer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -300,7 +301,7 @@ class ImportController extends Controller
 
             return redirect()->route('admin.settings.data_transfer.tracker.view', $jobTrackInstance->id);
         } catch (\Throwable $e) {
-            \Log::error('Import failed for job instance '.$id.': '.$e->getMessage());
+            Log::error('Import failed for job instance '.$id.': '.$e->getMessage());
 
             $batchId = $jobTrackInstance?->id ?? $id;
 

--- a/packages/Webkul/AiAgent/src/Chat/Tools/CreateProduct.php
+++ b/packages/Webkul/AiAgent/src/Chat/Tools/CreateProduct.php
@@ -5,6 +5,7 @@ namespace Webkul\AiAgent\Chat\Tools;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Http\File;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -329,7 +330,7 @@ class CreateProduct implements PimTool
                             }
                         } catch (\Throwable $e) {
                             $imageAttachError = $e->getMessage();
-                            \Log::warning('CreateProduct: Image attach failed', [
+                            Log::warning('CreateProduct: Image attach failed', [
                                 'product_id' => $product->id,
                                 'image_path' => $imagePath,
                                 'error'      => $e->getMessage(),

--- a/packages/Webkul/Completeness/src/Jobs/ProductCompletenessJob.php
+++ b/packages/Webkul/Completeness/src/Jobs/ProductCompletenessJob.php
@@ -5,6 +5,7 @@ namespace Webkul\Completeness\Jobs;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Completeness\Repositories\CompletenessSettingsRepository;
 use Webkul\Completeness\Repositories\ProductCompletenessScoreRepository;
@@ -57,7 +58,7 @@ class ProductCompletenessJob implements ShouldQueue
         $products->loadMissing('parent.parent');
 
         if (app()->environment('testing')) {
-            \Log::debug('CompletenessJob', [
+            Log::debug('CompletenessJob', [
                 'productIds'    => $this->productIds,
                 'productsFound' => $products->keys()->toArray(),
                 'channelCount'  => count($this->channels),

--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
@@ -3,6 +3,7 @@
 namespace Webkul\DataTransfer\Helpers\Sources\Export\Elastic;
 
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Log;
 use Webkul\Core\Facades\ElasticSearch;
 use Webkul\DataTransfer\Helpers\Sources\Export\Filters\ProductExportFilter;
 use Webkul\ElasticSearch\Cursor\AbstractElasticCursor;
@@ -76,7 +77,7 @@ class ProductCursor extends AbstractElasticCursor
                 return array_map(fn (array $hit): array => ['id' => $hit['_id']], $hits);
             }
         } catch (\Throwable $e) {
-            \Log::error('Elasticsearch search error: '.$e->getMessage());
+            Log::error('Elasticsearch search error: '.$e->getMessage());
             throw $e;
         }
 

--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/ProductCursor.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/ProductCursor.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\DataTransfer\Helpers\Sources\Export;
 
+use Illuminate\Support\Facades\Log;
 use Webkul\DataTransfer\Cursor\AbstractCursor;
 use Webkul\DataTransfer\Helpers\Sources\Export\Filters\ProductExportFilter;
 
@@ -50,7 +51,7 @@ class ProductCursor extends AbstractCursor
 
             $this->offset += $this->batchSize;
         } catch (\Throwable $e) {
-            \Log::error('Product export cursor error: '.$e->getMessage());
+            Log::error('Product export cursor error: '.$e->getMessage());
             throw $e;
         }
 


### PR DESCRIPTION
## Why

PR #657 (dependabot dev-dependencies group) transitively bumps `phpstan/phpstan` 2.2.8 → 2.2.9, which no longer resolves Laravel's global facade alias `\Log`. The Larastan check fails with 7× `Call to static method X() on an unknown class Log (class.notFound)`.

Verified locally: with the #657 lockfile, current `3.0` fails PHPStan; with this patch it passes (`[OK] No errors`).

## What

- Replace root-alias `\Log::` with imported `Illuminate\Support\Facades\Log` in the 7 flagged files (Admin, AiAgent, Completeness, DataTransfer).
- `ConfigurationController`: caught throwable was logged via `Log::info($th)` — now `Log::error($th->getMessage())`.

## Verification

- `vendor/bin/pint --test` — pass
- `vendor/bin/phpstan` 2.2.9 on all 7 files — 0 errors
- DataTransfer + Completeness Pest suites — identical results before/after patch (local failures are env-only, CI matrices authoritative)

After merge: comment `@dependabot rebase` on #657 → its PHPStan check goes green.