### PR TITLE
fix(data-transfer): match export category codes against the keyword subfield

### DIFF
--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
@@ -11,6 +11,13 @@ use Webkul\ElasticSearch\Cursor\AbstractElasticCursor;
 class ProductCursor extends AbstractElasticCursor
 {
     /**
+     * `values.categories` is indexed as analyzed text, so its tokens are lowercased and a
+     * term-level `terms` lookup for a code such as "Footwear" never matches. The exact-value
+     * keyword subfield is what a category code has to be compared against.
+     */
+    const CATEGORY_FIELD = 'values.categories.keyword';
+
+    /**
      * Memoized bool query. The filter clauses (family/category/value-filtered ids) are identical
      * for every page of a single export run, so they are resolved once instead of re-running the
      * underlying DB queries on every search_after fetch.
@@ -105,7 +112,7 @@ class ProductCursor extends AbstractElasticCursor
         $categoryCodes = $filter->categoryCodes($filters);
 
         if (! empty($categoryCodes)) {
-            $clauses[] = ['terms' => ['values.categories' => $categoryCodes]];
+            $clauses[] = ['terms' => [self::CATEGORY_FIELD => $categoryCodes]];
         }
 
         $range = array_filter([

--- a/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Sources/Export/Elastic/ProductCursor.php
@@ -15,7 +15,7 @@ class ProductCursor extends AbstractElasticCursor
      * term-level `terms` lookup for a code such as "Footwear" never matches. The exact-value
      * keyword subfield is what a category code has to be compared against.
      */
-    const CATEGORY_FIELD = 'values.categories.keyword';
+    private const string CATEGORY_FIELD = 'values.categories.keyword';
 
     /**
      * Memoized bool query. The filter clauses (family/category/value-filtered ids) are identical

--- a/packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/Export/Elastic/ProductCursorBoolQueryTest.php
+++ b/packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/Export/Elastic/ProductCursorBoolQueryTest.php
@@ -50,6 +50,14 @@ it('builds a status term clause', function () {
     ]);
 });
 
+it('matches category codes against the exact-value keyword subfield', function () {
+    expect(buildBoolQuery(['categories' => ['Footwear', 'Outerwear']]))->toBe([
+        'filter' => [
+            ['terms' => ['values.categories.keyword' => ['Footwear', 'Outerwear']]],
+        ],
+    ]);
+});
+
 it('builds an updated_at range clause', function () {
     expect(buildBoolQuery(['updated_after' => '2026-01-01 00:00:00']))->toBe([
         'filter' => [


### PR DESCRIPTION
## Description

Fixes #696.

A product export profile with a category filter matched no products. The job finished as `completed` with `{"created": 0, "skipped": 0, "processed": 0}` and produced no file, so it read as "the catalogue has no matching products" rather than as a failure.

`values.categories` is indexed as analyzed `text`, so the indexed tokens are lowercased. The export cursor filtered it with a `terms` query, which is term-level and does not analyze its input, so a category code carrying an uppercase letter was compared against a lowercased token and matched nothing.

The clause now targets the exact-value keyword subfield, `values.categories.keyword`.

The product grid sidesteps the same mapping by lowercasing its values through `QueryString::escapeArrayValue()`. The export cursor never got that treatment, and `ProductCursorBoolQueryTest` had no case covering the category clause, so nothing caught it. This adds that case.

Only the Elasticsearch path is affected. The database cursor uses `whereJsonContains` and was always correct.

The grid's lowercase approach is also fragile for a second reason worth a separate look: the standard analyzer splits on hyphens, so a category code such as `summer-sale` indexes as two tokens and matches nothing either way. The keyword subfield is exact for both cases.

## How To Test This?

1. Set `ELASTICSEARCH_ENABLED=true` and index the catalogue.
2. Have a category whose code contains an uppercase letter, e.g. `Footwear`, with a few products assigned to it.
3. Create a product export profile and set **Categories** to that category.
4. Run the export. Every product in the category should be exported; before this change the run completed with zero records and no file.
5. `vendor/bin/pest packages/Webkul/DataTransfer/tests/Unit/Helpers/Sources/Export/Elastic/ProductCursorBoolQueryTest.php`

## Verification

| Gate | Result |
| --- | --- |
| `vendor/bin/pint --test` | passed |
| `vendor/bin/phpstan analyse` (level 2) | no errors |
| `vendor/bin/rector --dry-run` | no changes |
| `vendor/bin/pest` DataTransfer + ElasticSearch | 9 failed, rest passed |

Those 9 failures are pre-existing: the same cases fail on unmodified `3.x` at `d33fc74c`, and none touch the cursor.

Note for deployment: PHP changes do not reach queue workers until they restart, so `php artisan queue:restart` is needed for this to take effect on a running installation.

https://claude.ai/code/session_01JvM9wYbv339YvEnEuvsKrT