### PR TITLE
fix(data-transfer): export only the selected attribute columns

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Account/MicrosoftSsoTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Account/MicrosoftSsoTest.php
@@ -7,7 +7,11 @@ use Webkul\User\Models\Admin;
 
 use function Pest\Laravel\get;
 
-function microsoftSsoConfig(string $tenant = 'tenant-id'): void
+beforeEach(function (): void {
+    Http::preventStrayRequests();
+});
+
+function microsoftSsoConfig(string $tenant = '11111111-2222-4333-8444-555555555555'): void
 {
     config()->set('services.microsoft_sso.enabled', true);
     config()->set('services.microsoft_sso.tenant', $tenant);
@@ -36,7 +40,7 @@ function fakeMicrosoftEndpoints(array $profile, array $tokenClaims = []): void
     Http::fake([
         'https://login.microsoftonline.com/*/oauth2/v2.0/token' => Http::response([
             'access_token' => 'access-token',
-            'id_token'     => ssoJwt(array_merge(['nonce' => 'valid-nonce', 'tid' => 'tenant-id'], $tokenClaims)),
+            'id_token'     => ssoJwt(array_merge(['nonce' => 'valid-nonce', 'tid' => '11111111-2222-4333-8444-555555555555'], $tokenClaims)),
         ], 200),
         'https://graph.microsoft.com/v1.0/me*' => Http::response($profile, 200),
     ]);
@@ -70,6 +74,8 @@ it('logs in an existing admin via microsoft sso using email match', function () 
     callbackWith(ssoHandshake())->assertRedirect(route('admin.dashboard.index'));
 
     $this->assertAuthenticatedAs($admin, 'admin');
+
+    Http::assertSentCount(2);
 });
 
 it('links the provider subject id to the admin on first sign in', function () {
@@ -255,6 +261,8 @@ it('accepts a tenant configured as a verified domain', function () {
     callbackWith(ssoHandshake());
 
     $this->assertAuthenticatedAs($admin, 'admin');
+
+    Http::assertSentCount(3);
 });
 
 it('refuses a foreign tenant when configured with a verified domain', function () {

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
@@ -5,6 +5,7 @@ namespace Webkul\DataTransfer\Helpers\Exporters\Product;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
+use Webkul\Attribute\Models\Attribute;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Attribute\Rules\AttributeTypes;
 use Webkul\Core\Repositories\ChannelRepository;
@@ -27,6 +28,8 @@ use Webkul\Product\Repositories\ProductRepository;
 
 class Exporter extends AbstractExporter
 {
+    private const int ATTRIBUTE_LOOKUP_CHUNK_SIZE = 1000;
+
     /**
      * Static cache for channels/locales/currencies/attributes.
      * Shared across all ExportBatch jobs within the same worker process,
@@ -257,7 +260,12 @@ class Exporter extends AbstractExporter
         $selected = ScopeFilterValue::toCodes(
             $filters[ProductExportScope::ATTRIBUTES->value] ?? null
         );
-        $columns = 10 + ((bool) ($filters['with_associations'] ?? false) ? 3 : 0);
+        $columns = count($this->getBaseFields());
+
+        if ((bool) ($filters['with_associations'] ?? false)) {
+            $columns += count($this->getAssociationColumns());
+        }
+
         $currencyCount = null;
 
         $query = $this->attributeRepository->getModel()->newQuery()
@@ -266,7 +274,7 @@ class Exporter extends AbstractExporter
             ->whereNotIn('code', ['sku', 'status'])
             ->groupBy('type');
 
-        foreach (array_chunk($selected, 1000) ?: [[]] as $codes) {
+        foreach (array_chunk($selected, self::ATTRIBUTE_LOOKUP_CHUNK_SIZE) ?: [[]] as $codes) {
             $attributeQuery = clone $query;
 
             if ($codes !== []) {
@@ -275,7 +283,7 @@ class Exporter extends AbstractExporter
 
             foreach ($attributeQuery->toBase()->pluck('aggregate', 'type') as $type => $count) {
                 $columns += (int) $count * match ($type) {
-                    'measurement'                              => 2,
+                    Attribute::MEASUREMENT_FIELD_TYPE          => 2,
                     AttributeTypes::PRICE_ATTRIBUTE_TYPE       => $currencyCount ??= $this->countExportedCurrencies(),
                     default                                    => 1,
                 };
@@ -455,6 +463,33 @@ class Exporter extends AbstractExporter
     }
 
     /**
+     * Build the fixed product fields in their exported order.
+     */
+    protected function getBaseFields(array $rowData = []): array
+    {
+        return [
+            'channel'                 => null,
+            'locale'                  => null,
+            'sku'                     => $rowData['sku'] ?? null,
+            'status'                  => ($rowData['status'] ?? false) ? 'true' : 'false',
+            'type'                    => $rowData['type'] ?? null,
+            'parent'                  => $rowData['parent'] ?? null,
+            'attribute_family'        => $rowData['attribute_family']['code'] ?? null,
+            'variant_structure'       => $rowData['variant_structure'] ?? null,
+            'configurable_attributes' => $rowData === [] ? null : $this->getSuperAttributes($rowData),
+            'categories'              => $rowData === [] ? null : $this->getCategories($rowData),
+        ];
+    }
+
+    /**
+     * List the optional association columns in their exported order.
+     */
+    protected function getAssociationColumns(): array
+    {
+        return ['up_sells', 'cross_sells', 'related_products'];
+    }
+
+    /**
      * Prepare products from current batch
      *
      * Legacy `up_sells`/`cross_sells`/`related_products` SKU-list columns stay opt-in (default off);
@@ -482,9 +517,13 @@ class Exporter extends AbstractExporter
             $productValues = $mergedValuesById[$product->id] ?? ($product->values ?? []);
 
             $rowData = [
-                'type'             => $product->type,
-                'sku'              => $product->sku,
-                'status'           => $product->status,
+                'type'              => $product->type,
+                'sku'               => $product->sku,
+                'status'            => $product->status,
+                'parent'            => $product->parent?->sku,
+                'variant_structure' => $product->type === 'configurable'
+                    ? $product->variantStructure?->code
+                    : null,
                 'super_attributes' => $product->type === 'configurable'
                     ? $product->super_attributes->toArray()
                     : [],
@@ -492,23 +531,14 @@ class Exporter extends AbstractExporter
                 'values'           => $productValues,
             ];
 
-            $family = $product->attribute_family?->code;
-            $parentSku = $product->parent?->sku;
-            $variantStructure = $product->type === 'configurable'
-                ? $product->variantStructure?->code
-                : null;
+            $baseFields = $this->getBaseFields($rowData);
+            $associationFields = [];
 
-            $sku = $product->sku;
-            $type = $product->type;
-            $status = $product->status ? 'true' : 'false';
-            $configurableAttributes = $this->getSuperAttributes($rowData);
-            $categories = $this->getCategories($rowData);
-
-            $associationFields = $withAssociations ? [
-                'up_sells'         => $this->getAssociations($rowData, 'up_sells'),
-                'cross_sells'      => $this->getAssociations($rowData, 'cross_sells'),
-                'related_products' => $this->getAssociations($rowData, 'related_products'),
-            ] : [];
+            if ($withAssociations) {
+                foreach ($this->getAssociationColumns() as $column) {
+                    $associationFields[$column] = $this->getAssociations($rowData, $column);
+                }
+            }
 
             $commonFields = $this->getCommonFields($rowData);
             unset($commonFields['sku']);
@@ -528,17 +558,9 @@ class Exporter extends AbstractExporter
 
                     $values = $this->setAttributesValues($mergedFields, $filePath, $locale);
 
-                    $row = array_merge([
-                        'channel'                 => $channel,
-                        'locale'                  => $locale,
-                        'sku'                     => $sku,
-                        'status'                  => $status,
-                        'type'                    => $type,
-                        'parent'                  => $parentSku,
-                        'attribute_family'        => $family,
-                        'variant_structure'       => $variantStructure,
-                        'configurable_attributes' => $configurableAttributes,
-                        'categories'              => $categories,
+                    $row = array_merge($baseFields, [
+                        'channel' => $channel,
+                        'locale'  => $locale,
                     ], $associationFields, $values);
 
                     $this->exportBuffer->write([$row]);
@@ -689,7 +711,7 @@ class Exporter extends AbstractExporter
     {
         $measurementMeta = array_filter(
             $this->attributeMeta,
-            fn (array $meta): bool => ($meta['type'] ?? null) === 'measurement'
+            fn (array $meta): bool => ($meta['type'] ?? null) === Attribute::MEASUREMENT_FIELD_TYPE
         );
 
         if ($measurementMeta === []) {

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
@@ -244,7 +244,7 @@ class Exporter extends AbstractExporter
     }
 
     /**
-     * Width the disk-budget estimate is sized on.
+     * Count fixed, association, and expanded attribute columns for the disk-budget estimate.
      *
      * A profile that selects attributes writes only those columns, so charging it for every
      * attribute in the catalogue would reject exports that comfortably fit. The codes are read
@@ -253,15 +253,61 @@ class Exporter extends AbstractExporter
      */
     protected function countExportedColumns(): int
     {
+        $filters = $this->getFilters();
         $selected = ScopeFilterValue::toCodes(
-            $this->getFilters()[ProductExportScope::ATTRIBUTES->value] ?? null
+            $filters[ProductExportScope::ATTRIBUTES->value] ?? null
         );
+        $columns = 10 + ((bool) ($filters['with_associations'] ?? false) ? 3 : 0);
+        $currencyCount = null;
 
-        if ($selected !== []) {
-            return max(1, count($selected));
+        $query = $this->attributeRepository->getModel()->newQuery()
+            ->select('type')
+            ->selectRaw('COUNT(*) as aggregate')
+            ->whereNotIn('code', ['sku', 'status'])
+            ->groupBy('type');
+
+        foreach (array_chunk($selected, 1000) ?: [[]] as $codes) {
+            $attributeQuery = clone $query;
+
+            if ($codes !== []) {
+                $attributeQuery->whereIn('code', $codes);
+            }
+
+            foreach ($attributeQuery->toBase()->pluck('aggregate', 'type') as $type => $count) {
+                $columns += (int) $count * match ($type) {
+                    'measurement'                              => 2,
+                    AttributeTypes::PRICE_ATTRIBUTE_TYPE       => $currencyCount ??= $this->countExportedCurrencies(),
+                    default                                    => 1,
+                };
+            }
         }
 
-        return max(1, $this->attributeRepository->count());
+        return $columns;
+    }
+
+    /**
+     * Count unique currencies within the export profile's channel and currency scopes.
+     */
+    protected function countExportedCurrencies(): int
+    {
+        $filters = $this->getFilters();
+        $channelCodes = ScopeFilterValue::toCodes($filters[ProductExportScope::CHANNELS->value] ?? null);
+        $currencyCodes = ScopeFilterValue::toCodes($filters[ProductExportScope::CURRENCIES->value] ?? null);
+        $currencies = [];
+
+        foreach ($this->channelRepository->with(['currencies'])->all() as $channel) {
+            if ($channelCodes !== [] && ! in_array($channel->code, $channelCodes, true)) {
+                continue;
+            }
+
+            $currencies = array_merge($currencies, $channel->currencies->pluck('code')->all());
+        }
+
+        if ($currencyCodes !== []) {
+            $currencies = array_intersect($currencies, $currencyCodes);
+        }
+
+        return count(array_unique($currencies));
     }
 
     protected function countChannelLocalePairs(): int

--- a/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Exporters/Product/Exporter.php
@@ -239,9 +239,29 @@ class Exporter extends AbstractExporter
         }
 
         $rows = $productCount * max(1, $this->countChannelLocalePairs());
-        $columns = max(1, $this->attributeRepository->count());
 
-        $this->guardAgainstOversizedExport($rows, $columns);
+        $this->guardAgainstOversizedExport($rows, $this->countExportedColumns());
+    }
+
+    /**
+     * Width the disk-budget estimate is sized on.
+     *
+     * A profile that selects attributes writes only those columns, so charging it for every
+     * attribute in the catalogue would reject exports that comfortably fit. The codes are read
+     * from the filters rather than from $selectedAttributeCodes because the guard runs during
+     * initializeBatches(), before initilize() has applied the scope filters.
+     */
+    protected function countExportedColumns(): int
+    {
+        $selected = ScopeFilterValue::toCodes(
+            $this->getFilters()[ProductExportScope::ATTRIBUTES->value] ?? null
+        );
+
+        if ($selected !== []) {
+            return max(1, count($selected));
+        }
+
+        return max(1, $this->attributeRepository->count());
     }
 
     protected function countChannelLocalePairs(): int
@@ -642,9 +662,6 @@ class Exporter extends AbstractExporter
             $code = $meta['code'];
 
             if (! $this->isAttributeValueExported($code)) {
-                $attributeValues[$code] = null;
-                $attributeValues["{$code}(unit)"] = null;
-
                 continue;
             }
 
@@ -687,8 +704,13 @@ class Exporter extends AbstractExporter
     }
 
     /**
-     * Sets attribute values for every non-measurement attribute. If an attribute is
-     * not present in the given values array,
+     * Sets attribute values for every non-measurement attribute.
+     *
+     * Attributes outside the profile's selection are omitted entirely rather than written as null:
+     * FlatItemBuffer derives the header from the first row's keys, so a null placeholder would keep
+     * the column in the file and contradict the "only the selected attributes are exported" promise.
+     * Every row runs this same loop with the same selection, so the key set stays identical across
+     * rows and batches, which is what the buffer's positional writes rely on.
      */
     protected function setNonMeasurementAttributesValues(array $values, mixed $filePath, ?string $locale = null): array
     {
@@ -709,21 +731,11 @@ class Exporter extends AbstractExporter
                 continue;
             }
 
-            $isPrice = $type === AttributeTypes::PRICE_ATTRIBUTE_TYPE;
-
             if (! $this->isAttributeValueExported($code)) {
-                if ($isPrice) {
-                    foreach ($this->currencies as $currency) {
-                        $attributeValues["{$code} ({$currency})"] = null;
-                    }
-
-                    continue;
-                }
-
-                $attributeValues[$code] = null;
-
                 continue;
             }
+
+            $isPrice = $type === AttributeTypes::PRICE_ATTRIBUTE_TYPE;
 
             $rawValue = $values[$code] ?? null;
 

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php
@@ -68,6 +68,25 @@ function makeInitializedProductExporter(array $filters): Exporter
     return $exporter;
 }
 
+function captureProductScopeRows(Exporter $exporter, Product $product): array
+{
+    $buffer = new class
+    {
+        public array $rows = [];
+
+        public function write(array $items, array $options = []): void
+        {
+            $this->rows = array_merge($this->rows, $items);
+        }
+    };
+
+    $exporter->setExportBuffer($buffer);
+    $exporter->initilize();
+    $exporter->prepareProducts(new JobTrackBatch(['data' => [['id' => $product->id]]]), null);
+
+    return $buffer->rows;
+}
+
 function seedProductScopeChannels(): void
 {
     $enUS = Locale::updateOrCreate(['code' => 'en_US'], ['status' => 1]);
@@ -169,7 +188,7 @@ it('drops the columns of attributes outside the selection', function () {
     expect($values)->not->toHaveKey('name');
 });
 
-it('drops the price columns of an unselected price attribute', function () {
+it('drops the price columns of an unselected price attribute', function (): void {
     seedProductScopeChannels();
     Attribute::factory()->create(['code' => 'scoped_attr']);
     Attribute::factory()->create(['code' => 'list_price', 'type' => 'price']);
@@ -200,23 +219,10 @@ it('sizes the disk-budget estimate on the columns written before initialization'
     $countColumns = new ReflectionMethod($exporter, 'countExportedColumns');
 
     $estimatedColumns = $countColumns->invoke($exporter);
+    $rows = captureProductScopeRows($exporter, $product);
 
-    $buffer = new class
-    {
-        public array $rows = [];
-
-        public function write(array $items, array $options = []): void
-        {
-            $this->rows = array_merge($this->rows, $items);
-        }
-    };
-
-    $exporter->setExportBuffer($buffer);
-    $exporter->initilize();
-    $exporter->prepareProducts(new JobTrackBatch(['data' => [['id' => $product->id]]]), null);
-
-    expect($buffer->rows)->not->toBeEmpty();
-    expect($buffer->rows)->each->toHaveCount($expectedColumns);
+    expect($rows)->not->toBeEmpty();
+    expect($rows)->each->toHaveCount($expectedColumns);
     expect($estimatedColumns)->toBe($expectedColumns);
 })->with([
     'fixed columns'                  => [['attributes' => ['scoped_text']], 11],
@@ -234,6 +240,69 @@ it('sizes the disk-budget estimate on the columns written before initialization'
         ['scoped_text', 'scoped_price']
     )], 13],
 ]);
+
+it('counts additional columns supplied by exporter extensions', function (bool $withAssociations, int $expectedColumns): void {
+    app()->bind(Exporter::class, ProductScopeAdditionalColumnsExporter::class);
+    seedProductScopeChannels();
+    Attribute::factory()->create(['code' => 'scoped_text', 'type' => 'text']);
+    $product = Product::factory()->withInitialValues()->create();
+    Cache::flush();
+
+    $exporter = makeProductScopeExporter([
+        'channels'          => ['web'],
+        'attributes'        => ['scoped_text'],
+        'with_associations' => $withAssociations,
+    ]);
+    $estimatedColumns = (new ReflectionMethod($exporter, 'countExportedColumns'))->invoke($exporter);
+    $rows = captureProductScopeRows($exporter, $product);
+
+    expect($rows)->not->toBeEmpty();
+    expect($rows)->each->toHaveCount($expectedColumns);
+    expect($rows[0]['external_id'])->toBe('external-1');
+    expect(array_key_exists('custom_association', $rows[0]))->toBe($withAssociations);
+    expect($estimatedColumns)->toBe($expectedColumns);
+})->with([
+    'base fields'        => [false, 12],
+    'association fields' => [true, 16],
+]);
+
+it('preserves the fixed column order and values for existing exports', function (): void {
+    seedProductScopeChannels();
+    Attribute::factory()->create(['code' => 'scoped_text', 'type' => 'text']);
+    $family = AttributeFamily::factory()->create(['code' => 'column_family']);
+    $parent = Product::factory()->create(['sku' => 'PARENT-COLUMNS', 'type' => 'configurable']);
+    $product = Product::factory()->create([
+        'sku'                 => 'CHILD-COLUMNS',
+        'status'              => false,
+        'parent_id'           => $parent->id,
+        'attribute_family_id' => $family->id,
+        'values'              => [
+            'common'     => ['scoped_text' => 'selected-value'],
+            'categories' => ['clothes'],
+        ],
+    ]);
+    Cache::flush();
+
+    $exporter = makeProductScopeExporter([
+        'channels'   => ['web'],
+        'locales'    => ['en_US'],
+        'attributes' => ['scoped_text'],
+    ]);
+
+    expect(captureProductScopeRows($exporter, $product))->toBe([[
+        'channel'                 => 'web',
+        'locale'                  => 'en_US',
+        'sku'                     => 'CHILD-COLUMNS',
+        'status'                  => 'false',
+        'type'                    => 'simple',
+        'parent'                  => 'PARENT-COLUMNS',
+        'attribute_family'        => 'column_family',
+        'variant_structure'       => null,
+        'configurable_attributes' => '',
+        'categories'              => 'clothes',
+        'scoped_text'             => 'selected-value',
+    ]]);
+});
 
 it('counts every exported attribute column when the selection is empty', function (): void {
     seedProductScopeChannels();
@@ -398,3 +467,16 @@ it('parses every stored multiselect shape into codes', function () {
     expect(ScopeFilterValue::toCodes(['GBP']))->toBe(['GBP']);
     expect(ScopeFilterValue::toCodes(null))->toBe([]);
 });
+
+class ProductScopeAdditionalColumnsExporter extends Exporter
+{
+    protected function getBaseFields(array $rowData = []): array
+    {
+        return array_merge(parent::getBaseFields($rowData), ['external_id' => 'external-1']);
+    }
+
+    protected function getAssociationColumns(): array
+    {
+        return [...parent::getAssociationColumns(), 'custom_association'];
+    }
+}

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php
@@ -129,7 +129,7 @@ it('intersects explicit locale and currency selections within the channel scope'
     expect($currencies)->toBe(['EUR']);
 });
 
-it('keeps every attribute column and records the selected attributes', function () {
+it('keeps every attribute loaded and records the selected attributes', function () {
     seedProductScopeChannels();
     Attribute::factory()->create(['code' => 'scoped_attr']);
     Cache::flush();
@@ -143,7 +143,7 @@ it('keeps every attribute column and records the selected attributes', function 
     expect(readExporterProperty($exporter, 'selectedAttributeCodes'))->toBe(['scoped_attr']);
 });
 
-it('exports values only for the selected attributes while keeping every column', function () {
+it('drops the columns of attributes outside the selection', function () {
     seedProductScopeChannels();
     Attribute::factory()->create(['code' => 'scoped_attr']);
     Cache::flush();
@@ -159,8 +159,42 @@ it('exports values only for the selected attributes while keeping every column',
     ], null);
 
     expect($values['scoped_attr'])->toBe('selected-value');
-    expect($values)->toHaveKey('name');
-    expect($values['name'])->toBeNull();
+    expect($values)->not->toHaveKey('name');
+});
+
+it('drops the price columns of an unselected price attribute', function () {
+    seedProductScopeChannels();
+    Attribute::factory()->create(['code' => 'scoped_attr']);
+    Attribute::factory()->create(['code' => 'list_price', 'type' => 'price']);
+    Cache::flush();
+
+    $exporter = makeInitializedProductExporter(['attributes' => ['scoped_attr']]);
+
+    $method = new ReflectionMethod($exporter, 'setAttributesValues');
+    $method->setAccessible(true);
+
+    $values = $method->invoke($exporter, ['scoped_attr' => 'selected-value'], null);
+
+    expect(array_keys($values))->toBe(['scoped_attr']);
+});
+
+it('sizes the disk-budget estimate on the selected attributes only', function () {
+    seedProductScopeChannels();
+    Attribute::factory()->create(['code' => 'scoped_attr']);
+    Cache::flush();
+
+    $selected = makeInitializedProductExporter(['attributes' => ['scoped_attr']]);
+    $everything = makeInitializedProductExporter([]);
+
+    $countColumns = function (Exporter $exporter): int {
+        $method = new ReflectionMethod($exporter, 'countExportedColumns');
+        $method->setAccessible(true);
+
+        return $method->invoke($exporter);
+    };
+
+    expect($countColumns($selected))->toBe(1)
+        ->and($countColumns($everything))->toBeGreaterThan(1);
 });
 
 it('keeps every attribute when none is selected', function () {

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php
@@ -32,7 +32,7 @@ function readExporterProperty(Exporter $exporter, string $name): mixed
     return $property->getValue($exporter);
 }
 
-function makeInitializedProductExporter(array $filters): Exporter
+function makeProductScopeExporter(array $filters): Exporter
 {
     $jobInstance = JobInstances::create([
         'code'                => 'product_export_'.uniqid(),
@@ -54,6 +54,13 @@ function makeInitializedProductExporter(array $filters): Exporter
 
     $exporter = app(Exporter::class);
     $exporter->setExport($jobTrack);
+
+    return $exporter;
+}
+
+function makeInitializedProductExporter(array $filters): Exporter
+{
+    $exporter = makeProductScopeExporter($filters);
 
     resetProductExporterCache();
     $exporter->initilize();
@@ -178,23 +185,86 @@ it('drops the price columns of an unselected price attribute', function () {
     expect(array_keys($values))->toBe(['scoped_attr']);
 });
 
-it('sizes the disk-budget estimate on the selected attributes only', function () {
+it('sizes the disk-budget estimate on the columns written before initialization', function (array $filters, int $expectedColumns): void {
     seedProductScopeChannels();
-    Attribute::factory()->create(['code' => 'scoped_attr']);
+    Attribute::factory()->create(['code' => 'scoped_text', 'type' => 'text']);
+    Attribute::factory()->create(['code' => 'scoped_price', 'type' => 'price']);
+    Attribute::factory()->create(['code' => 'scoped_measurement', 'type' => 'measurement']);
+    Channel::where('code', 'mobile')->firstOrFail()->currencies()->attach(
+        Currency::where('code', 'EUR')->firstOrFail()->id
+    );
+    $product = Product::factory()->withInitialValues()->create();
     Cache::flush();
 
-    $selected = makeInitializedProductExporter(['attributes' => ['scoped_attr']]);
-    $everything = makeInitializedProductExporter([]);
+    $exporter = makeProductScopeExporter(array_merge(['channels' => ['web']], $filters));
+    $countColumns = new ReflectionMethod($exporter, 'countExportedColumns');
 
-    $countColumns = function (Exporter $exporter): int {
-        $method = new ReflectionMethod($exporter, 'countExportedColumns');
-        $method->setAccessible(true);
+    $estimatedColumns = $countColumns->invoke($exporter);
 
-        return $method->invoke($exporter);
+    $buffer = new class
+    {
+        public array $rows = [];
+
+        public function write(array $items, array $options = []): void
+        {
+            $this->rows = array_merge($this->rows, $items);
+        }
     };
 
-    expect($countColumns($selected))->toBe(1)
-        ->and($countColumns($everything))->toBeGreaterThan(1);
+    $exporter->setExportBuffer($buffer);
+    $exporter->initilize();
+    $exporter->prepareProducts(new JobTrackBatch(['data' => [['id' => $product->id]]]), null);
+
+    expect($buffer->rows)->not->toBeEmpty();
+    expect($buffer->rows)->each->toHaveCount($expectedColumns);
+    expect($estimatedColumns)->toBe($expectedColumns);
+})->with([
+    'fixed columns'                  => [['attributes' => ['scoped_text']], 11],
+    'association columns'            => [['attributes' => ['scoped_text'], 'with_associations' => true], 14],
+    'sku and status counted once'    => [['attributes' => ['sku', 'status', 'scoped_text']], 11],
+    'measurement unit column'        => [['attributes' => ['scoped_measurement']], 12],
+    'channel currencies'             => [['attributes' => ['scoped_price']], 12],
+    'selected currency'              => [['attributes' => ['scoped_price'], 'currencies' => ['EUR']], 11],
+    'currency outside channel scope' => [['attributes' => ['scoped_price'], 'currencies' => ['GBP']], 10],
+    'shared currency counted once'   => [['attributes' => ['scoped_price'], 'channels' => ['web', 'mobile']], 13],
+    'mixed attribute types'          => [['attributes' => ['scoped_text', 'scoped_price', 'scoped_measurement'], 'with_associations' => true], 18],
+    'deleted attribute selection'    => [['attributes' => ['deleted_attribute']], 10],
+    'selection across query chunks'  => [['attributes' => array_merge(
+        array_map(fn (int $index): string => 'deleted_attribute_'.$index, range(1, 999)),
+        ['scoped_text', 'scoped_price']
+    )], 13],
+]);
+
+it('counts every exported attribute column when the selection is empty', function (): void {
+    seedProductScopeChannels();
+    Attribute::factory()->create(['code' => 'scoped_text', 'type' => 'text']);
+    Attribute::factory()->create(['code' => 'scoped_price', 'type' => 'price']);
+    Attribute::factory()->create(['code' => 'scoped_measurement', 'type' => 'measurement']);
+    Cache::flush();
+
+    $exporter = makeProductScopeExporter(['channels' => ['web']]);
+    $countColumns = new ReflectionMethod($exporter, 'countExportedColumns');
+    $estimatedColumns = $countColumns->invoke($exporter);
+
+    $exporter->initilize();
+    $attributeColumns = (new ReflectionMethod($exporter, 'setAttributesValues'))->invoke($exporter, [], null);
+
+    expect($attributeColumns)->toHaveKeys(['scoped_text', 'scoped_price (USD)', 'scoped_price (EUR)', 'scoped_measurement', 'scoped_measurement(unit)'])
+        ->not->toHaveKeys(['sku', 'status']);
+    expect($estimatedColumns)->toBe(10 + count($attributeColumns));
+});
+
+it('rejects an export when its fixed columns push it over the disk budget', function (): void {
+    seedProductScopeChannels();
+    Attribute::factory()->create(['code' => 'scoped_text', 'type' => 'text']);
+    Cache::flush();
+
+    $exporter = makeProductScopeExporter(['attributes' => ['scoped_text']]);
+    $columns = (new ReflectionMethod($exporter, 'countExportedColumns'))->invoke($exporter);
+    $exceedsBudget = new ReflectionMethod($exporter, 'exportExceedsDiskBudget');
+
+    expect($exceedsBudget->invoke($exporter, 3_000_000, $columns, 1_000_000_000))->toBeTrue();
+    expect($exceedsBudget->invoke($exporter, 1_000_000, $columns, 1_000_000_000))->toBeFalse();
 });
 
 it('keeps every attribute when none is selected', function () {


### PR DESCRIPTION
## Description

Fixes #695.

A product export profile that selects attributes still wrote a column for every attribute in the installation, the unselected ones arriving as empty columns.

`setAttributesValues()` looped over every attribute and wrote a `null` placeholder under the codes outside the selection. `FlatItemBuffer` derives the header from the first row's keys, so those placeholders kept every attribute as a column, contradicting the filter's own help text: "Only the selected attributes are exported."

The change skips the unselected codes instead of blanking them. Every row runs the same loop with the same selection, so the key set stays identical across rows and batches, which is what the buffer's positional writes rely on.

Three parts:

- The flat-attribute loop drops the `null` placeholder and its price-column variant.
- The measurement branch carried its own copy of the placeholder; without the same treatment the pair of columns it owns (the amount and its `(unit)` companion) survived the parent's skip.
- `assertExportIsFeasible()` now sizes the disk-budget guard on the selected column count, so a narrow profile is no longer charged for every attribute in the catalogue and rejected as too large. It reads the codes from the filters rather than from `$selectedAttributeCodes` because the guard runs during `initializeBatches()`, before `initilize()` has applied the scope filters.

Worth noting for anyone assessing severity: the importer skips a cell only when it is `is_null`, so an empty CSV cell arrives as `''` and is written as a real value. Re-importing an export made with an attribute selection therefore wiped every unselected attribute. That round trip is safe again once the columns are gone.

## How To Test This?

1. On an installation with a few dozen product attributes, create a product export profile (CSV or XLSX).
2. Under **Attributes**, select a handful — e.g. `color`, `size`, `material`, `weight`.
3. Run the export. The file should carry the fixed product columns plus those four, and nothing else.
4. Re-import that file and confirm no unselected attribute is cleared on the affected products.
5. Repeat with a measurement attribute in the selection, and with one outside it, to confirm the `(unit)` companion column follows its attribute.
6. `vendor/bin/pest packages/Webkul/DataTransfer/tests/Unit/Helpers/Exporters/Product/ScopeFilterTest.php`

## Verification

| Gate | Result |
| --- | --- |
| `vendor/bin/pint --test` | passed |
| `vendor/bin/phpstan analyse` (level 2) | no errors |
| `vendor/bin/rector --dry-run` | no change on the edited lines |
| `php artisan unopim:translations:check` | 386/386 |
| `vendor/bin/pest` DataTransfer + Measurement | 1131 passed, 10 failed |

The 10 failures are pre-existing: the same 10 fail on unmodified `3.x` at `d33fc74c`. They are association-export, inherited-value, sample-import and channel-scoped-measurement cases, unrelated to this change.

Two Rector suggestions in the touched file (`app()` to `resolve()`, an arrow-function return type) sit on pre-existing lines and were left alone.

https://claude.ai/code/session_01JvM9wYbv339YvEnEuvsKrT