### PR TITLE
fix(passport): content-address copied documents so a re-issued file seals a new version

### DIFF
--- a/packages/Webkul/ProductPassport/src/Services/PassportPayloadBuilder.php
+++ b/packages/Webkul/ProductPassport/src/Services/PassportPayloadBuilder.php
@@ -205,13 +205,14 @@ class PassportPayloadBuilder implements PayloadBuilder
             ];
         }
 
-        $copiedPath = $this->copyToAssetDisk($context->uuid, $localeCode, $field->code, $raw);
+        $copied = $this->copyToAssetDisk($context->uuid, $localeCode, $field->code, $raw);
 
         return array_filter([
-            'code'  => $field->code,
-            'label' => $label,
-            'path'  => $copiedPath,
-            'kind'  => $kind,
+            'code'   => $field->code,
+            'label'  => $label,
+            'path'   => $copied['path'] ?? null,
+            'sha256' => $copied['sha256'] ?? null,
+            'kind'   => $kind,
         ], fn ($value): bool => $value !== null);
     }
 
@@ -280,11 +281,19 @@ class PassportPayloadBuilder implements PayloadBuilder
     }
 
     /**
-     * Copies the file from the catalog default disk to the asset disk, stamping the final path into the payload.
+     * Copies the file from the catalog default disk to a content-addressed location on the asset disk,
+     * stamping the final path and the file's digest into the payload.
+     *
+     * The digest is part of the path on purpose. A re-issued file lands beside the previous one instead
+     * of being skipped as "already there", so the payload changes, the checksum changes and Publisher
+     * mints a new version, while every sealed version keeps pointing at the exact bytes it attested.
+     * The basename stays the field code, so the download filename is unchanged.
      *
      * Must run at build time: PublicationVersion::payload is immutable once the version row exists, so no path can be rewritten later.
+     *
+     * @return array{path: string, sha256: string}|null
      */
-    private function copyToAssetDisk(string $uuid, string $localeCode, string $fieldCode, string $sourcePath): ?string
+    private function copyToAssetDisk(string $uuid, string $localeCode, string $fieldCode, string $sourcePath): ?array
     {
         $source = Storage::disk(config('filesystems.default'));
 
@@ -292,15 +301,19 @@ class PassportPayloadBuilder implements PayloadBuilder
             return null;
         }
 
+        $contents = (string) $source->get($sourcePath);
+        $digest = hash('sha256', $contents);
         $extension = pathinfo($sourcePath, PATHINFO_EXTENSION);
-        $targetPath = "publication/{$uuid}/{$localeCode}/{$fieldCode}".($extension !== '' ? ".{$extension}" : '');
+
+        $targetPath = "publication/{$uuid}/{$localeCode}/".substr($digest, 0, 16)."/{$fieldCode}".($extension !== '' ? ".{$extension}" : '');
 
         $target = Storage::disk(config('publication.asset_disk'));
 
+        // Content-addressed: an object already at this path holds these exact bytes.
         if (! $target->exists($targetPath)) {
-            $target->put($targetPath, $source->get($sourcePath));
+            $target->put($targetPath, $contents);
         }
 
-        return $targetPath;
+        return ['path' => $targetPath, 'sha256' => $digest];
     }
 }

--- a/packages/Webkul/ProductPassport/tests/Feature/PassportDocumentReissueTest.php
+++ b/packages/Webkul/ProductPassport/tests/Feature/PassportDocumentReissueTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+use Webkul\Publication\Services\Publisher;
+
+it('mints a new sealed version when a referenced document is re-issued', function (): void {
+    $first = $this->publishedPassportFixture(withDocument: true);
+
+    $publication = $first->publication;
+    $firstPath = $first->payload['documents'][0]['path'];
+
+    // Same catalog path, new bytes: what a re-issued declaration of conformity looks like to the PIM.
+    Storage::disk(config('filesystems.default'))->put('product-files/dpp_disassembly_guide/guide.pdf', '%PDF-1.4 re-issued');
+
+    $second = resolve(Publisher::class)->publish($publication->product, $publication->channel, $first->locale, 'dpp');
+
+    $assets = Storage::disk(config('publication.asset_disk'));
+
+    expect($second)->not->toBeNull()
+        ->and($second->version)->toBe($first->version + 1)
+        ->and($second->payload['documents'][0]['path'])->not->toBe($firstPath)
+        ->and($assets->get($firstPath))->toBe('%PDF-1.4 stub')
+        ->and($assets->get($second->payload['documents'][0]['path']))->toBe('%PDF-1.4 re-issued');
+});
+
+it('mints nothing while the referenced document is unchanged', function (): void {
+    $first = $this->publishedPassportFixture(withDocument: true);
+
+    $publication = $first->publication;
+
+    expect(resolve(Publisher::class)->publish($publication->product, $publication->channel, $first->locale, 'dpp'))
+        ->toBeNull();
+});

--- a/packages/Webkul/ProductPassport/tests/Feature/PassportPayloadBuilderTest.php
+++ b/packages/Webkul/ProductPassport/tests/Feature/PassportPayloadBuilderTest.php
@@ -52,3 +52,32 @@ it('excludes the whole meta key from being treated as content by never placing c
 
     expect(array_keys($payload['meta']))->toEqualCanonicalizing(['uuid', 'url', 'locale', 'channel', 'built_at', 'template']);
 });
+
+it('addresses a copied document by its content so a re-issued file lands beside the old one', function (): void {
+    [$product, $context, $sourcePath] = $this->productWithSecretAndDppAttributes(withDocument: true);
+
+    $builder = resolve(PassportPayloadBuilder::class);
+    $assets = Storage::disk(config('publication.asset_disk'));
+
+    $first = $builder->build($product, $context)['documents'][0];
+
+    Storage::disk(config('filesystems.default'))->put($sourcePath, '%PDF-1.4 re-issued');
+
+    $second = $builder->build($product, $context)['documents'][0];
+
+    expect($second['path'])->not->toBe($first['path'])
+        ->and($second['sha256'])->toBe(hash('sha256', '%PDF-1.4 re-issued'))
+        ->and($second['sha256'])->not->toBe($first['sha256'])
+        ->and(basename($second['path']))->toBe(basename($first['path']))
+        ->and($assets->get($first['path']))->toBe('%PDF-1.4 stub')
+        ->and($assets->get($second['path']))->toBe('%PDF-1.4 re-issued');
+});
+
+it('reuses the same asset path while the document is unchanged', function (): void {
+    [$product, $context] = $this->productWithSecretAndDppAttributes(withDocument: true);
+
+    $builder = resolve(PassportPayloadBuilder::class);
+
+    expect($builder->build($product, $context)['documents'][0]['path'])
+        ->toBe($builder->build($product, $context)['documents'][0]['path']);
+});


### PR DESCRIPTION
## Problem

`PassportPayloadBuilder::copyToAssetDisk()` copies a referenced document to `publication/{uuid}/{locale}/{field}.{ext}` and skips the copy when that path already exists.

Replacing a file in the catalog therefore changes nothing the publisher can see:

1. the path is unchanged, so the payload is unchanged,
2. so the checksum is unchanged, so `Publisher::publish()` returns `null` and no version is minted,
3. and because the copy is skipped, the new bytes are never written to the asset disk either.

The passport keeps serving the previous document with no signal that it was replaced. For a re-issued declaration of conformity that is a silent compliance failure, and it also means a sealed version cannot actually guarantee which bytes it attested, since a later publish would have overwritten them at the same path if the guard were removed.

## Fix

Content-address the copy. The first 16 hex characters of the file's SHA-256 go into the path:

```
publication/{uuid}/{locale}/{digest16}/{field}.{ext}
```

and the full digest is stamped into the document entry as `sha256`.

- A re-issued file lands beside the old one, the payload changes, and `Publisher` seals a new version.
- Every existing version keeps resolving to the exact bytes it attested.
- The basename is still the field code, so download filenames are unchanged.
- The `exists()` guard is now correct rather than a bug: an object at that path holds those bytes by construction.

The public template and asset controller only read `path` and `label`, so the extra `sha256` key is inert for them. `preview` mode is untouched.

## Upgrade note

The first republish of a product with documents after this change mints one new version per locale, because the path shape changed. That version is the first whose documents are genuinely attested, so this is intended and a one-time effect.

## Tests

- Builder: a re-issued file yields a new path and digest, keeps the old object intact, and keeps the basename.
- Builder: an unchanged file yields the same path.
- End to end (`PassportDocumentReissueTest`): re-issuing the source file mints version n+1 pointing at the new bytes while the old version's bytes remain; an unchanged file mints nothing. The second case also pins the `meta`-excluded checksum behaviour.

## Related

Companion to #677, which stops pruning the document index of superseded versions. Together they make a sealed version's documents both retained and trustworthy.