### PR TITLE
fix(ai-chat-agent): add Gemini chat completions endpoint

### DIFF
--- a/packages/Webkul/AiAgent/src/Http/Client/AiApiClient.php
+++ b/packages/Webkul/AiAgent/src/Http/Client/AiApiClient.php
@@ -189,6 +189,7 @@ class AiApiClient
     {
         return match ($this->provider) {
             'anthropic' => $this->baseUrl.'/v1/messages',
+            'gemini'    => $this->baseUrl.'/openai/chat/completions',
             default     => $this->baseUrl.'/v1/chat/completions',
         };
     }


### PR DESCRIPTION
## Issue Reference

No issue reference.

## Description

Fix the Gemini chat endpoint in the AI Chat Agent client.

Previously, Gemini requests fell through to the default OpenAI-compatible endpoint:

`/v1/chat/completions`

Gemini's OpenAI-compatible API uses:

`/openai/chat/completions`

This change adds a dedicated `gemini` provider case so Gemini requests are sent to the correct endpoint while preserving the existing endpoints for Anthropic and other OpenAI-compatible providers.

## How To Test This?

1. Configure the AI Chat Agent with:

   * Provider: `gemini`
   * A valid Gemini API key
   * A Gemini model
2. Send a chat request through the AI Chat Agent.
3. Verify that the request uses `/openai/chat/completions`.
4. Verify that the Gemini response is returned successfully.
5. Verify that Anthropic requests still use `/v1/messages`.
6. Verify that other OpenAI-compatible providers still use `/v1/chat/completions`.
