### PR TITLE
fix(publication): redact every version on erasure and keep tombstones out of shared caches

### DIFF
--- a/packages/Webkul/Publication/src/Http/Controllers/PublicationController.php
+++ b/packages/Webkul/Publication/src/Http/Controllers/PublicationController.php
@@ -169,11 +169,16 @@ class PublicationController extends Controller
                 ->values(),
         ]);
 
+        $tombstone = $publication->status !== PublicationStatus::Published;
+
+        // Redacted is irreversible, so it is 410 Gone; Withdrawn can be reinstated, so it stays 200.
+        // Neither may sit in a shared cache: a reinstated or (worse) freshly redacted passport must not
+        // keep serving whatever state a proxy happened to capture, and there is no purge hook to rely on.
         return $this->tierCache(
-            response($view->render())
+            response($view->render(), $publication->status === PublicationStatus::Redacted ? 410 : 200)
                 ->header('ETag', $etag)
-                ->header('Cache-Control', $this->cacheControl($publication->channel?->code))
-                ->header('X-Robots-Tag', ((bool) (core()->getConfigData('general.publication.settings.indexable', $publication->channel->code) ?? false)) ? 'index, nofollow' : 'noindex, nofollow'),
+                ->header('Cache-Control', $tombstone ? 'private, no-store' : $this->cacheControl($publication->channel?->code))
+                ->header('X-Robots-Tag', (! $tombstone && (bool) (core()->getConfigData('general.publication.settings.indexable', $publication->channel->code) ?? false)) ? 'index, nofollow' : 'noindex, nofollow'),
             $grantedIndex,
         );
     }

--- a/packages/Webkul/Publication/src/Services/Publisher.php
+++ b/packages/Webkul/Publication/src/Services/Publisher.php
@@ -217,7 +217,12 @@ class Publisher
     }
 
     /**
-     * GDPR Art. 17 erasure: redacts every current version and flips the publication to Redacted (sticky).
+     * GDPR Art. 17 erasure: redacts every not-yet-redacted version of the publication, superseded ones
+     * included, and flips the publication to Redacted (sticky).
+     *
+     * A superseded version is still a sealed record of the same data. Redacting only the current ones
+     * left every earlier payload readable in the database, so the erasure held only for as long as
+     * nothing ever read history. Versions redacted individually earlier are left as they are.
      */
     public function redactAll(Publication $publication, int $redactedById, string $reason): void
     {
@@ -231,15 +236,15 @@ class Publisher
                 );
             }
 
-            $currentVersions = $publication->versions()->where('is_current', true)->get();
+            $versions = $publication->versions()->whereNull('redacted_at')->get();
 
-            if ($currentVersions->isEmpty()) {
+            if ($versions->isEmpty()) {
                 throw new InvalidPublicationTransitionException(
-                    'Publication '.$publication->id.' has no current versions to redact.'
+                    'Publication '.$publication->id.' has no versions left to redact.'
                 );
             }
 
-            foreach ($currentVersions as $version) {
+            foreach ($versions as $version) {
                 $version->redact($redactedById, $reason);
             }
 

--- a/packages/Webkul/Publication/tests/Feature/PublicPassportRouteTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublicPassportRouteTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Str;
 use Webkul\Publication\Enums\PublicationStatus;
+use Webkul\Publication\Services\Publisher;
 
 it('redirects the bare uuid to the canonical per-locale url without caching the redirect', function (): void {
     $version = $this->publishedPassportFixture();
@@ -94,4 +95,33 @@ it('404s everything when the global kill switch is off, regardless of channel se
     config(['publication.enabled' => false]);
 
     $this->get('/p/'.$version->publication->uuid.'/'.$version->locale->code)->assertNotFound();
+});
+
+it('answers 410 Gone, uncacheable and unindexable, for a redacted passport', function (): void {
+    $version = $this->publishedPassportFixture();
+
+    resolve(Publisher::class)->redactAll($version->publication->fresh(), $this->loginAsAdmin()->id, 'gdpr request');
+
+    $response = $this->get('/p/'.$version->publication->uuid.'/'.$version->locale->code)
+        ->assertStatus(410)
+        ->assertHeader('X-Robots-Tag', 'noindex, nofollow')
+        ->assertSee(trans('publication::app.public.withdrawn.heading'));
+
+    expect($response->headers->getCacheControlDirective('no-store'))->toBeTrue()
+        ->and($response->headers->getCacheControlDirective('private'))->toBeTrue()
+        ->and($response->headers->hasCacheControlDirective('s-maxage'))->toBeFalse();
+});
+
+it('keeps a withdrawn tombstone out of shared caches while still answering 200', function (): void {
+    $version = $this->publishedPassportFixture();
+
+    $version->publication->update(['status' => PublicationStatus::Withdrawn]);
+
+    $response = $this->get('/p/'.$version->publication->uuid.'/'.$version->locale->code)
+        ->assertOk()
+        ->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+
+    expect($response->headers->getCacheControlDirective('no-store'))->toBeTrue()
+        ->and($response->headers->getCacheControlDirective('private'))->toBeTrue()
+        ->and($response->headers->hasCacheControlDirective('s-maxage'))->toBeFalse();
 });

--- a/packages/Webkul/Publication/tests/Feature/PublisherRedactAllTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublisherRedactAllTest.php
@@ -6,6 +6,7 @@ use Webkul\Publication\Events\PublicationRedacted;
 use Webkul\Publication\Exceptions\InvalidPublicationTransitionException;
 use Webkul\Publication\Repositories\PublicationRepository;
 use Webkul\Publication\Services\Publisher;
+use Webkul\Publication\Tests\Support\DocumentStubPayloadBuilder;
 use Webkul\Publication\Tests\Support\StubPayloadBuilder;
 use Webkul\User\Models\Admin;
 
@@ -68,4 +69,52 @@ it('refuses to redact an already-redacted publication', function (): void {
 
     expect(fn (): mixed => $publisher->redactAll($first->publication->fresh(), $admin->id, 'second attempt'))
         ->toThrow(InvalidPublicationTransitionException::class);
+});
+
+it('redacts superseded versions too, not only the current one', function (): void {
+    config()->set('publication.types.dpp.payload_builder', DocumentStubPayloadBuilder::class);
+
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/first.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/second.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    expect((bool) $first->fresh()->is_current)->toBeFalse()
+        ->and($second->version)->toBe($first->version + 1);
+
+    $publisher->redactAll($first->publication->fresh(), Admin::factory()->create()->id, 'contained personal data');
+
+    expect($first->fresh()->payload)->toBeNull()
+        ->and($first->fresh()->redacted_at)->not->toBeNull()
+        ->and($first->fresh()->redacted_reason)->toBe('contained personal data')
+        ->and($second->fresh()->payload)->toBeNull()
+        ->and($second->fresh()->redacted_reason)->toBe('contained personal data');
+});
+
+it('leaves a version that was already redacted individually untouched', function (): void {
+    config()->set('publication.types.dpp.payload_builder', DocumentStubPayloadBuilder::class);
+
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+    $admin = Admin::factory()->create();
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/first.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/second.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    $first->redact($admin->id, 'earlier, on its own');
+
+    $publisher->redactAll($first->publication->fresh(), $admin->id, 'whole publication');
+
+    expect($first->fresh()->redacted_reason)->toBe('earlier, on its own')
+        ->and($second->fresh()->redacted_reason)->toBe('whole publication')
+        ->and($first->publication->fresh()->status)->toBe(PublicationStatus::Redacted);
 });


### PR DESCRIPTION
## Problem

`Publisher::redactAll()` redacts only the `is_current` versions and then flips the publication to `Redacted`. Every superseded version keeps its sealed payload readable in the database.

The method's own docblock frames it as GDPR Art. 17 erasure. As written, that erasure holds only for as long as nothing reads history: an admin export, an audit view, or any future per-version route would find earlier payloads intact under a publication that claims to be redacted.

## Fix

Redact every version of the publication that has not been redacted yet, superseded ones included. Versions redacted individually earlier keep their own `redacted_at` / reason and are skipped, so `redactAll()` cannot throw on them. The empty-publication guard is unchanged.

The public tombstone is adjusted alongside, since both are about what a redaction guarantees:

- Redacted answers **`410 Gone`**. The state is irreversible, and 410 still resolves (a 404 would let a caller infer a passport never existed, which the enum docblock rightly avoids).
- Withdrawn stays **`200`**, because it can be reinstated.
- Both tombstones are **`private, no-store`** and **`noindex, nofollow`**. The package has no cache-purge hook, so a shared cache must never hold a tombstone that a reinstatement would have to displace, and a tombstone must not be indexed regardless of the channel's `indexable` setting. Live pages keep the existing `s-maxage` behaviour.

The `If-None-Match` path already keys the ETag on status, so it is unaffected.

## Tests

- `redacts superseded versions too, not only the current one`
- `leaves a version that was already redacted individually untouched`
- `answers 410 Gone, uncacheable and unindexable, for a redacted passport`
- `keeps a withdrawn tombstone out of shared caches while still answering 200`

Existing redaction, tombstone and 304 tests pass unchanged.

## Related

Third in a series on making sealed passport states trustworthy over the product lifetime, after #677 (keep the document index of superseded versions) and #678 (content-addressed document copies).
