### PR TITLE
feat(publication): public per-release route

### DIFF
--- a/packages/Webkul/ProductPassport/src/Resources/views/public/passport.blade.php
+++ b/packages/Webkul/ProductPassport/src/Resources/views/public/passport.blade.php
@@ -9,7 +9,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ trans('passport::app.public.title') }}</title>
-    @if (! ($preview ?? false) && ! $withdrawn && (! empty($payload['identifier']['gtin']) || ! empty($payload['sections'])))
+    @if ($release ?? false)
+        {{-- A release page is a reference to one moment, never the page search engines should surface. --}}
+        <link rel="canonical" href="{{ $release['current_url'] }}">
+        <meta name="robots" content="noindex, noarchive">
+    @endif
+    @if (! ($preview ?? false) && ! ($release ?? false) && ! $withdrawn && (! empty($payload['identifier']['gtin']) || ! empty($payload['sections'])))
         {{-- Emitted only for a live (Published) passport: a withdrawn/redacted
              page renders a tombstone, so its frozen payload must never surface
              as machine-readable JSON-LD — matching the controller's Published
@@ -114,6 +119,10 @@
             header.hero { background: var(--accent); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
             .card { break-inside: avoid; border-color: #ccc; }
         }
+        .release-banner { background: var(--accent-soft); border: 1px solid var(--border); border-radius: var(--radius); padding: .75rem 1rem; margin-bottom: 1rem; }
+        .release-banner .t { font-weight: 600; }
+        .release-banner .d { color: var(--muted); font-size: .9rem; }
+        .release-banner a { color: var(--accent-strong); }
     </style>
 </head>
 <body>
@@ -129,12 +138,22 @@
                 @foreach ($locales as $availableLocale)
                     <a @class(['active' => $availableLocale->code === $locale])
                        data-code="{{ strtolower($availableLocale->code) }}"
-                       href="{{ route('publication.public.dpp.show.locale', ['uuid' => $uuid, 'locale' => $availableLocale->code]) }}">{{ $availableLocale->code }}</a>
+                       href="{{ ($release ?? false)
+                            ? route('publication.public.dpp.show.release', ['uuid' => $uuid, 'sequence' => $release['sequence'], 'locale' => $availableLocale->code])
+                            : route('publication.public.dpp.show.locale', ['uuid' => $uuid, 'locale' => $availableLocale->code]) }}">{{ $availableLocale->code }}</a>
                 @endforeach
             </div>
         </div>
     </details>
     @endunless
+
+    @if ($release ?? false)
+        <div class="release-banner" role="status">
+            <div class="t">{{ trans('publication::app.public.release.banner', ['sequence' => $release['sequence']]) }}</div>
+            <div class="d">{{ $release['is_current'] ? trans('publication::app.public.release.current') : trans('publication::app.public.release.superseded') }}
+                <a href="{{ $release['current_url'] }}">{{ trans('publication::app.public.release.view-current') }}</a></div>
+        </div>
+    @endif
 
     @if ($preview ?? false)
         <div class="preview-banner" role="status">

--- a/packages/Webkul/ProductPassport/tests/Feature/PassportPageRenderTest.php
+++ b/packages/Webkul/ProductPassport/tests/Feature/PassportPageRenderTest.php
@@ -77,3 +77,20 @@ it('sets a restrictive csp and referrer policy on the public route group', funct
         ->toContain("default-src 'none'")
         ->toContain("frame-ancestors 'none'");
 });
+
+it('renders a release url with the release banner, a canonical link to the live page and no indexing', function (): void {
+    $version = $this->publishedPassportFixture();
+
+    $uuid = $version->publication->uuid;
+    $locale = $version->locale->code;
+    $live = route('publication.public.dpp.show.locale', ['uuid' => $uuid, 'locale' => $locale]);
+
+    $this->get('/p/'.$uuid.'/r/1/'.$locale)
+        ->assertOk()
+        ->assertHeader('X-Robots-Tag', 'noindex, noarchive, nofollow')
+        ->assertSee('<link rel="canonical" href="'.$live.'">', false)
+        ->assertSee(trans('publication::app.public.release.banner', ['sequence' => 1]))
+        ->assertSee(trans('publication::app.public.release.current'))
+        ->assertSee(route('publication.public.dpp.show.release', ['uuid' => $uuid, 'sequence' => 1, 'locale' => $locale]), false)
+        ->assertDontSee('application/ld+json');
+});

--- a/packages/Webkul/Publication/src/Contracts/PublicationRelease.php
+++ b/packages/Webkul/Publication/src/Contracts/PublicationRelease.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Webkul\Publication\Contracts;
+
+interface PublicationRelease {}

--- a/packages/Webkul/Publication/src/Database/Factories/PublicationReleaseFactory.php
+++ b/packages/Webkul/Publication/src/Database/Factories/PublicationReleaseFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Webkul\Publication\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Webkul\Publication\Models\PublicationRelease;
+
+/**
+ * @extends Factory<PublicationRelease>
+ */
+class PublicationReleaseFactory extends Factory
+{
+    protected $model = PublicationRelease::class;
+
+    public function definition(): array
+    {
+        return [
+            'publication_id' => PublicationFactory::new(),
+            'sequence'       => 1,
+            'published_at'   => now(),
+        ];
+    }
+}

--- a/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000010_create_publication_releases_table.php
+++ b/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000010_create_publication_releases_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('publication_releases', function (Blueprint $table): void {
+            $table->id();
+
+            $table->unsignedBigInteger('publication_id');
+            $table->foreign('publication_id')->references('id')->on('publications')->restrictOnDelete();
+
+            // Monotonic per publication: one number identifies one publish moment across every locale.
+            $table->unsignedInteger('sequence');
+
+            $table->dateTime('published_at');
+
+            $table->unsignedInteger('published_by_id')->nullable();
+            $table->foreign('published_by_id')->references('id')->on('admins')->nullOnDelete();
+            $table->index('published_by_id', 'pubrel_pubby_idx');
+
+            $table->timestamps();
+
+            // Explicit names: auto names include the prefix and overrun MySQL's 64-char identifier limit on prefixed installs.
+            $table->unique(['publication_id', 'sequence'], 'pubrel_pub_seq_uq');
+            $table->index(['publication_id', 'published_at'], 'pubrel_pub_pubat_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('publication_releases');
+    }
+};

--- a/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000011_add_release_id_to_publication_versions_table.php
+++ b/packages/Webkul/Publication/src/Database/Migrations/2026_09_04_000011_add_release_id_to_publication_versions_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('publication_versions', function (Blueprint $table): void {
+            $table->unsignedBigInteger('release_id')->nullable()->after('checksum');
+            $table->foreign('release_id')->references('id')->on('publication_releases')->restrictOnDelete();
+            $table->index('release_id', 'pubver_release_idx');
+        });
+
+        // Backfill: every existing version becomes its own release, numbered per publication in
+        // publish order, so history reads the same way as anything minted from now on.
+        $sequences = [];
+
+        $versions = DB::table('publication_versions')
+            ->select('id', 'publication_id', 'published_at', 'published_by_id')
+            ->whereNull('release_id')
+            ->orderBy('publication_id')
+            ->orderBy('published_at')
+            ->orderBy('id')
+            ->cursor();
+
+        foreach ($versions as $version) {
+            $sequence = ($sequences[$version->publication_id] ?? 0) + 1;
+            $sequences[$version->publication_id] = $sequence;
+
+            $releaseId = DB::table('publication_releases')->insertGetId([
+                'publication_id'  => $version->publication_id,
+                'sequence'        => $sequence,
+                'published_at'    => $version->published_at,
+                'published_by_id' => $version->published_by_id,
+                'created_at'      => now(),
+                'updated_at'      => now(),
+            ]);
+
+            DB::table('publication_versions')->where('id', $version->id)->update(['release_id' => $releaseId]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('publication_versions', function (Blueprint $table): void {
+            $table->dropForeign(['release_id']);
+            $table->dropIndex('pubver_release_idx');
+            $table->dropColumn('release_id');
+        });
+    }
+};

--- a/packages/Webkul/Publication/src/Http/Controllers/PublicationController.php
+++ b/packages/Webkul/Publication/src/Http/Controllers/PublicationController.php
@@ -2,12 +2,15 @@
 
 namespace Webkul\Publication\Http\Controllers;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Symfony\Component\HttpFoundation\Response;
+use Webkul\Publication\DataTransferObjects\PublicationType;
 use Webkul\Publication\Enums\PublicationStatus;
 use Webkul\Publication\Jobs\RecordPublicationView;
 use Webkul\Publication\Models\Publication;
+use Webkul\Publication\Models\PublicationRelease;
 use Webkul\Publication\Models\PublicationVersion;
 use Webkul\Publication\Registry\PublicationTypeRegistry;
 use Webkul\Publication\Services\PublicationResolver;
@@ -18,7 +21,7 @@ class PublicationController extends Controller
      * Bump when the rendered template's HTML shape changes in a way that must
      * invalidate every previously cached ETag, independent of payload content.
      */
-    private const TEMPLATE_VERSION = '1';
+    private const TEMPLATE_VERSION = '2';
 
     public function __construct(
         private readonly PublicationResolver $resolver,
@@ -88,7 +91,7 @@ class PublicationController extends Controller
     }
 
     /**
-     * Renders the publication, honouring If-None-Match against a checksum-derived ETag.
+     * Renders the live state: the current version for the requested locale, honouring If-None-Match.
      *
      * The locale switcher is built from the published versions, not the channel's
      * locales: a channel locale with no current version has no URL to switch to.
@@ -100,8 +103,6 @@ class PublicationController extends Controller
         if (! $this->registry->has($type)) {
             return $this->notFound();
         }
-
-        $definition = $this->registry->get($type);
 
         $publication = $this->resolveEnabledPublication($uuid, $type);
 
@@ -115,13 +116,73 @@ class PublicationController extends Controller
             return $this->notFound();
         }
 
+        return $this->render($request, $this->registry->get($type), $publication, $version, null, $publication->versions);
+    }
+
+    /**
+     * Renders the state as of one release: for the requested locale, the most recent version minted at
+     * or before that release. Strict locale, no Accept-Language negotiation: an explicit historical URL
+     * is a reference, and a reference must not resolve to a different document per reader.
+     */
+    public function showRelease(Request $request, string $uuid, string $sequence, string $locale): Response
+    {
+        $type = $this->routeType($request);
+
+        if (! $this->registry->has($type)) {
+            return $this->notFound();
+        }
+
+        $publication = $this->resolveEnabledPublication($uuid, $type);
+
+        if ($publication === null) {
+            return $this->notFound();
+        }
+
+        $release = $this->resolver->findRelease($publication, (int) $sequence);
+
+        if ($release === null) {
+            return $this->notFound();
+        }
+
+        $versions = $release->versionsAsOf();
+
+        $version = $versions->first(fn (PublicationVersion $candidate): bool => $candidate->locale->code === $locale);
+
+        if ($version === null) {
+            return $this->notFound();
+        }
+
+        return $this->render($request, $this->registry->get($type), $publication, $version, $release, $versions);
+    }
+
+    /**
+     * Shared by the live and the release routes. A release page differs in three ways: its locale switcher
+     * stays inside the release, it is never indexed and always carries a canonical link to the live page,
+     * and it never negotiates JSON-LD (a historical payload's stamped identity is the publication URL,
+     * which would misdescribe it).
+     *
+     * @param  Collection<int, PublicationVersion>  $switchable  the versions the locale switcher may link to
+     */
+    private function render(
+        Request $request,
+        PublicationType $definition,
+        Publication $publication,
+        PublicationVersion $version,
+        ?PublicationRelease $release,
+        Collection $switchable,
+    ): Response {
         [$granted, $grantedIndex] = $this->grantedTier($request);
         $payload = $this->applyTierGate($version->payload, $grantedIndex);
 
-        // Only Published exposes payload: withdrawn/redacted must fall through to the tombstone, not leak JSON-LD.
+        // An individually redacted version is a tombstone even under a Published publication: its payload is gone.
+        $gone = $publication->status === PublicationStatus::Redacted || $version->redacted_at !== null;
+        $tombstone = $gone || $publication->status !== PublicationStatus::Published;
+
+        // Only the live Published state exposes payload as JSON-LD: tombstones must not leak it, historical states are HTML only.
         if (
-            $definition->jsonld !== null
-            && $publication->status === PublicationStatus::Published
+            $release === null
+            && ! $tombstone
+            && $definition->jsonld !== null
             && str_contains((string) $request->header('Accept'), 'application/ld+json')
         ) {
             app()->setLocale($version->locale->code);
@@ -139,12 +200,17 @@ class PublicationController extends Controller
 
         app()->setLocale($version->locale->code);
 
+        // Release pages carry a banner whose text depends on whether the state is still current, and a
+        // redacted version renders as a tombstone; both change the HTML without changing the checksum.
         $etag = '"'.hash_hmac('sha256', implode('|', [
             $version->checksum,
             $publication->status->value,
             $version->locale->code,
             $granted,
             self::TEMPLATE_VERSION,
+            $release?->sequence ?? 'live',
+            $version->is_current ? 'current' : 'superseded',
+            $version->redacted_at === null ? 'intact' : 'redacted',
         ]), config('app.key')).'"';
 
         if (trim((string) $request->header('If-None-Match')) === $etag) {
@@ -152,35 +218,52 @@ class PublicationController extends Controller
         }
 
         // Count only a live (Published) full HTML render — never a 304, a JSON-LD
-        // negotiation, or a withdrawn/redacted tombstone. Queued so the render is
+        // negotiation, a tombstone, or a historical release page. Queued so the render is
         // not slowed, and it stores a daily count only: no IP, no visitor identity.
-        if ($publication->status === PublicationStatus::Published) {
+        if ($release === null && ! $tombstone) {
             RecordPublicationView::dispatch($publication->id, (int) $version->locale->id);
         }
 
+        $liveUrl = route('publication.public.'.$definition->code.'.show.locale', [
+            'uuid'   => $publication->uuid,
+            'locale' => $version->locale->code,
+        ]);
+
         $view = view($definition->template, [
             'payload'   => $payload,
-            'withdrawn' => $publication->status !== PublicationStatus::Published,
+            'withdrawn' => $tombstone,
             'uuid'      => $publication->uuid,
             'locale'    => $version->locale->code,
-            'locales'   => $publication->versions
+            'locales'   => $switchable
                 ->map(fn (PublicationVersion $published) => $published->locale)
                 ->sortBy('code')
                 ->values(),
+            'release'   => $release === null ? null : [
+                'sequence'     => (int) $release->sequence,
+                'is_current'   => (bool) $version->is_current,
+                'published_at' => $release->published_at,
+                'current_url'  => $liveUrl,
+            ],
         ]);
 
-        $tombstone = $publication->status !== PublicationStatus::Published;
+        $robots = match (true) {
+            $release !== null => 'noindex, noarchive, nofollow',
+            $tombstone        => 'noindex, nofollow',
+            default           => ((bool) (core()->getConfigData('general.publication.settings.indexable', $publication->channel->code) ?? false)) ? 'index, nofollow' : 'noindex, nofollow',
+        };
 
         // Redacted is irreversible, so it is 410 Gone; Withdrawn can be reinstated, so it stays 200.
-        // Neither may sit in a shared cache: a reinstated or (worse) freshly redacted passport must not
-        // keep serving whatever state a proxy happened to capture, and there is no purge hook to rely on.
-        return $this->tierCache(
-            response($view->render(), $publication->status === PublicationStatus::Redacted ? 410 : 200)
-                ->header('ETag', $etag)
-                ->header('Cache-Control', $tombstone ? 'private, no-store' : $this->cacheControl($publication->channel?->code))
-                ->header('X-Robots-Tag', (! $tombstone && (bool) (core()->getConfigData('general.publication.settings.indexable', $publication->channel->code) ?? false)) ? 'index, nofollow' : 'noindex, nofollow'),
-            $grantedIndex,
-        );
+        // No tombstone may sit in a shared cache: there is no purge hook to displace it on reinstatement.
+        $response = response($view->render(), $gone ? 410 : 200)
+            ->header('ETag', $etag)
+            ->header('Cache-Control', $tombstone ? 'private, no-store' : $this->cacheControl($publication->channel?->code))
+            ->header('X-Robots-Tag', $robots);
+
+        if ($release !== null) {
+            $response->header('Link', '<'.$liveUrl.'>; rel="canonical"');
+        }
+
+        return $this->tierCache($response, $grantedIndex);
     }
 
     /**

--- a/packages/Webkul/Publication/src/Http/Controllers/PublicationController.php
+++ b/packages/Webkul/Publication/src/Http/Controllers/PublicationController.php
@@ -169,11 +169,16 @@ class PublicationController extends Controller
                 ->values(),
         ]);
 
+        $tombstone = $publication->status !== PublicationStatus::Published;
+
+        // Redacted is irreversible, so it is 410 Gone; Withdrawn can be reinstated, so it stays 200.
+        // Neither may sit in a shared cache: a reinstated or (worse) freshly redacted passport must not
+        // keep serving whatever state a proxy happened to capture, and there is no purge hook to rely on.
         return $this->tierCache(
-            response($view->render())
+            response($view->render(), $publication->status === PublicationStatus::Redacted ? 410 : 200)
                 ->header('ETag', $etag)
-                ->header('Cache-Control', $this->cacheControl($publication->channel?->code))
-                ->header('X-Robots-Tag', ((bool) (core()->getConfigData('general.publication.settings.indexable', $publication->channel->code) ?? false)) ? 'index, nofollow' : 'noindex, nofollow'),
+                ->header('Cache-Control', $tombstone ? 'private, no-store' : $this->cacheControl($publication->channel?->code))
+                ->header('X-Robots-Tag', (! $tombstone && (bool) (core()->getConfigData('general.publication.settings.indexable', $publication->channel->code) ?? false)) ? 'index, nofollow' : 'noindex, nofollow'),
             $grantedIndex,
         );
     }

--- a/packages/Webkul/Publication/src/Models/Publication.php
+++ b/packages/Webkul/Publication/src/Models/Publication.php
@@ -71,6 +71,11 @@ class Publication extends Model implements HistoryContract, PublicationContract
         return $this->hasMany(PublicationVersionProxy::modelClass());
     }
 
+    public function releases(): HasMany
+    {
+        return $this->hasMany(PublicationReleaseProxy::modelClass());
+    }
+
     /**
      * `orderByDesc('version')` guards against a data anomaly, not the normal
      * path: `is_current` is uniquely constrained to one row per locale, so at

--- a/packages/Webkul/Publication/src/Models/PublicationRelease.php
+++ b/packages/Webkul/Publication/src/Models/PublicationRelease.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Webkul\Publication\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Webkul\Publication\Contracts\PublicationRelease as PublicationReleaseContract;
+use Webkul\Publication\Database\Factories\PublicationReleaseFactory;
+use Webkul\Publication\Exceptions\ImmutableVersionException;
+use Webkul\User\Models\AdminProxy;
+
+/**
+ * One publish moment of a publication, identified across every locale by a
+ * per-publication `sequence`.
+ *
+ * Versions are numbered per locale, so "v3" names a different state in each
+ * language. A release names one moment: the state of the passport as of
+ * release N is, for every locale, the most recent version minted at or before
+ * release N. Releases are immutable for the same reason versions are: a number
+ * that has been printed must keep meaning what it meant.
+ */
+#[Fillable([
+    'publication_id',
+    'sequence',
+    'published_at',
+    'published_by_id',
+])]
+#[Table(name: 'publication_releases')]
+class PublicationRelease extends Model implements PublicationReleaseContract
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'sequence'     => 'integer',
+            'published_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::updating(function (self $release): void {
+            $touched = array_diff(array_keys($release->getDirty()), ['updated_at']);
+
+            if ($touched !== []) {
+                throw new ImmutableVersionException(
+                    'Release '.$release->id.' is immutable; attempted to change: '.implode(', ', $touched)
+                );
+            }
+        });
+
+        static::deleting(function (self $release): void {
+            throw new ImmutableVersionException('Release '.$release->id.' cannot be deleted.');
+        });
+    }
+
+    public function publication(): BelongsTo
+    {
+        return $this->belongsTo(PublicationProxy::modelClass());
+    }
+
+    public function publishedBy(): BelongsTo
+    {
+        return $this->belongsTo(AdminProxy::modelClass(), 'published_by_id');
+    }
+
+    /**
+     * The versions minted in this release (at most one per locale by construction).
+     */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(PublicationVersionProxy::modelClass(), 'release_id');
+    }
+
+    /**
+     * The state of the publication as of this release: for every locale, the most
+     * recent version minted at or before it. Redacted versions are included; how
+     * they render is the caller's decision, not a question of which state applied.
+     *
+     * @return Collection<int, PublicationVersion> keyed by locale_id
+     */
+    public function versionsAsOf(): Collection
+    {
+        $versions = $this->publication->versions()
+            ->with(['release', 'locale'])
+            ->whereHas('release', fn ($release) => $release->where('sequence', '<=', $this->sequence))
+            ->get();
+
+        return $versions
+            ->sortByDesc(fn (PublicationVersion $version): int => (int) $version->release->sequence)
+            ->unique('locale_id')
+            ->sortBy('locale_id')
+            ->keyBy('locale_id');
+    }
+
+    protected static function newFactory(): PublicationReleaseFactory
+    {
+        return PublicationReleaseFactory::new();
+    }
+}

--- a/packages/Webkul/Publication/src/Models/PublicationReleaseProxy.php
+++ b/packages/Webkul/Publication/src/Models/PublicationReleaseProxy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Webkul\Publication\Models;
+
+use Konekt\Concord\Proxies\ModelProxy;
+
+class PublicationReleaseProxy extends ModelProxy {}

--- a/packages/Webkul/Publication/src/Models/PublicationVersion.php
+++ b/packages/Webkul/Publication/src/Models/PublicationVersion.php
@@ -22,6 +22,7 @@ use Webkul\User\Models\AdminProxy;
     'publication_id',
     'locale_id',
     'version',
+    'release_id',
     'payload',
     'checksum',
     'is_current',
@@ -154,6 +155,11 @@ class PublicationVersion extends Model implements PublicationVersionContract
     public function publication(): BelongsTo
     {
         return $this->belongsTo(PublicationProxy::modelClass());
+    }
+
+    public function release(): BelongsTo
+    {
+        return $this->belongsTo(PublicationReleaseProxy::modelClass(), 'release_id');
     }
 
     public function locale(): BelongsTo

--- a/packages/Webkul/Publication/src/Providers/ModuleServiceProvider.php
+++ b/packages/Webkul/Publication/src/Providers/ModuleServiceProvider.php
@@ -5,6 +5,7 @@ namespace Webkul\Publication\Providers;
 use Webkul\Core\Providers\CoreModuleServiceProvider;
 use Webkul\Publication\Models\Publication;
 use Webkul\Publication\Models\PublicationPublishAttempt;
+use Webkul\Publication\Models\PublicationRelease;
 use Webkul\Publication\Models\PublicationVersion;
 use Webkul\Publication\Models\PublicationVersionDocument;
 use Webkul\Publication\Models\PublicationVersionPayload;
@@ -14,6 +15,7 @@ class ModuleServiceProvider extends CoreModuleServiceProvider
 {
     protected $models = [
         Publication::class,
+        PublicationRelease::class,
         PublicationVersion::class,
         PublicationVersionPayload::class,
         PublicationVersionDocument::class,

--- a/packages/Webkul/Publication/src/Providers/PublicationServiceProvider.php
+++ b/packages/Webkul/Publication/src/Providers/PublicationServiceProvider.php
@@ -121,6 +121,13 @@ class PublicationServiceProvider extends ServiceProvider
                         ->defaults('type', $type->code)
                         ->name('publication.public.'.$type->code.'.carrier.svg');
 
+                    // Four segments with a literal `r`, so it can never shadow the two-segment routes above.
+                    // `sequence` is bounded to a positive int that fits the column; anything else 404s at the router.
+                    Route::get('/{uuid}/r/{sequence}/{locale}', [PublicationController::class, 'showRelease'])
+                        ->where('sequence', '[1-9][0-9]{0,9}')
+                        ->defaults('type', $type->code)
+                        ->name('publication.public.'.$type->code.'.show.release');
+
                     Route::get('/{uuid}/{locale}', [PublicationController::class, 'show'])
                         ->defaults('type', $type->code)
                         ->name('publication.public.'.$type->code.'.show.locale');

--- a/packages/Webkul/Publication/src/Resources/lang/ar_AE/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/ar_AE/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'هذا الجواز لم يعد متاحًا.',
             'notice'  => 'يُحتفظ بهذا السجل لأغراض الشفافية، لكنه لم يعد يُحدَّث بشكل نشط.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/ca_ES/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/ca_ES/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Aquest passaport ja no està disponible.',
             'notice'  => 'Aquest registre es conserva per transparència, però ja no es manté activament.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/da_DK/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/da_DK/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Dette pas er ikke længere tilgængeligt.',
             'notice'  => 'Denne post opbevares af hensyn til gennemsigtighed, men vedligeholdes ikke længere aktivt.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/de_DE/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/de_DE/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Dieser Produktpass ist nicht mehr verfügbar.',
             'notice'  => 'Dieser Datensatz wird aus Gründen der Transparenz aufbewahrt, wird jedoch nicht mehr aktiv gepflegt.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/en_AU/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/en_AU/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'This passport is no longer available.',
             'notice'  => 'This record is retained for transparency but is no longer actively maintained.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/en_GB/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/en_GB/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'This passport is no longer available.',
             'notice'  => 'This record is retained for transparency but is no longer actively maintained.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/en_NZ/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/en_NZ/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'This passport is no longer available.',
             'notice'  => 'This record is retained for transparency but is no longer actively maintained.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/en_US/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/en_US/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'This passport is no longer available.',
             'notice'  => 'This record is retained for transparency but is no longer actively maintained.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/es_ES/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/es_ES/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Este pasaporte ya no está disponible.',
             'notice'  => 'Este registro se conserva por motivos de transparencia, pero ya no se mantiene activamente.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/es_VE/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/es_VE/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Este pasaporte ya no está disponible.',
             'notice'  => 'Este registro se conserva por transparencia, pero ya no se mantiene de forma activa.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/fi_FI/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/fi_FI/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Tämä passi ei ole enää saatavilla.',
             'notice'  => 'Tämä tietue säilytetään avoimuuden vuoksi, mutta sitä ei enää ylläpidetä aktiivisesti.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/fr_FR/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/fr_FR/app.php
@@ -49,5 +49,11 @@ return [
             'heading' => 'Ce passeport n\'est plus disponible.',
             'notice'  => 'Cet enregistrement est conservé à des fins de transparence, mais n\'est plus activement maintenu.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/hi_IN/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'यह पासपोर्ट अब उपलब्ध नहीं है।',
             'notice'  => 'यह रिकॉर्ड पारदर्शिता के लिए बनाए रखा गया है, लेकिन अब इसे सक्रिय रूप से अद्यतन नहीं किया जा रहा है।',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/hr_HR/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/hr_HR/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Ova putovnica više nije dostupna.',
             'notice'  => 'Ovaj zapis zadržan je radi transparentnosti, ali se više aktivno ne održava.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/id_ID/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/id_ID/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Paspor ini sudah tidak tersedia lagi.',
             'notice'  => 'Catatan ini disimpan untuk transparansi, tetapi tidak lagi dikelola secara aktif.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/it_IT/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/it_IT/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Questo passaporto non è più disponibile.',
             'notice'  => 'Questo record viene conservato per motivi di trasparenza, ma non è più attivamente mantenuto.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/ja_JP/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/ja_JP/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'このパスポートは現在利用できません。',
             'notice'  => 'この記録は透明性のために保持されていますが、現在は積極的に更新されていません。',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/ko_KR/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/ko_KR/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => '이 여권 정보는 더 이상 제공되지 않습니다.',
             'notice'  => '이 기록은 투명성을 위해 보존되지만 더 이상 적극적으로 관리되지 않습니다.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/mn_MN/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/mn_MN/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Энэ паспорт цаашид боломжгүй.',
             'notice'  => 'Энэ бүртгэлийг ил тод байдлын үүднээс хадгалж байгаа боловч цаашид идэвхтэй арчилахгүй.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/nl_NL/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/nl_NL/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Dit paspoort is niet langer beschikbaar.',
             'notice'  => 'Dit record wordt bewaard omwille van transparantie, maar wordt niet langer actief bijgehouden.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/no_NO/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/no_NO/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Dette passet er ikke lenger tilgjengelig.',
             'notice'  => 'Denne posten oppbevares av hensyn til åpenhet, men vedlikeholdes ikke lenger aktivt.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/pl_PL/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/pl_PL/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Ten paszport nie jest już dostępny.',
             'notice'  => 'Ten rekord jest przechowywany dla przejrzystości, ale nie jest już aktywnie utrzymywany.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/pt_BR/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Este passaporte não está mais disponível.',
             'notice'  => 'Este registro é mantido para fins de transparência, mas não é mais atualizado ativamente.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/pt_PT/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/pt_PT/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Este passaporte já não está disponível.',
             'notice'  => 'Este registo é mantido para efeitos de transparência, mas já não é atualizado ativamente.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/ro_RO/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/ro_RO/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Acest pașaport nu mai este disponibil.',
             'notice'  => 'Această înregistrare este păstrată pentru transparență, dar nu mai este menținută activ.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/ru_RU/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/ru_RU/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Этот паспорт больше не доступен.',
             'notice'  => 'Эта запись сохраняется для прозрачности, но больше не поддерживается активно.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/sv_SE/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/sv_SE/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Detta pass är inte längre tillgängligt.',
             'notice'  => 'Denna post behålls av öppenhetsskäl men underhålls inte längre aktivt.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/tl_PH/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/tl_PH/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Hindi na available ang pasaporteng ito.',
             'notice'  => 'Itinatago ang talaang ito para sa transparency ngunit hindi na ito aktibong pinananatili.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/tr_TR/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/tr_TR/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Bu pasaport artık kullanılamıyor.',
             'notice'  => 'Bu kayıt şeffaflık amacıyla saklanmaktadır ancak artık aktif olarak güncellenmemektedir.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/uk_UA/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/uk_UA/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Цей паспорт більше недоступний.',
             'notice'  => 'Цей запис зберігається для прозорості, але більше не підтримується активно.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/vi_VN/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/vi_VN/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => 'Hộ chiếu này không còn khả dụng.',
             'notice'  => 'Bản ghi này được lưu giữ vì mục đích minh bạch nhưng không còn được duy trì tích cực.',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/zh_CN/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => '此护照信息已不再可用。',
             'notice'  => '此记录出于透明度目的予以保留,但不再进行主动维护。',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/lang/zh_TW/app.php
+++ b/packages/Webkul/Publication/src/Resources/lang/zh_TW/app.php
@@ -51,5 +51,11 @@ return [
             'heading' => '此護照資訊已不再提供。',
             'notice'  => '此記錄基於透明度予以保留,但已不再主動維護。',
         ],
+        'release' => [
+            'banner'       => 'Release :sequence of this passport',
+            'superseded'   => 'This is an earlier state of the passport, kept exactly as it was published. A newer state exists.',
+            'current'      => 'This is the current state of the passport.',
+            'view-current' => 'View the current passport',
+        ],
     ],
 ];

--- a/packages/Webkul/Publication/src/Resources/views/public/stub.blade.php
+++ b/packages/Webkul/Publication/src/Resources/views/public/stub.blade.php
@@ -10,6 +10,12 @@
         <pre>{{ json_encode($payload) }}</pre>
     @endif
 
+    @if ($release ?? false)
+        <p class="release">{{ trans('publication::app.public.release.banner', ['sequence' => $release['sequence']]) }}
+            {{ $release['is_current'] ? trans('publication::app.public.release.current') : trans('publication::app.public.release.superseded') }}
+            <a href="{{ $release['current_url'] }}">{{ trans('publication::app.public.release.view-current') }}</a></p>
+    @endif
+
     @if (isset($locales))
         <ul>
             @foreach ($locales as $availableLocale)

--- a/packages/Webkul/Publication/src/Services/PublicationResolver.php
+++ b/packages/Webkul/Publication/src/Services/PublicationResolver.php
@@ -5,6 +5,7 @@ namespace Webkul\Publication\Services;
 use Illuminate\Support\Facades\Log;
 use Webkul\Publication\Models\Publication;
 use Webkul\Publication\Models\PublicationProxy;
+use Webkul\Publication\Models\PublicationRelease;
 use Webkul\Publication\Models\PublicationVersion;
 
 class PublicationResolver
@@ -68,6 +69,14 @@ class PublicationResolver
         }
 
         return $publication;
+    }
+
+    /**
+     * Finds one release of the publication by its per-publication sequence.
+     */
+    public function findRelease(Publication $publication, int $sequence): ?PublicationRelease
+    {
+        return $publication->releases()->where('sequence', $sequence)->first();
     }
 
     /**

--- a/packages/Webkul/Publication/src/Services/Publisher.php
+++ b/packages/Webkul/Publication/src/Services/Publisher.php
@@ -224,7 +224,12 @@ class Publisher
     }
 
     /**
-     * GDPR Art. 17 erasure: redacts every current version and flips the publication to Redacted (sticky).
+     * GDPR Art. 17 erasure: redacts every not-yet-redacted version of the publication, superseded ones
+     * included, and flips the publication to Redacted (sticky).
+     *
+     * A superseded version is still a sealed record of the same data. Redacting only the current ones
+     * left every earlier payload readable in the database, so the erasure held only for as long as
+     * nothing ever read history. Versions redacted individually earlier are left as they are.
      */
     public function redactAll(Publication $publication, int $redactedById, string $reason): void
     {
@@ -238,15 +243,15 @@ class Publisher
                 );
             }
 
-            $currentVersions = $publication->versions()->where('is_current', true)->get();
+            $versions = $publication->versions()->whereNull('redacted_at')->get();
 
-            if ($currentVersions->isEmpty()) {
+            if ($versions->isEmpty()) {
                 throw new InvalidPublicationTransitionException(
-                    'Publication '.$publication->id.' has no current versions to redact.'
+                    'Publication '.$publication->id.' has no versions left to redact.'
                 );
             }
 
-            foreach ($currentVersions as $version) {
+            foreach ($versions as $version) {
                 $version->redact($redactedById, $reason);
             }
 

--- a/packages/Webkul/Publication/src/Services/Publisher.php
+++ b/packages/Webkul/Publication/src/Services/Publisher.php
@@ -19,6 +19,7 @@ use Webkul\Publication\Events\PublicationReinstated;
 use Webkul\Publication\Events\PublicationWithdrawn;
 use Webkul\Publication\Exceptions\InvalidPublicationTransitionException;
 use Webkul\Publication\Models\Publication;
+use Webkul\Publication\Models\PublicationRelease;
 use Webkul\Publication\Models\PublicationVersion;
 use Webkul\Publication\Registry\PublicationTypeRegistry;
 use Webkul\Publication\Repositories\PublicationRepository;
@@ -95,13 +96,16 @@ class Publisher
 
             $current?->markSuperseded();
 
+            $release = $this->mintRelease($publication, $publishedById);
+
             $version = $publication->versions()->create([
                 'locale_id'       => $locale->id,
                 'version'         => $nextVersion,
+                'release_id'      => $release->id,
                 'payload'         => $payload,
                 'checksum'        => $checksum,
                 'is_current'      => true,
-                'published_at'    => now(),
+                'published_at'    => $release->published_at,
                 'published_by_id' => $publishedById,
             ]);
 
@@ -161,13 +165,16 @@ class Publisher
 
             $current?->markSuperseded();
 
+            $release = $this->mintRelease($publication, $publishedById);
+
             $version = $publication->versions()->create([
                 'locale_id'       => $localeId,
                 'version'         => $nextVersion,
+                'release_id'      => $release->id,
                 'payload'         => $payload,
                 'checksum'        => $source->checksum,
                 'is_current'      => true,
-                'published_at'    => now(),
+                'published_at'    => $release->published_at,
                 'published_by_id' => $publishedById,
             ]);
 
@@ -247,6 +254,21 @@ class Publisher
 
             DB::afterCommit(fn () => PublicationRedacted::dispatch($publication, $reason));
         });
+    }
+
+    /**
+     * Mints the release a newly minted version belongs to. Callers hold the publication row lock,
+     * so MAX(sequence)+1 cannot race, for the same reason version numbers cannot.
+     */
+    private function mintRelease(Publication $publication, ?int $publishedById): PublicationRelease
+    {
+        $sequence = (int) $publication->releases()->max('sequence') + 1;
+
+        return $publication->releases()->create([
+            'sequence'        => $sequence,
+            'published_at'    => now(),
+            'published_by_id' => $publishedById,
+        ]);
     }
 
     /**

--- a/packages/Webkul/Publication/tests/Feature/PublicPassportRouteTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublicPassportRouteTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Str;
 use Webkul\Publication\Enums\PublicationStatus;
+use Webkul\Publication\Services\Publisher;
 
 it('redirects the bare uuid to the canonical per-locale url without caching the redirect', function (): void {
     $version = $this->publishedPassportFixture();
@@ -94,4 +95,33 @@ it('404s everything when the global kill switch is off, regardless of channel se
     config(['publication.enabled' => false]);
 
     $this->get('/p/'.$version->publication->uuid.'/'.$version->locale->code)->assertNotFound();
+});
+
+it('answers 410 Gone, uncacheable and unindexable, for a redacted passport', function (): void {
+    $version = $this->publishedPassportFixture();
+
+    resolve(Publisher::class)->redactAll($version->publication->fresh(), $this->loginAsAdmin()->id, 'gdpr request');
+
+    $response = $this->get('/p/'.$version->publication->uuid.'/'.$version->locale->code)
+        ->assertStatus(410)
+        ->assertHeader('X-Robots-Tag', 'noindex, nofollow')
+        ->assertSee(trans('publication::app.public.withdrawn.heading'));
+
+    expect($response->headers->getCacheControlDirective('no-store'))->toBeTrue()
+        ->and($response->headers->getCacheControlDirective('private'))->toBeTrue()
+        ->and($response->headers->hasCacheControlDirective('s-maxage'))->toBeFalse();
+});
+
+it('keeps a withdrawn tombstone out of shared caches while still answering 200', function (): void {
+    $version = $this->publishedPassportFixture();
+
+    $version->publication->update(['status' => PublicationStatus::Withdrawn]);
+
+    $response = $this->get('/p/'.$version->publication->uuid.'/'.$version->locale->code)
+        ->assertOk()
+        ->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+
+    expect($response->headers->getCacheControlDirective('no-store'))->toBeTrue()
+        ->and($response->headers->getCacheControlDirective('private'))->toBeTrue()
+        ->and($response->headers->hasCacheControlDirective('s-maxage'))->toBeFalse();
 });

--- a/packages/Webkul/Publication/tests/Feature/PublicPassportRouteTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublicPassportRouteTest.php
@@ -125,3 +125,97 @@ it('keeps a withdrawn tombstone out of shared caches while still answering 200',
         ->and($response->headers->getCacheControlDirective('private'))->toBeTrue()
         ->and($response->headers->hasCacheControlDirective('s-maxage'))->toBeFalse();
 });
+
+it('serves an earlier release at its own url, unindexed, with a canonical link to the live page', function (): void {
+    $first = $this->publishedPassportFixture();
+    $second = $this->republishWithMaterial($first, 'recycled steel');
+
+    $uuid = $first->publication->uuid;
+    $locale = $first->locale->code;
+    $live = route('publication.public.dpp.show.locale', ['uuid' => $uuid, 'locale' => $locale]);
+
+    $this->get('/p/'.$uuid.'/r/1/'.$locale)
+        ->assertOk()
+        ->assertHeader('X-Robots-Tag', 'noindex, noarchive, nofollow')
+        ->assertHeader('Link', '<'.$live.'>; rel="canonical"')
+        ->assertSee(e(json_encode($first->fresh()->payload)), false)
+        ->assertDontSee('recycled steel')
+        ->assertSee(trans('publication::app.public.release.banner', ['sequence' => 1]))
+        ->assertSee(trans('publication::app.public.release.superseded'));
+
+    $this->get('/p/'.$uuid.'/r/2/'.$locale)
+        ->assertOk()
+        ->assertSee('recycled steel')
+        ->assertSee(trans('publication::app.public.release.current'));
+
+    expect($second->release->sequence)->toBe(2);
+});
+
+it('404s a release that does not exist and a sequence the router rejects', function (): void {
+    $version = $this->publishedPassportFixture();
+
+    $uuid = $version->publication->uuid;
+    $locale = $version->locale->code;
+
+    $this->get('/p/'.$uuid.'/r/9/'.$locale)->assertNotFound();
+    $this->get('/p/'.$uuid.'/r/0/'.$locale)->assertNotFound();
+    $this->get('/p/'.$uuid.'/r/abc/'.$locale)->assertNotFound();
+});
+
+it('answers 410 for a release whose version was redacted, even while the publication stays published', function (): void {
+    $first = $this->publishedPassportFixture();
+    $this->republishWithMaterial($first, 'recycled steel');
+
+    $first->fresh()->redact($this->loginAsAdmin()->id, 'contained personal data');
+
+    $uuid = $first->publication->uuid;
+    $locale = $first->locale->code;
+
+    $response = $this->get('/p/'.$uuid.'/r/1/'.$locale)
+        ->assertStatus(410)
+        ->assertSee(trans('publication::app.public.withdrawn.heading'))
+        ->assertDontSee('material');
+
+    expect($response->headers->getCacheControlDirective('no-store'))->toBeTrue();
+
+    // The live page is unaffected.
+    $this->get('/p/'.$uuid.'/'.$locale)->assertOk()->assertSee('recycled steel');
+});
+
+it('changes the etag of a release page once that state stops being current', function (): void {
+    $first = $this->publishedPassportFixture();
+
+    $uuid = $first->publication->uuid;
+    $locale = $first->locale->code;
+
+    $whileCurrent = $this->get('/p/'.$uuid.'/r/1/'.$locale)->assertOk()->headers->get('ETag');
+
+    $this->republishWithMaterial($first, 'recycled steel');
+
+    $onceSuperseded = $this->get('/p/'.$uuid.'/r/1/'.$locale)->assertOk()->headers->get('ETag');
+
+    expect($whileCurrent)->not->toBe($onceSuperseded)
+        ->and($this->withHeaders(['If-None-Match' => $onceSuperseded])->get('/p/'.$uuid.'/r/1/'.$locale)->status())->toBe(304);
+});
+
+it('resolves a release strictly per locale: a locale first published later is absent from earlier releases', function (): void {
+    $first = $this->publishedPassportFixture();
+
+    $publication = $first->publication;
+    $other = $publication->channel->locales()->where('locales.id', '!=', $first->locale_id)->firstOrFail();
+
+    $product = $publication->product;
+    $product->values = array_replace_recursive($product->values, [
+        'locale_specific' => [$other->code => ['dpp_material_composition' => 'aluminium']],
+    ]);
+    $product->save();
+
+    $otherVersion = resolve(Publisher::class)->publish($product, $publication->channel, $other, 'dpp');
+
+    expect($otherVersion)->not->toBeNull()
+        ->and($otherVersion->release->sequence)->toBe(2);
+
+    $this->get('/p/'.$publication->uuid.'/r/1/'.$other->code)->assertNotFound();
+    $this->get('/p/'.$publication->uuid.'/r/2/'.$other->code)->assertOk()->assertSee('aluminium');
+    $this->get('/p/'.$publication->uuid.'/r/2/'.$first->locale->code)->assertOk();
+});

--- a/packages/Webkul/Publication/tests/Feature/PublicationReleaseTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublicationReleaseTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Webkul\Publication\Exceptions\ImmutableVersionException;
+use Webkul\Publication\Services\Publisher;
+use Webkul\Publication\Tests\Support\DocumentStubPayloadBuilder;
+use Webkul\User\Models\Admin;
+
+beforeEach(function (): void {
+    config()->set('publication.types.dpp', [
+        'label'           => 'publication::app.publications.status.draft',
+        'payload_builder' => DocumentStubPayloadBuilder::class,
+        'template'        => 'publication::dpp.show',
+        'route_prefix'    => 'dpp',
+    ]);
+});
+
+it('mints one release per minted version, numbered per publication', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    // Unchanged payload: no version, so no release either.
+    expect($publisher->publish($product, $channel, $complete, 'dpp'))->toBeNull();
+
+    $publication = $first->publication->fresh();
+
+    expect($first->release->sequence)->toBe(1)
+        ->and($second->release->sequence)->toBe(2)
+        ->and($second->release->published_at->equalTo($second->published_at))->toBeTrue()
+        ->and($publication->releases()->count())->toBe(2)
+        ->and($second->release->versions()->pluck('id')->all())->toBe([$second->id]);
+});
+
+it('numbers releases across locales in publish order and resolves the state as of each one', function (): void {
+    [$product, $channel, $other, $complete] = $this->seedPassportFixture(completeBoth: true);
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $completeV1 = $publisher->publish($product, $channel, $complete, 'dpp');
+    $otherV1 = $publisher->publish($product, $channel, $other, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $completeV2 = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    $publication = $completeV1->publication->fresh();
+
+    expect($completeV1->release->sequence)->toBe(1)
+        ->and($otherV1->release->sequence)->toBe(2)
+        ->and($completeV2->release->sequence)->toBe(3)
+        // Version numbers still run per locale; the release is what spans them.
+        ->and($completeV2->version)->toBe(2)
+        ->and($otherV1->version)->toBe(1);
+
+    $asOf = fn (int $sequence): array => $publication->releases()->where('sequence', $sequence)->firstOrFail()
+        ->versionsAsOf()
+        ->map(fn ($version): int => $version->id)
+        ->all();
+
+    expect($asOf(1))->toBe([$complete->id => $completeV1->id])
+        ->and($asOf(2))->toEqualCanonicalizing([$complete->id => $completeV1->id, $other->id => $otherV1->id])
+        ->and($asOf(3))->toEqualCanonicalizing([$complete->id => $completeV2->id, $other->id => $otherV1->id]);
+});
+
+it('mints a release for a forward-only rollback too', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $publisher->publish($product, $channel, $complete, 'dpp');
+
+    $rolledBack = $publisher->republishFrom($first, Admin::factory()->create()->id);
+
+    expect($rolledBack->version)->toBe(3)
+        ->and($rolledBack->release->sequence)->toBe(3)
+        ->and($rolledBack->release->published_by_id)->not->toBeNull();
+});
+
+it('refuses to change or delete a release', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $release = resolve(Publisher::class)->publish($product, $channel, $complete, 'dpp')->release;
+
+    expect(fn (): mixed => $release->update(['sequence' => 99]))->toThrow(ImmutableVersionException::class)
+        ->and(fn (): mixed => $release->delete())->toThrow(ImmutableVersionException::class)
+        ->and($release->fresh()->sequence)->toBe(1);
+});
+
+it('refuses to move a version to another release', function (): void {
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/a.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/release/b.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    expect(fn (): mixed => $first->update(['release_id' => $second->release_id]))
+        ->toThrow(ImmutableVersionException::class);
+});

--- a/packages/Webkul/Publication/tests/Feature/PublisherRedactAllTest.php
+++ b/packages/Webkul/Publication/tests/Feature/PublisherRedactAllTest.php
@@ -6,6 +6,7 @@ use Webkul\Publication\Events\PublicationRedacted;
 use Webkul\Publication\Exceptions\InvalidPublicationTransitionException;
 use Webkul\Publication\Repositories\PublicationRepository;
 use Webkul\Publication\Services\Publisher;
+use Webkul\Publication\Tests\Support\DocumentStubPayloadBuilder;
 use Webkul\Publication\Tests\Support\StubPayloadBuilder;
 use Webkul\User\Models\Admin;
 
@@ -68,4 +69,52 @@ it('refuses to redact an already-redacted publication', function (): void {
 
     expect(fn (): mixed => $publisher->redactAll($first->publication->fresh(), $admin->id, 'second attempt'))
         ->toThrow(InvalidPublicationTransitionException::class);
+});
+
+it('redacts superseded versions too, not only the current one', function (): void {
+    config()->set('publication.types.dpp.payload_builder', DocumentStubPayloadBuilder::class);
+
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/first.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/second.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    expect((bool) $first->fresh()->is_current)->toBeFalse()
+        ->and($second->version)->toBe($first->version + 1);
+
+    $publisher->redactAll($first->publication->fresh(), Admin::factory()->create()->id, 'contained personal data');
+
+    expect($first->fresh()->payload)->toBeNull()
+        ->and($first->fresh()->redacted_at)->not->toBeNull()
+        ->and($first->fresh()->redacted_reason)->toBe('contained personal data')
+        ->and($second->fresh()->payload)->toBeNull()
+        ->and($second->fresh()->redacted_reason)->toBe('contained personal data');
+});
+
+it('leaves a version that was already redacted individually untouched', function (): void {
+    config()->set('publication.types.dpp.payload_builder', DocumentStubPayloadBuilder::class);
+
+    [$product, $channel, , $complete] = $this->seedPassportFixture();
+
+    $publisher = resolve(Publisher::class);
+    $admin = Admin::factory()->create();
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/first.pdf';
+    $first = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    DocumentStubPayloadBuilder::$documentPath = 'publication/redact/second.pdf';
+    $second = $publisher->publish($product, $channel, $complete, 'dpp');
+
+    $first->redact($admin->id, 'earlier, on its own');
+
+    $publisher->redactAll($first->publication->fresh(), $admin->id, 'whole publication');
+
+    expect($first->fresh()->redacted_reason)->toBe('earlier, on its own')
+        ->and($second->fresh()->redacted_reason)->toBe('whole publication')
+        ->and($first->publication->fresh()->status)->toBe(PublicationStatus::Redacted);
 });

--- a/packages/Webkul/Publication/tests/PublicationTestCase.php
+++ b/packages/Webkul/Publication/tests/PublicationTestCase.php
@@ -111,6 +111,22 @@ class PublicationTestCase extends TestCase
     }
 
     /**
+     * Mints a further version for the fixture's locale by changing the one value the stub payload reads.
+     */
+    protected function republishWithMaterial(PublicationVersion $previous, string $material): PublicationVersion
+    {
+        $publication = $previous->publication;
+        $product = $publication->product;
+
+        $product->values = array_replace_recursive($product->values, [
+            'locale_specific' => [$previous->locale->code => ['dpp_material_composition' => $material]],
+        ]);
+        $product->save();
+
+        return resolve(Publisher::class)->publish($product, $publication->channel, $previous->locale, 'dpp');
+    }
+
+    /**
      * Public tier is opt-in per channel; an unset flag reads as disabled.
      */
     protected function enablePublicTier(string $channelCode): void


### PR DESCRIPTION
## Stacked on #680 and #679

This PR shows their commits until they land. Only the last commit (`feat(publication): public per-release route`) is new here.

## Problem

Every public passport URL resolves to the current state. A QR code printed into a manual two years ago therefore shows today's data. The regulation asks for the opposite: the state the product was placed on the market with must stay reachable, and one printed reference must keep meaning that one state. #680 gave that state a name (a release, spanning all locales); nothing serves it yet.

## Change

**Route** `GET /{prefix}/{uuid}/r/{sequence}/{locale}` in the per-type group, `where('sequence', '[1-9][0-9]{0,9}')`. Four segments with a literal `r`, so it cannot shadow the existing two-segment routes. Resolved via `PublicationRelease::versionsAsOf()`: for the requested locale, the most recent version minted at or before that release.

**Semantics**

- Strict locale. No `Accept-Language` negotiation on an explicit historical URL: a reference must not resolve to a different document per reader. A locale that had no version yet at that release is 404 there.
- 200 with a banner naming the release and whether that state is still current, linking to the live page. The locale switcher stays inside the release.
- Never indexed: `X-Robots-Tag: noindex, noarchive, nofollow`, a `<link rel="canonical">` and a `Link: <…>; rel="canonical"` header pointing at the live page. No JSON-LD negotiation on release pages: a historical payload's stamped identity is the publication URL, which would misdescribe it.
- A version that was redacted individually renders the tombstone with `410` and `no-store`, even while the publication itself stays Published. The same check now applies on the live route, which previously handed the template a null payload while telling it the page was not withdrawn.
- Release pages are not counted as views.

**ETag** now also covers the release sequence, whether the version is still current, and whether it is redacted: the banner text and the tombstone change the HTML without changing the payload checksum. `TEMPLATE_VERSION` bumped to invalidate cached live pages.

**Refactor**: `show()` and the new `showRelease()` share one private `render()`; behaviour of the live route is unchanged apart from the redacted-version case above.

**Strings**: four new keys under `publication::app.public.release`, present in all 33 locales (English placeholders where no translation exists yet). `unopim:translations:check` passes.

## Tests

Stub-template route tests (`PublicPassportRouteTest`):
- earlier release served at its URL with banner, canonical `Link`, no indexing, and the earlier payload rather than the newer one; latest release marked current
- unknown sequence, `0` and non-numeric are 404
- a release whose version was redacted answers 410 `no-store` while the live page still serves the newer state
- the ETag of a release page changes once that state stops being current, and 304 works against the new one
- strict per-locale resolution across two locales published in different releases

Real template (`PassportPageRenderTest`): banner, `<link rel="canonical">`, `noindex`, switcher links inside the release, and no JSON-LD on a release page.

## Related

Follows #677, #678, #679 and #680. Next on this track: an issuance record binding a printed carrier to the release it was issued against, and GS1 Digital Link qualifiers (`/01/{gtin}/10/{lot}`).
