### PR TITLE
feat(publication): releases, a cross-locale identifier for a publish moment

### DIFF
--- a/packages/Webkul/Publication/src/Contracts/PublicationRelease.php
+++ b/packages/Webkul/Publication/src/Contracts/PublicationRelease.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Webkul\Publication\Contracts;
+
+interface PublicationRelease {}

--- a/packages/Webkul/Publication/src/Database/Factories/PublicationReleaseFactory.php
+++ b/packages/Webkul/Publication/src/Database/Factories/PublicationReleaseFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Webkul\Publication\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Webkul\Publication\Models\PublicationRelease;
+
+/**
+ * @extends Factory<PublicationRelease>
+ */
+class PublicationReleaseFactory extends Factory
+{
+    protected $model = PublicationRelease::class;
+
+    public function definition(): array
+    {
+        return [
+            'publication_id' => PublicationFactory::new(),
+            'sequence'       => 1,
+            'published_at'   => now(),
+        ];
+    }
+}

--- a/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000010_create_publication_releases_table.php
+++ b/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000010_create_publication_releases_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('publication_releases', function (Blueprint $table): void {
+            $table->id();
+
+            $table->unsignedBigInteger('publication_id');
+            $table->foreign('publication_id')->references('id')->on('publications')->restrictOnDelete();
+
+            // Monotonic per publication: one number identifies one publish moment across every locale.
+            $table->unsignedInteger('sequence');
+
+            $table->dateTime('published_at');
+
+            $table->unsignedInteger('published_by_id')->nullable();
+            $table->foreign('published_by_id')->references('id')->on('admins')->nullOnDelete();
+            $table->index('published_by_id', 'pubrel_pubby_idx');
+
+            $table->timestamps();
+
+            // Explicit names: auto names include the prefix and overrun MySQL's 64-char identifier limit on prefixed installs.
+            $table->unique(['publication_id', 'sequence'], 'pubrel_pub_seq_uq');
+            $table->index(['publication_id', 'published_at'], 'pubrel_pub_pubat_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('publication_releases');
+    }
+};

--- a/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000011_add_release_id_to_publication_versions_table.php
+++ b/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000011_add_release_id_to_publication_versions_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('publication_versions', function (Blueprint $table): void {
+            $table->unsignedBigInteger('release_id')->nullable()->after('checksum');
+            $table->foreign('release_id')->references('id')->on('publication_releases')->restrictOnDelete();
+            $table->index('release_id', 'pubver_release_idx');
+        });
+
+        // Backfill: every existing version becomes its own release, numbered per publication in
+        // publish order, so history reads the same way as anything minted from now on.
+        $sequences = [];
+
+        $versions = DB::table('publication_versions')
+            ->select('id', 'publication_id', 'published_at', 'published_by_id')
+            ->whereNull('release_id')
+            ->orderBy('publication_id')
+            ->orderBy('published_at')
+            ->orderBy('id')
+            ->cursor();
+
+        foreach ($versions as $version) {
+            $sequence = ($sequences[$version->publication_id] ?? 0) + 1;
+            $sequences[$version->publication_id] = $sequence;
+
+            $releaseId = DB::table('publication_releases')->insertGetId([
+                'publication_id'  => $version->publication_id,
+                'sequence'        => $sequence,
+                'published_at'    => $version->published_at,
+                'published_by_id' => $version->published_by_id,
+                'created_at'      => now(),
+                'updated_at'      => now(),
+            ]);
+
+            DB::table('publication_versions')->where('id', $version->id)->update(['release_id' => $releaseId]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('publication_versions', function (Blueprint $table): void {
+            $table->dropForeign(['release_id']);
+            $table->dropIndex('pubver_release_idx');
+            $table->dropColumn('release_id');
+        });
+    }
+};

--- a/packages/Webkul/Publication/src/Models/Publication.php
+++ b/packages/Webkul/Publication/src/Models/Publication.php
@@ -71,6 +71,11 @@ class Publication extends Model implements HistoryContract, PublicationContract
         return $this->hasMany(PublicationVersionProxy::modelClass());
     }
 
+    public function releases(): HasMany
+    {
+        return $this->hasMany(PublicationReleaseProxy::modelClass());
+    }
+
     /**
      * `orderByDesc('version')` guards against a data anomaly, not the normal
      * path: `is_current` is uniquely constrained to one row per locale, so at

--- a/packages/Webkul/Publication/src/Models/PublicationRelease.php
+++ b/packages/Webkul/Publication/src/Models/PublicationRelease.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Webkul\Publication\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Webkul\Publication\Contracts\PublicationRelease as PublicationReleaseContract;
+use Webkul\Publication\Database\Factories\PublicationReleaseFactory;
+use Webkul\Publication\Exceptions\ImmutableVersionException;
+use Webkul\User\Models\AdminProxy;
+
+/**
+ * One publish moment of a publication, identified across every locale by a
+ * per-publication `sequence`.
+ *
+ * Versions are numbered per locale, so "v3" names a different state in each
+ * language. A release names one moment: the state of the passport as of
+ * release N is, for every locale, the most recent version minted at or before
+ * release N. Releases are immutable for the same reason versions are: a number
+ * that has been printed must keep meaning what it meant.
+ */
+#[Fillable([
+    'publication_id',
+    'sequence',
+    'published_at',
+    'published_by_id',
+])]
+#[Table(name: 'publication_releases')]
+class PublicationRelease extends Model implements PublicationReleaseContract
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'sequence'     => 'integer',
+            'published_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::updating(function (self $release): void {
+            $touched = array_diff(array_keys($release->getDirty()), ['updated_at']);
+
+            if ($touched !== []) {
+                throw new ImmutableVersionException(
+                    'Release '.$release->id.' is immutable; attempted to change: '.implode(', ', $touched)
+                );
+            }
+        });
+
+        static::deleting(function (self $release): void {
+            throw new ImmutableVersionException('Release '.$release->id.' cannot be deleted.');
+        });
+    }
+
+    public function publication(): BelongsTo
+    {
+        return $this->belongsTo(PublicationProxy::modelClass());
+    }
+
+    public function publishedBy(): BelongsTo
+    {
+        return $this->belongsTo(AdminProxy::modelClass(), 'published_by_id');
+    }
+
+    /**
+     * The versions minted in this release (at most one per locale by construction).
+     */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(PublicationVersionProxy::modelClass(), 'release_id');
+    }
+
+    /**
+     * The state of the publication as of this release: for every locale, the most
+     * recent version minted at or before it. Redacted versions are included; how
+     * they render is the caller's decision, not a question of which state applied.
+     *
+     * @return Collection<int, PublicationVersion> keyed by locale_id
+     */
+    public function versionsAsOf(): Collection
+    {
+        $versions = $this->publication->versions()
+            ->with(['release', 'locale'])
+            ->whereHas('release', fn ($release) => $release->where('sequence', '<=', $this->sequence))
+            ->get();
+
+        return $versions
+            ->sortByDesc(fn (PublicationVersion $version): int => (int) $version->release->sequence)
+            ->unique('locale_id')
+            ->sortBy('locale_id')
+            ->keyBy('locale_id');
+    }
+
+    protected static function newFactory(): PublicationReleaseFactory
+    {
+        return PublicationReleaseFactory::new();
+    }
+}

--- a/packages/Webkul/Publication/src/Models/PublicationReleaseProxy.php
+++ b/packages/Webkul/Publication/src/Models/PublicationReleaseProxy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Webkul\Publication\Models;
+
+use Konekt\Concord\Proxies\ModelProxy;
+
+class PublicationReleaseProxy extends ModelProxy {}

--- a/packages/Webkul/Publication/src/Models/PublicationVersion.php
+++ b/packages/Webkul/Publication/src/Models/PublicationVersion.php
@@ -22,6 +22,7 @@ use Webkul\User\Models\AdminProxy;
     'publication_id',
     'locale_id',
     'version',
+    'release_id',
     'payload',
     'checksum',
     'is_current',
@@ -154,6 +155,11 @@ class PublicationVersion extends Model implements PublicationVersionContract
     public function publication(): BelongsTo
     {
         return $this->belongsTo(PublicationProxy::modelClass());
+    }
+
+    public function release(): BelongsTo
+    {
+        return $this->belongsTo(PublicationReleaseProxy::modelClass(), 'release_id');
     }
 
     public function locale(): BelongsTo

--- a/packages/Webkul/Publication/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Publication/src/Providers/ModuleServiceProvider.php
@@ -5,6 +5,7 @@ namespace Webkul\Publication\Providers;
 use Webkul\Core\Providers\CoreModuleServiceProvider;
 use Webkul\Publication\Models\Publication;
 use Webkul\Publication\Models\PublicationPublishAttempt;
+use Webkul\Publication\Models\PublicationRelease;
 use Webkul\Publication\Models\PublicationVersion;
 use Webkul\Publication\Models\PublicationVersionDocument;
 use Webkul\Publication\Models\PublicationVersionPayload;
@@ -14,6 +15,7 @@ class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
         Publication::class,
+        PublicationRelease::class,
         PublicationVersion::class,
         PublicationVersionPayload::class,
         PublicationVersionDocument::class,

--- a/packages/Webkul/Publication/src/Services/Publisher.php
+++ b/packages/Webkul/Publication/src/Services/Publisher.php
@@ -19,6 +19,7 @@ use Webkul\Publication\Events\PublicationReinstated;
 use Webkul\Publication\Events\PublicationWithdrawn;
 use Webkul\Publication\Exceptions\InvalidPublicationTransitionException;
 use Webkul\Publication\Models\Publication;
+use Webkul\Publication\Models\PublicationRelease;
 use Webkul\Publication\Models\PublicationVersion;
 use Webkul\Publication\Registry\PublicationTypeRegistry;
 use Webkul\Publication\Repositories\PublicationRepository;
@@ -95,13 +96,16 @@ class Publisher
 
             $current?->markSuperseded();
 
+            $release = $this->mintRelease($publication, $publishedById);
+
             $version = $publication->versions()->create([
                 'locale_id'       => $locale->id,
                 'version'         => $nextVersion,
+                'release_id'      => $release->id,
                 'payload'         => $payload,
                 'checksum'        => $checksum,
                 'is_current'      => true,
-                'published_at'    => now(),
+                'published_at'    => $release->published_at,
                 'published_by_id' => $publishedById,
             ]);
 
@@ -161,13 +165,16 @@ class Publisher
 
             $current?->markSuperseded();
 
+            $release = $this->mintRelease($publication, $publishedById);
+
             $version = $publication->versions()->create([
                 'locale_id'       => $localeId,
                 'version'         => $nextVersion,
+                'release_id'      => $release->id,
                 'payload'         => $payload,
                 'checksum'        => $source->checksum,
                 'is_current'      => true,
-                'published_at'    => now(),
+                'published_at'    => $release->published_at,
                 'published_by_id' => $publishedById,
             ]);
 
@@ -247,6 +254,21 @@ class Publisher
 
             DB::afterCommit(fn () => PublicationRedacted::dispatch($publication, $reason));
         });
+    }
+
+    /**
+     * Mints the release a newly minted version belongs to. Callers hold the publication row lock,
+     * so MAX(sequence)+1 cannot race, for the same reason version numbers cannot.
+     */
+    private function mintRelease(Publication $publication, ?int $publishedById): PublicationRelease
+    {
+        $sequence = (int) $publication->releases()->max('sequence') + 1;
+
+        return $publication->releases()->create([
+            'sequence'        => $sequence,
+            'published_at'    => now(),
+            'published_by_id' => $publishedById,
+        ]);
     }
 
     /**

--- a/packages/Webkul/Publication/tests/Feature/PublicationReleaseTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublicationReleaseTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Webkul\Publication\Exceptions\ImmutableVersionException;
+use Webkul\Publication\Services\Publisher;
+use Webkul\Publication\Tests\Support\DocumentStubPayloadBuilder;
+use Webkul\User\Models\Admin;
+
+beforeEach(function (): void {
+    config()->set('publication.types.dpp', [
+        'label'           => 'publication::app.publications.status.draft',
+        'payload_builder' => DocumentStubPayloadBuilder::class,
+        'template'        => 'publication::dpp.show',
+        'route_prefix'    => 'dpp',
+    ]);
+});
+
+it('mints one release per minted version, numbered per publication', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    // Unchanged payload: no version, so no release either.
+    expect($publisher->publish($product, $channel, $complete, 'dpp'))->toBeNull();
+
+    $publication = $first->publication->fresh();
+
+    expect($first->release->sequence)->toBe(1)
+        ->and($second->release->sequence)->toBe(2)
+        ->and($second->release->published_at->equalTo($second->published_at))->toBeTrue()
+        ->and($publication->releases()->count())->toBe(2)
+        ->and($second->release->versions()->pluck('id')->all())->toBe([$second->id]);
+});
+
+it('numbers releases across locales in publish order and resolves the state as of each one', function (): void {
+    [$product, $channel, $other, $complete] = $this->seedPassportFixture(completeBoth: true);
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $completeV1 = $publisher->publish($product, $channel, $complete, 'dpp');
+    $otherV1 = $publisher->publish($product, $channel, $other, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $completeV2 = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    $publication = $completeV1->publication->fresh();
+
+    expect($completeV1->release->sequence)->toBe(1)
+        ->and($otherV1->release->sequence)->toBe(2)
+        ->and($completeV2->release->sequence)->toBe(3)
+        // Version numbers still run per locale; the release is what spans them.
+        ->and($completeV2->version)->toBe(2)
+        ->and($otherV1->version)->toBe(1);
+
+    $asOf = fn (int $sequence): array => $publication->releases()->where('sequence', $sequence)->firstOrFail()
+        ->versionsAsOf()
+        ->map(fn ($version): int => $version->id)
+        ->all();
+
+    expect($asOf(1))->toBe([$complete->id => $completeV1->id])
+        ->and($asOf(2))->toEqualCanonicalizing([$complete->id => $completeV1->id, $other->id => $otherV1->id])
+        ->and($asOf(3))->toEqualCanonicalizing([$complete->id => $completeV2->id, $other->id => $otherV1->id]);
+});
+
+it('mints a release for a forward-only rollback too', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $publisher->publish($product, $channel, $complete, 'dpp');
+
+    $rolledBack = $publisher->republishFrom($first, Admin::factory()->create()->id);
+
+    expect($rolledBack->version)->toBe(3)
+        ->and($rolledBack->release->sequence)->toBe(3)
+        ->and($rolledBack->release->published_by_id)->not->toBeNull();
+});
+
+it('refuses to change or delete a release', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $release = resolve(Publisher::class)->publish($product, $channel, $complete, 'dpp')->release;
+
+    expect(fn (): mixed => $release->update(['sequence' => 99]))->toThrow(ImmutableVersionException::class)
+        ->and(fn (): mixed => $release->delete())->toThrow(ImmutableVersionException::class)
+        ->and($release->fresh()->sequence)->toBe(1);
+});
+
+it('refuses to move a version to another release', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    expect(fn (): mixed => $first->update(['release_id' => $second->release_id]))
+        ->toThrow(ImmutableVersionException::class);
+});


### PR DESCRIPTION
## Problem

Versions are numbered per locale, so "version 3" names a different state in every language. There is nothing that identifies one publish moment across locales.

That matters for the Digital Product Passport: the state a product was placed on the market with is one moment, not one per language, and a printed carrier needs one number that keeps meaning that moment. Today the only cross-locale handle is a timestamp lookup, which is nothing you can print or reason about.

## Change

**New table `publication_releases`**: `publication_id`, `sequence` (monotonic per publication, unique on `(publication_id, sequence)`), `published_at`, `published_by_id`. One release is minted per minted version, inside the same publication row lock that already protects the version number, so `MAX(sequence) + 1` cannot race for the same reason `MAX(version) + 1` cannot.

**`publication_versions.release_id`** (nullable FK, `restrictOnDelete`), set by both `publish()` and `republishFrom()`. The version's `published_at` is now taken from the release so the two never drift.

**Backfill** in the same migration: every existing version becomes its own release, numbered per publication in `(published_at, id)` order. Uses the query builder only, so it runs on MySQL and PostgreSQL alike and respects the table prefix.

**Immutability**: releases refuse `update()` and `delete()` with `ImmutableVersionException`, like versions. `release_id` is not in a version's mutable-after-publish set, so moving a version to another release throws.

**`PublicationRelease::versionsAsOf()`**: the state of the publication as of that release, for every locale the most recent version minted at or before it, keyed by `locale_id`. Redacted versions are included; rendering them is the caller's decision. This is the read a per-release public route needs and nothing else.

No public behaviour changes in this PR. Routes, templates and JSON-LD are untouched.

## Tests

- one release per minted version, numbered per publication; an unchanged publish mints neither
- releases number across locales in publish order, and `versionsAsOf()` resolves the right version per locale for each of three consecutive releases, while version numbers keep running per locale
- `republishFrom()` mints a release too
- a release refuses update and delete
- a version refuses to move to another release

Backfill was additionally exercised by rolling the migration back on a database with interleaved versions across two publications and migrating forward again: sequences come out per publication in publish order, and no `release_id` is left null.

## Related

Follows #677, #678 and #679, which make a sealed version's documents and redaction trustworthy. A per-release public route builds on this.
