### PR TITLE
fix(publication): keep document index rows of superseded versions

### DIFF
--- a/packages/Webkul/Publication/src/Http/Controllers/PublicationAssetController.php
+++ b/packages/Webkul/Publication/src/Http/Controllers/PublicationAssetController.php
@@ -28,7 +28,7 @@ class PublicationAssetController extends Controller
     public function __construct(private readonly PublicationResolver $resolver) {}
 
     /**
-     * Serves a private-disk document, but only a path the current Published version's payload references.
+     * Serves a private-disk document, but only a path a current, unredacted version's payload references.
      *
      * `type` is read via the Request, not a parameter: route defaults are appended after URI captures, so a
      * `string $type` parameter would receive `{uuid}`'s value.
@@ -101,13 +101,20 @@ class PublicationAssetController extends Controller
     }
 
     /**
-     * Whether any current Published version for this publication references $path.
+     * Whether a current, unredacted version of this publication references $path.
+     *
+     * The index keeps rows for superseded versions (their documents remain attested
+     * content), so servability is decided here against the referencing version's
+     * state rather than by row existence alone.
      */
     private function isReferenced(int $publicationId, string $path): bool
     {
         return PublicationVersionDocumentProxy::modelClass()::query()
             ->where('publication_id', $publicationId)
             ->where('path', $path)
+            ->whereHas('version', fn ($version) => $version
+                ->where('is_current', true)
+                ->whereNull('redacted_at'))
             ->exists();
     }
 }

--- a/packages/Webkul/Publication/src/Listeners/SyncPublicationVersionDocuments.php
+++ b/packages/Webkul/Publication/src/Listeners/SyncPublicationVersionDocuments.php
@@ -5,32 +5,22 @@ namespace Webkul\Publication\Listeners;
 use Illuminate\Support\Facades\DB;
 use Webkul\Publication\Events\PublicationPublished;
 use Webkul\Publication\Models\PublicationVersionDocumentProxy;
-use Webkul\Publication\Models\PublicationVersionProxy;
 
 /**
- * Keeps `publication_version_documents` in sync with whichever version is
- * currently is_current for each (publication, locale): every path the new
- * version's payload references becomes servable, and every path only a
- * now-superseded version referenced stops being servable. This is a rebuild
- * of a derived index, not a change to attested content — safe to prune.
+ * Indexes every document path the newly published version references so the
+ * asset proxy can serve it.
+ *
+ * Rows of superseded versions are deliberately kept: a sealed version's
+ * documents are attested content and must stay resolvable for as long as the
+ * version itself does. Whether a path is *servable* right now is decided at
+ * request time by the asset controller against the referencing version's
+ * state, not by deleting history here.
  */
 class SyncPublicationVersionDocuments
 {
     public function handle(PublicationPublished $event): void
     {
         DB::transaction(function () use ($event): void {
-            $staleVersionIds = PublicationVersionProxy::modelClass()::query()
-                ->where('publication_id', $event->publication->id)
-                ->where('locale_id', $event->version->locale_id)
-                ->where('id', '!=', $event->version->id)
-                ->pluck('id');
-
-            if ($staleVersionIds->isNotEmpty()) {
-                PublicationVersionDocumentProxy::modelClass()::query()
-                    ->whereIn('publication_version_id', $staleVersionIds)
-                    ->delete();
-            }
-
             $paths = collect(data_get($event->version->payload, 'documents', []))
                 ->pluck('path')
                 ->filter()

--- a/packages/Webkul/Publication/tests/Feature/PublicationAssetTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublicationAssetTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\DB;
 use Webkul\Publication\Enums\PublicationStatus;
+use Webkul\Publication\Models\PublicationVersionDocumentProxy;
 use Webkul\Publication\Services\Publisher;
 
 it('serves a document referenced by the current published version', function (): void {
@@ -59,4 +60,28 @@ it('404s a document once the per-channel kill switch is disabled, even though th
     app('config')->set('core_config', null);
 
     $this->get('/p/'.$version->publication->uuid.'/asset/'.$path)->assertNotFound();
+});
+
+it('keeps the document index rows of a superseded version', function (): void {
+    [$first, $firstPath] = $this->passportWithDocumentFixture();
+
+    [$second, $secondPath] = $this->republishWithDocument($first, 'certificate-reissued.pdf');
+
+    $rows = PublicationVersionDocumentProxy::modelClass()::query()
+        ->where('publication_id', $first->publication_id)
+        ->pluck('path', 'publication_version_id');
+
+    expect($rows->get($first->id))->toBe($firstPath)
+        ->and($rows->get($second->id))->toBe($secondPath);
+});
+
+it('serves only the paths the current version references once a version is superseded', function (): void {
+    [$first, $firstPath] = $this->passportWithDocumentFixture();
+
+    [, $secondPath] = $this->republishWithDocument($first, 'certificate-reissued.pdf');
+
+    $uuid = $first->publication->uuid;
+
+    $this->get('/p/'.$uuid.'/asset/'.$secondPath)->assertOk();
+    $this->get('/p/'.$uuid.'/asset/'.$firstPath)->assertNotFound();
 });

--- a/packages/Webkul/Publication/tests/PublicationTestCase.php
+++ b/packages/Webkul/Publication/tests/PublicationTestCase.php
@@ -152,4 +152,30 @@ class PublicationTestCase extends TestCase
 
         return [$version, $path];
     }
+
+    /**
+     * Publishes a further version of the fixture's publication whose payload references a fresh document,
+     * superseding $previous for its locale.
+     *
+     * @return array{0: PublicationVersion, 1: string}
+     */
+    protected function republishWithDocument(PublicationVersion $previous, string $filename): array
+    {
+        $publication = $previous->publication;
+
+        $path = 'publication/'.$publication->product_id.'/'.$previous->locale->code.'/'.$filename;
+
+        Storage::disk(config('publication.asset_disk'))->put($path, '%PDF-1.4 stub '.$filename);
+
+        DocumentStubPayloadBuilder::$documentPath = $path;
+
+        $version = resolve(Publisher::class)->publish(
+            $publication->product,
+            $publication->channel,
+            $previous->locale,
+            'dpp',
+        );
+
+        return [$version, $path];
+    }
 }


### PR DESCRIPTION
## Problem

`SyncPublicationVersionDocuments` deletes the `publication_version_documents` rows of every other version for the published `(publication, locale)` on each publish. That destroys the only record of which documents a sealed version attested to. The moment a version is superseded, its declaration of conformity is no longer resolvable through the asset proxy, even though the version row and its payload are kept immutable on purpose.

For a Digital Product Passport this matters: the regulation requires the passport state a product was placed on the market with to remain reachable for the product's lifetime, documents included. Anything built on top of the version history (a per-version public route, an audit export, a regulator view) currently finds versions whose documents 404.

## Fix

Keep the rows. The index now records which version references which path, for every version, and the docblock says so.

Servability is decided at request time in `PublicationAssetController::isReferenced()` against the referencing version's state (`is_current` and not redacted), so the public contract is unchanged: only documents of a current, unredacted version are served from the publication-level asset URL. `PrunePublicationVersionDocumentsOnRedaction` is untouched and still prunes on erasure.

No migration. The unique key `(publication_version_id, path)` already scopes rows per version.

## Tests

- `keeps the document index rows of a superseded version`: after a republish with a fresh document, both versions still have their row.
- `serves only the paths the current version references once a version is superseded`: the new path is 200, the superseded one is 404. This is the guard that the change does not widen what is publicly reachable.

Helper `republishWithDocument()` added to `PublicationTestCase` for the second publish.

Existing `PublicationAssetTest` and the redaction tests pass unchanged.

## Related

Found while assessing DPP lifetime reachability for a customer. Companion PR: #678 fixes the other half of the same problem (document copies are not content-addressed, so a re-issued file never seals a new version).