### PR TITLE
ci: point the release line config at 3.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] `vendor/bin/pint --test` reports no style issues
 - [ ] Tailwind classes are reordered
 - [ ] New user-facing strings use translation keys (all 33 locales)
-- [ ] Target branch is `master` (unless a maintainer requested a backport)
+- [ ] Target branch is `3.x`, the current release line (`master` targets the next major)
 
 ## Documentation
 - [ ] My pull request requires an update on the documentation repository.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Major dependency bumps are breaking, so they target `master`, the next-major
-# integration branch. The current release line `3.0` only accepts minor and
+# integration branch. The current release line `3.x` only accepts minor and
 # patch bumps. Dependabot reads this file from the default branch only.
 
 version: 2
@@ -10,7 +10,7 @@ updates:
   # Composer (PHP) — current release line: minor + patch only
   - package-ecosystem: "composer"
     directory: "/"
-    target-branch: "3.0"
+    target-branch: "3.x"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -64,7 +64,7 @@ updates:
   # npm — Playwright e2e tests, current release line
   - package-ecosystem: "npm"
     directory: "/tests/e2e-pw"
-    target-branch: "3.0"
+    target-branch: "3.x"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -115,7 +115,7 @@ updates:
   # GitHub Actions — current release line
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "3.0"
+    target-branch: "3.x"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/linting_tests.yml
+++ b/.github/workflows/linting_tests.yml
@@ -4,7 +4,7 @@ name: Linting Tests
 # limited to the release lines and everything else arrives through the PR event.
 on:
   push:
-    branches: [master, '3.0']
+    branches: [master, '3.x']
   pull_request:
 
 # head_ref is the branch on a pull request and empty elsewhere, which keeps a

--- a/.github/workflows/pest_tests.yml
+++ b/.github/workflows/pest_tests.yml
@@ -4,7 +4,7 @@ name: Pest Tests
 # limited to the release lines and everything else arrives through the PR event.
 on:
   push:
-    branches: [master, '3.0']
+    branches: [master, '3.x']
   pull_request:
 
 # head_ref is the branch on a pull request and empty elsewhere, which keeps a

--- a/.github/workflows/pest_tests_pgsql.yml
+++ b/.github/workflows/pest_tests_pgsql.yml
@@ -4,7 +4,7 @@ name: Pest Tests (PostgreSQL)
 # limited to the release lines and everything else arrives through the PR event.
 on:
   push:
-    branches: [master, '3.0']
+    branches: [master, '3.x']
   pull_request:
 
 # head_ref is the branch on a pull request and empty elsewhere, which keeps a

--- a/.github/workflows/playwright_test.yml
+++ b/.github/workflows/playwright_test.yml
@@ -4,7 +4,7 @@ name: Playwright Tests
 # limited to the release lines and everything else arrives through the PR event.
 on:
   push:
-    branches: [master, '3.0']
+    branches: [master, '3.x']
   pull_request:
 
 # head_ref is the branch on a pull request and empty elsewhere, which keeps a

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -4,7 +4,7 @@ name: Static Analysis
 # limited to the release lines and everything else arrives through the PR event.
 on:
   push:
-    branches: [master, '3.0']
+    branches: [master, '3.x']
   pull_request:
 
 # head_ref is the branch on a pull request and empty elsewhere, which keeps a

--- a/.github/workflows/translation_tests.yml
+++ b/.github/workflows/translation_tests.yml
@@ -4,7 +4,7 @@ name: Translation Tests
 # limited to the release lines and everything else arrives through the PR event.
 on:
   push:
-    branches: [master, '3.0']
+    branches: [master, '3.x']
   pull_request:
 
 # head_ref is the branch on a pull request and empty elsewhere, which keeps a


### PR DESCRIPTION
## Issue Reference

N/A — follow-up to the `3.0` → `3.x` branch rename.

## Description

- Points dependabot's three release-line targets at `3.x`.
- Updates the six workflow push filters to `[master, '3.x']`. Without this, a push to `3.x` runs no CI.
- Updates the branch names in the dependabot header comment and the PR checklist.

The 3.1.0 release preparation landed separately in #661.

## How To Test This?

1. Confirm this PR's own checks ran — that is what proves the workflow filters still match.
2. After merge, confirm a push to `3.x` triggers the suites.

## Checklist

- [x] No code changes — CI configuration only
- [x] No new user-facing strings
- [x] Target branch is `3.x`, the current release line

## Documentation

- [ ] My pull request requires an update on the documentation repository.