### PR TITLE
feat(admin): make the product grid quick-search fields configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Extended the upload active-content scan from PDF to Office documents: `.docx`/`.pptx` packages shipping a VBA project, legacy `.doc`/`.ppt` files carrying a VBA stream, and RTF documents with auto-updating embedded objects are now rejected at save time, with the reason reported in the validation message.
 - Added a pick-time scan to the media widgets (files, gallery, image) so a rejected upload is reported as soon as it is chosen, before the form is submitted.
+- Fixed a product quick search none of whose fields resolves to an attribute returning the entire catalogue instead of no products. The database path dropped the empty condition group; the Elasticsearch path emitted an empty `should`, which Elasticsearch answers with a match_all because it applies `minimum_should_match` only once there are `should` clauses to count. Both now refuse the term, with `1 = 0` and with `match_none`.
 
 # 3.1.0 — August 27th, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added a pick-time scan to the media widgets (files, gallery, image) so a rejected upload is reported as soon as it is chosen, before the form is submitted.
 - Fixed a product quick search none of whose fields resolves to an attribute returning the entire catalogue instead of no products. The database path dropped the empty condition group; the Elasticsearch path emitted an empty `should`, which Elasticsearch answers with a match_all because it applies `minimum_should_match` only once there are `should` clauses to count. Both now refuse the term, with `1 = 0` and with `match_none`.
 
+## New features
+
+- The product grid's quick search reads the attribute codes it looks in from `products.search_fields`, so an EAN, a GTIN or a supplier article number can be searched from the one search box. An attribute marked `is_filterable` could already be filtered by substring on its own grid column with the `contains` operator; this saves adding the column and picking the operator, and covers identifier attributes that are not filterable, such as the seeded `product_number`. The SKU and the name are still searched by default, codes that do not resolve to a text attribute are skipped, and at most ten are searched.
+
 # 3.1.0 — August 27th, 2026
 
 ## Bug fixes

--- a/config/products.php
+++ b/config/products.php
@@ -11,4 +11,50 @@ return [
     'copy' => [
         'skip_attributes' => [],
     ],
+
+    /**
+     * Attribute codes the product grid's quick search box looks in.
+     *
+     * Defaults to the SKU and the name. Add identifier attributes such as an
+     * EAN, a GTIN or a supplier article number to make a product findable by
+     * them from the one search box (Example: ['sku', 'name', 'ean',
+     * 'supplier_article_number']). An attribute marked `is_filterable` can
+     * already be filtered on its own grid column with the `contains`
+     * operator; listing it here saves adding the column and picking the
+     * operator, and works for attributes that are not filterable as well --
+     * `is_filterable` is deliberately not consulted.
+     *
+     * Applies to the product grid's quick search box only. The association and
+     * variant product pickers (`admin.catalog.products.search`) still match
+     * the SKU column.
+     *
+     * Only text attributes are searched, because the quick search is a text
+     * search: Elasticsearch maps price as float and date/datetime as date, and
+     * the option backed types store the option code rather than the label that
+     * was typed. textarea is excluded as well, because a long text attribute
+     * matches most of the catalogue and the grid orders by its sort column
+     * rather than by relevance, so the row that was meant would not come
+     * first. Codes resolving to anything else, or to no attribute at all, are
+     * skipped, and the SKU and the name are searched when none of them is
+     * left.
+     *
+     * At most ten codes are used. The order given here is kept, except that
+     * the SKU and the name are moved to the front so a long list cannot push
+     * them out. The cap matters most without Elasticsearch: on the database
+     * path every code adds a JSON extraction and a leading-wildcard LIKE per
+     * product to a query no index can serve, while on Elasticsearch it adds
+     * one more clause to a query that is already indexed.
+     *
+     * The two engines do not match alike: Elasticsearch matches from the start
+     * of a word (match_phrase_prefix), the database matches anywhere in the
+     * value (LIKE '%term%'). The last six digits of an EAN therefore find the
+     * product without Elasticsearch and find nothing with it; the full
+     * identifier finds it on both.
+     *
+     * On installations that cache the configuration (`php artisan
+     * config:cache`, `php artisan optimize`), run `php artisan config:clear`
+     * or re-cache after changing this list, otherwise the previous value stays
+     * in effect.
+     */
+    'search_fields' => ['sku', 'name'],
 ];

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Webkul\Admin\Filters\ProductPropertyFilters;
 use Webkul\Admin\Traits\AttributeColumnTrait;
+use Webkul\Attribute\Models\Attribute as AttributeModel;
 use Webkul\Attribute\Repositories\AttributeFamilyRepository;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Attribute\Services\AttributeService;
@@ -29,6 +30,44 @@ use Webkul\Product\Type\AbstractType;
 class ProductDataGrid extends DataGrid implements ExportableInterface
 {
     use AttributeColumnTrait;
+
+    /**
+     * Searched by the quick search box when `products.search_fields` is unset,
+     * and fallen back to when none of the configured codes resolves to a
+     * searchable attribute. Keeping the historical pair here means a mistyped
+     * configuration narrows the search back to the SKU and the name instead of
+     * leaving both engines with a term they cannot evaluate, which they now
+     * answer with no products at all.
+     *
+     * Read through `static::`, so a data grid subclassing this one can replace
+     * the list; the same goes for the two constants below.
+     *
+     * @var array<int, string>
+     */
+    protected const DEFAULT_SEARCH_FIELDS = ['sku', 'name'];
+
+    /**
+     * Attribute types the quick search can look in.
+     *
+     * Text only. It is a text search, and the remaining types either cannot
+     * answer one -- Elasticsearch maps price as float and date/datetime as
+     * date -- or answer it with the option code rather than the label that was
+     * typed, so a configured `color` would be found by typing `midnight_blue`
+     * rather than "Midnight Blue". textarea is left out although the index
+     * would accept it: a description matches most of the catalogue, and the
+     * grid cannot float the row that was meant, because the Elasticsearch
+     * query is wrapped in a constant_score and the rows come back in the sort
+     * column's order rather than by relevance.
+     *
+     * @var array<int, string>
+     */
+    protected const SEARCHABLE_ATTRIBUTE_TYPES = [AttributeModel::TEXT_TYPE];
+
+    /**
+     * Upper bound on the configured search fields. Every field adds a clause
+     * to every quick search, on the Elasticsearch and on the database path.
+     */
+    protected const MAX_SEARCH_FIELDS = 10;
 
     /**
      * Prepare query builder.
@@ -678,7 +717,7 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
             }
 
             if ($attribute === 'all') {
-                $queryBuilder->applySkuOrUnfilteredFilter(['sku', 'name'], FilterOperators::WILDCARD, $value, $context);
+                $queryBuilder->applySkuOrUnfilteredFilter($this->getSearchFields(), FilterOperators::WILDCARD, $value, $context);
 
                 continue;
             }
@@ -698,6 +737,61 @@ class ProductDataGrid extends DataGrid implements ExportableInterface
                 $this->applyFilterValue($queryBuilder, $attribute, $value, $operator, $context);
             }
         }
+    }
+
+    /**
+     * Attribute codes the quick search box looks in, from `products.search_fields`.
+     *
+     * Codes that do not resolve to a searchable attribute are skipped, so a bad
+     * entry narrows the search instead of breaking it, and the default pair is
+     * searched when nothing is left. The configured order is preserved, so the
+     * cap drops the codes the administrator wrote last rather than an arbitrary
+     * pair: `findByCodes()` returns its map in attribute cache order, not in the
+     * order it was asked for. The default pair is moved in front of the rest
+     * before the cap is applied, so a long list cannot push the SKU out of the
+     * quick search. Resolving the whole list in one call also warms the cache
+     * the filter then reads field by field.
+     *
+     * `is_filterable` is deliberately not consulted. It gates the per-column
+     * filters, and the seeded identifier attribute this feature exists for,
+     * `product_number`, ships with it turned off, so honouring it here would
+     * make the documented example fail on a fresh install.
+     *
+     * @return array<int, string>
+     */
+    protected function getSearchFields(): array
+    {
+        $configured = array_values(array_unique(array_filter(
+            (array) config('products.search_fields', static::DEFAULT_SEARCH_FIELDS),
+            fn ($code): bool => is_string($code) && $code !== '',
+        )));
+
+        if ($configured === []) {
+            return static::DEFAULT_SEARCH_FIELDS;
+        }
+
+        $attributes = $this->attributeService->findByCodes($configured) ?? [];
+
+        $fields = [];
+
+        foreach ($configured as $code) {
+            $attribute = $attributes[$code] ?? null;
+
+            if ($attribute && in_array($attribute->type, static::SEARCHABLE_ATTRIBUTE_TYPES, true)) {
+                $fields[] = $code;
+            }
+        }
+
+        if ($fields === []) {
+            return static::DEFAULT_SEARCH_FIELDS;
+        }
+
+        $fields = array_values(array_unique(array_merge(
+            array_intersect(static::DEFAULT_SEARCH_FIELDS, $fields),
+            $fields,
+        )));
+
+        return array_slice($fields, 0, static::MAX_SEARCH_FIELDS);
     }
 
     protected function getOperatorAndValue($attribute, $value)

--- a/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSearchFieldsTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/ProductDataGridSearchFieldsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use Illuminate\Support\Arr;
+use Webkul\Admin\DataGrids\Catalog\ProductDataGrid;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Services\AttributeService;
+use Webkul\ElasticSearch\ElasticSearchQuery;
+use Webkul\ElasticSearch\Enums\FilterOperators;
+use Webkul\Product\Filter\ElasticSearch\SkuOrUniversalFilter;
+use Webkul\Product\Models\Product;
+
+/*
+ * The quick search box posts its term as filters[all]. Which attribute codes it
+ * looks in comes from products.search_fields; whatever is configured there, the
+ * search must never degrade into matching everything or matching nothing.
+ *
+ * The end-to-end cases are driven on the database path, which resolves the
+ * field list through the same ProductDataGrid::processFilters() call site as
+ * the Elasticsearch path and needs no live index. The last case asserts that
+ * the list the grid resolves is one the Elasticsearch filter turns into
+ * clauses, which is the half a database-only run cannot see.
+ */
+
+beforeEach(function () {
+    config(['elasticsearch.enabled' => false]);
+
+    $this->loginAsAdmin();
+
+    Product::factory()->create([
+        'sku'    => 'QSEARCHA',
+        'values' => ['common' => ['sku' => 'QSEARCHA', 'product_number' => '1111111111116']],
+    ]);
+
+    Product::factory()->create([
+        'sku'    => 'QSEARCHB',
+        'values' => ['common' => ['sku' => 'QSEARCHB', 'product_number' => '2222222222223']],
+    ]);
+});
+
+/**
+ * The SKUs the quick search box returns for one term.
+ *
+ * @return array<int, string>
+ */
+function quickSearchSkus(string $term): array
+{
+    $response = test()->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+        ->json('GET', route('admin.catalog.products.index'), [
+            'pagination' => ['page' => 1, 'per_page' => 50],
+            'filters'    => ['all' => [$term]],
+        ])->assertOk();
+
+    return collect($response->json('records'))->pluck('sku')->all();
+}
+
+/**
+ * The field list the grid resolves from the current configuration.
+ *
+ * @return array<int, string>
+ */
+function resolvedSearchFields(): array
+{
+    app()->forgetInstance(AttributeService::class);
+
+    $method = new ReflectionMethod(ProductDataGrid::class, 'getSearchFields');
+    $method->setAccessible(true);
+
+    return $method->invoke(app(ProductDataGrid::class));
+}
+
+it('searches the sku and not other identifiers by default', function () {
+    expect(quickSearchSkus('QSEARCHA'))->toContain('QSEARCHA')->not->toContain('QSEARCHB');
+
+    expect(quickSearchSkus('1111111111116'))->not->toContain('QSEARCHA');
+});
+
+it('searches the sku and the name on an installation whose config file predates the setting', function () {
+    /*
+     * The shipped config/products.php carries the key, so every other case in
+     * this file reads it. An installation upgraded from an earlier release
+     * does not have it: that path falls through to the class constant, and it
+     * is the path every existing installation takes.
+     */
+    config(['products' => Arr::except(config('products'), 'search_fields')]);
+
+    expect(config()->has('products.search_fields'))->toBeFalse();
+
+    expect(resolvedSearchFields())->toBe(['sku', 'name']);
+
+    expect(quickSearchSkus('QSEARCHA'))->toContain('QSEARCHA')->not->toContain('QSEARCHB');
+});
+
+it('ships the same default in the config file and in the class constant', function () {
+    /*
+     * A fresh installation reads the config file, an upgraded one reads the
+     * constant. They have to agree, or the two populations search different
+     * fields out of the box.
+     */
+    expect(config('products.search_fields'))
+        ->toBe((new ReflectionClass(ProductDataGrid::class))->getConstant('DEFAULT_SEARCH_FIELDS'));
+});
+
+it('searches a configured identifier attribute too', function () {
+    config(['products.search_fields' => ['sku', 'name', 'product_number']]);
+
+    expect(quickSearchSkus('1111111111116'))->toContain('QSEARCHA')->not->toContain('QSEARCHB');
+
+    expect(quickSearchSkus('QSEARCHB'))->toContain('QSEARCHB')->not->toContain('QSEARCHA');
+});
+
+it('falls back to the sku and name pair when nothing configured is searchable', function () {
+    config(['products.search_fields' => ['no_such_attribute', 'price']]);
+
+    expect(quickSearchSkus('QSEARCHA'))->toContain('QSEARCHA')->not->toContain('QSEARCHB');
+
+    expect(quickSearchSkus('1111111111116'))->not->toContain('QSEARCHA');
+});
+
+it('resolves only the attribute types a text search can look in', function () {
+    config(['products.search_fields' => ['sku', 'price', 'color', 'no_such_attribute', 'description']]);
+
+    /*
+     * description is a textarea: a long text attribute matches most of the
+     * catalogue, and the grid orders by its sort column rather than by
+     * relevance, so the row that was meant would not come first.
+     */
+    expect(resolvedSearchFields())->toBe(['sku']);
+});
+
+it('keeps the configured order so the cap drops the codes written last', function () {
+    $cap = (new ReflectionClass(ProductDataGrid::class))->getConstant('MAX_SEARCH_FIELDS');
+
+    foreach (range(1, $cap + 3) as $index) {
+        Attribute::factory()->create(['code' => "qsearch_field_{$index}", 'type' => 'text']);
+    }
+
+    /*
+     * Configured in the reverse of the order they were created in on purpose:
+     * AttributeService::findByCodes() hands its map back in attribute cache
+     * order, so only reading the configured list keeps the administrator's own
+     * ordering in charge of which codes the cap drops.
+     */
+    $codes = collect(range($cap + 3, 1))
+        ->map(fn (int $index): string => "qsearch_field_{$index}")
+        ->all();
+
+    config(['products.search_fields' => $codes]);
+
+    expect(resolvedSearchFields())->toBe(array_slice($codes, 0, $cap));
+});
+
+it('never lets the cap drop the sku out of the quick search', function () {
+    $cap = (new ReflectionClass(ProductDataGrid::class))->getConstant('MAX_SEARCH_FIELDS');
+
+    foreach (range(1, $cap) as $index) {
+        Attribute::factory()->create(['code' => "qsearch_tail_{$index}", 'type' => 'text']);
+    }
+
+    $codes = collect(range(1, $cap))
+        ->map(fn (int $index): string => "qsearch_tail_{$index}")
+        ->all();
+
+    // Written last, so an unguarded array_slice would drop the one identifier
+    // the product grid cannot do without.
+    $codes[] = 'sku';
+
+    config(['products.search_fields' => $codes]);
+
+    $fields = resolvedSearchFields();
+
+    expect($fields)->toHaveCount($cap);
+    expect($fields[0])->toBe('sku');
+
+    expect(quickSearchSkus('QSEARCHA'))->toContain('QSEARCHA')->not->toContain('QSEARCHB');
+});
+
+it('hands a field list the elasticsearch filter turns into clauses', function () {
+    config(['products.search_fields' => ['sku', 'product_number']]);
+
+    $fields = resolvedSearchFields();
+
+    expect($fields)->toBe(['sku', 'product_number']);
+
+    $query = new ElasticSearchQuery;
+
+    $filter = resolve(SkuOrUniversalFilter::class);
+
+    $filter->setQueryManager($query);
+
+    $filter->applyUnfilteredFilter($fields, FilterOperators::WILDCARD, 'QSEARCHA', [
+        'locale'  => 'en_US',
+        'channel' => 'default',
+    ]);
+
+    $clauses = $query->build()['query']['constant_score']['filter']['bool']['filter'][0]['bool']['should'];
+
+    expect($clauses)->toHaveCount(2);
+
+    // Neither attribute is scoped, so the indexed path is the common one.
+    expect(json_encode($clauses))
+        ->toContain('values.common.sku-text')
+        ->toContain('values.common.product_number-text');
+});

--- a/packages/Webkul/Product/src/Filter/Database/SkuOrUniversalFilter.php
+++ b/packages/Webkul/Product/src/Filter/Database/SkuOrUniversalFilter.php
@@ -30,6 +30,8 @@ class SkuOrUniversalFilter extends AbstractDatabaseAttributeFilter
         $escapedValue = QueryString::escapeValue(current((array) $value));
 
         $this->queryBuilder->where(function ($query) use ($fields, $options, $escapedValue): void {
+            $searched = false;
+
             foreach ($fields as $attribute) {
                 $attribute = $this->attributeService->findAttributeByCode($attribute);
                 if (! $attribute instanceof Attribute) {
@@ -47,6 +49,18 @@ class SkuOrUniversalFilter extends AbstractDatabaseAttributeFilter
                     "LOWER($searchPath) LIKE ?",
                     '%'.strtolower($escapedValue).'%'
                 );
+
+                $searched = true;
+            }
+
+            if (! $searched) {
+                /**
+                 * A nested group that added no condition is dropped by the query
+                 * builder, which would answer a term that cannot be evaluated
+                 * with the entire catalogue. The Elasticsearch filter refuses
+                 * the same term with a match_none clause, so refuse it here too.
+                 */
+                $query->whereRaw('1 = 0');
             }
         });
 

--- a/packages/Webkul/Product/src/Filter/ElasticSearch/SkuOrUniversalFilter.php
+++ b/packages/Webkul/Product/src/Filter/ElasticSearch/SkuOrUniversalFilter.php
@@ -61,9 +61,14 @@ class SkuOrUniversalFilter extends AbstractElasticSearchAttributeFilter
             }
 
             /**
-             * For keyword fields (e.g., sku), use wildcard with
-             * rewrite: 'top_terms_1024' to cap internal clause expansion
-             * and avoid too_many_clauses error on large indexes.
+             * Every remaining type the indexer does not map as text, float or
+             * date lands on the fallback dynamic template, which maps it as a
+             * keyword (see ProductIndexer::dynamicAttributeMappings()); the
+             * option backed types are the ones that reach this in practice.
+             * rewrite: 'top_terms_1024' caps internal clause expansion and
+             * avoids a too_many_clauses error on large indexes. The product
+             * grid never gets here, because its quick search only ever looks
+             * in text attributes; only a direct caller of the filter does.
              */
             $clauses[] = [
                 'wildcard' => [
@@ -74,6 +79,22 @@ class SkuOrUniversalFilter extends AbstractElasticSearchAttributeFilter
                     ],
                 ],
             ];
+        }
+
+        if ($clauses === []) {
+            /**
+             * An empty `should` is not an empty result set. Elasticsearch
+             * builds the Lucene BooleanQuery first and answers a bool query
+             * that ended up with no clause at all with a MatchAllDocsQuery,
+             * before it looks at minimum_should_match -- which it only
+             * applies when there are should clauses to count. Emitting the
+             * empty bool would therefore answer a term that cannot be
+             * evaluated with the entire catalogue. match_none refuses it, the
+             * way the `1 = 0` of the database filter does.
+             */
+            $this->queryBuilder->where(['match_none' => new \stdClass]);
+
+            return $this;
         }
 
         $this->queryBuilder->where([

--- a/packages/Webkul/Product/tests/Unit/Filter/Database/SkuOrUniversalFilterTest.php
+++ b/packages/Webkul/Product/tests/Unit/Filter/Database/SkuOrUniversalFilterTest.php
@@ -66,3 +66,44 @@ describe('SkuOrUniversalFilter groups OR conditions correctly when combined with
         expect(strtolower($sql))->toContain('like ?');
     });
 });
+
+describe('SkuOrUniversalFilter refuses to answer a search it cannot evaluate', function () {
+
+    it('matches no products when not one field resolves, instead of returning every product', function () {
+        $filter = new SkuOrUniversalFilter(app(AttributeService::class));
+
+        $qb = DB::table('products');
+
+        $filter->setQueryManager($qb);
+
+        $filter->applyUnfilteredFilter(
+            ['no_such_attribute_code'],
+            FilterOperators::WILDCARD,
+            'test',
+            ['locale' => 'en_US', 'channel' => 'default']
+        );
+
+        // An empty nested group would be dropped and the term silently ignored.
+        expect($qb->toSql())->toContain('1 = 0');
+        expect(strtolower($qb->toSql()))->not->toContain('like ?');
+    });
+
+    it('still searches the fields that do resolve when another code does not', function () {
+        $filter = new SkuOrUniversalFilter(app(AttributeService::class));
+
+        $qb = DB::table('products');
+
+        $filter->setQueryManager($qb);
+
+        $filter->applyUnfilteredFilter(
+            ['sku', 'no_such_attribute_code'],
+            FilterOperators::WILDCARD,
+            'test',
+            ['locale' => 'en_US', 'channel' => 'default']
+        );
+
+        // One resolved field is enough; the refusal must not fire.
+        expect(substr_count(strtolower($qb->toSql()), 'like ?'))->toBe(1);
+        expect($qb->toSql())->not->toContain('1 = 0');
+    });
+});

--- a/packages/Webkul/Product/tests/Unit/Filter/ElasticSearch/SkuOrUniversalFilterTest.php
+++ b/packages/Webkul/Product/tests/Unit/Filter/ElasticSearch/SkuOrUniversalFilterTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Services\AttributeService;
+use Webkul\ElasticSearch\ElasticSearchQuery;
+use Webkul\ElasticSearch\Enums\FilterOperators;
+use Webkul\Product\Filter\ElasticSearch\SkuOrUniversalFilter;
+
+/*
+ * The quick search fans out over the field list it is handed. Whatever that
+ * list is, the query it emits must be one Elasticsearch evaluates against the
+ * term: an empty `bool` is answered with a match_all, because Elasticsearch
+ * applies minimum_should_match only once there are `should` clauses to count,
+ * so a term no field can answer would return the whole catalogue.
+ */
+
+beforeEach(function () {
+    config(['elasticsearch.enabled' => true]);
+});
+
+function quickSearchAttribute(string $code, string $type): Attribute
+{
+    $attribute = new Attribute;
+
+    $attribute->code = $code;
+    $attribute->type = $type;
+    $attribute->value_per_locale = false;
+    $attribute->value_per_channel = false;
+
+    return $attribute;
+}
+
+/**
+ * A filter resolving only the given codes; every other code resolves to null,
+ * the way a configured code that was never created behaves in production.
+ *
+ * @param  array<string, Attribute>  $attributes
+ */
+function quickSearchFilter(array $attributes): SkuOrUniversalFilter
+{
+    $attributeService = Mockery::mock(AttributeService::class);
+
+    $attributeService->shouldReceive('findAttributeByCode')
+        ->andReturnUsing(fn (string $code): ?Attribute => $attributes[$code] ?? null);
+
+    return new SkuOrUniversalFilter($attributeService);
+}
+
+/**
+ * The single `filter` clause one quick search put on the query.
+ *
+ * @param  array<int, string>  $fields
+ * @return array<string, mixed>
+ */
+function quickSearchClause(SkuOrUniversalFilter $filter, array $fields): array
+{
+    $query = new ElasticSearchQuery;
+
+    $filter->setQueryManager($query);
+
+    $filter->applyUnfilteredFilter($fields, FilterOperators::WILDCARD, 'test', [
+        'locale'  => 'en_US',
+        'channel' => 'default',
+    ]);
+
+    return $query->build()['query']['constant_score']['filter']['bool']['filter'][0];
+}
+
+/**
+ * The `should` clauses one quick search accumulated.
+ *
+ * @param  array<int, string>  $fields
+ * @return array<int, mixed>
+ */
+function quickSearchShouldClauses(SkuOrUniversalFilter $filter, array $fields): array
+{
+    return quickSearchClause($filter, $fields)['bool']['should'];
+}
+
+it('emits one clause per searchable field', function () {
+    $filter = quickSearchFilter([
+        'sku'      => quickSearchAttribute('sku', Attribute::TEXT_TYPE),
+        'ean_gtin' => quickSearchAttribute('ean_gtin', Attribute::TEXT_TYPE),
+    ]);
+
+    expect(quickSearchShouldClauses($filter, ['sku', 'ean_gtin']))->toHaveCount(2);
+});
+
+it('emits the cheap match_phrase_prefix clause rather than a wildcard', function () {
+    $filter = quickSearchFilter(['sku' => quickSearchAttribute('sku', Attribute::TEXT_TYPE)]);
+
+    $clauses = quickSearchShouldClauses($filter, ['sku']);
+
+    expect($clauses[0])->toHaveKey('match_phrase_prefix');
+    expect($clauses[0])->not->toHaveKey('wildcard');
+});
+
+it('skips a code that resolves to no attribute', function () {
+    $filter = quickSearchFilter(['sku' => quickSearchAttribute('sku', Attribute::TEXT_TYPE)]);
+
+    expect(quickSearchShouldClauses($filter, ['sku', 'gone_attribute']))->toHaveCount(1);
+});
+
+it('matches no products when not one field resolves, instead of returning every product', function () {
+    $filter = quickSearchFilter([]);
+
+    $clause = quickSearchClause($filter, ['gone_attribute', 'another_gone_attribute']);
+
+    /*
+     * An empty `should` with a minimum_should_match of 1 is NOT an empty
+     * result set: Elasticsearch builds the Lucene BooleanQuery first, returns
+     * a MatchAllDocsQuery for a bool query that ended up with no clause, and
+     * only then applies minimum_should_match -- which it skips when there are
+     * no should clauses. The filter has to say match_none itself.
+     */
+    expect($clause)->toHaveKey('match_none');
+    expect($clause)->not->toHaveKey('bool');
+    expect(json_encode($clause))->toBe('{"match_none":{}}');
+});


### PR DESCRIPTION
## Issue Reference

Closes #702

## Description

The product grid's quick search looked in a hardcoded `['sku', 'name']` — one literal in the `all` branch of `ProductDataGrid::processFilters()`, serving both the Elasticsearch and the database path. It now reads the codes from `products.search_fields`, so an identifier attribute such as an EAN or a supplier article number is findable from the one search box.

Two commits, the first standing on its own:

**`fix(product): match no products when a quick search resolves no field`**

When none of the codes handed to `SkuOrUniversalFilter` resolves, both engines answered with the entire catalogue: the database filter opened a `where` group it never filled, which the query builder drops; the Elasticsearch filter emitted `{"bool": {"should": [], "minimum_should_match": 1}}`, which Lucene answers with a `MatchAllDocsQuery` before `minimum_should_match` is applied. Now `1 = 0` and `match_none` respectively. Also corrects the comment above the ES wildcard branch, which claimed to serve "keyword fields (e.g., sku)" — `sku` is seeded `text` and has always taken the `match_phrase_prefix` branch above it.

**`feat(admin): make the product grid quick-search fields configurable`**

- `config/products.php` gains `'search_fields' => ['sku', 'name']`, documented in place.
- `ProductDataGrid::getSearchFields()` resolves the codes and hands them to `applySkuOrUnfilteredFilter()`. No signature below the call site changed.
- **Unchanged out of the box**, and on an upgraded installation whose config predates the key — both covered by a test, plus one asserting the config file and the constant cannot drift apart.
- **`text` only**, unknown or non-text codes skipped, default pair as the fallback, capped at ten with SKU and name pinned to the front.
- **`is_filterable` deliberately not consulted**: the seeded `product_number` ships with it off, so honouring it would make the documented example fail on a fresh install.
- The three constants are read through `static::`, so a subclassing grid — the DAM product grid does — can replace them.

Scope: the quick search box only. The association and variant pickers (`admin.catalog.products.search`) still match the SKU column.

Honest about the baseline: an attribute with `is_filterable` can already be filtered on its own column with `contains`. This puts identifiers into the single search box instead, and reaches attributes that are not filterable.

## How To Test This?

1. On a catalogue with a populated `text` identifier attribute, type its value into the product grid's search box — no results.
2. Add the code to `search_fields` in `config/products.php` (`config:clear` if the config is cached).
3. Search again — the product is found. Searching by SKU or name is unchanged.
4. Put a nonsense code in the list: the search falls back to SKU and name rather than breaking.
5. Worth running on both engines: `elasticsearch.enabled` true and false.

`vendor/bin/pest --filter=SearchFields` covers 1–4 on the database path.

## Checklist
- [ ] `vendor/bin/pest` passes locally *(not run — no PHP toolchain on the machine this was written on; `php -l` is clean on all changed files and the tests are written against the existing suites. Please let CI be the judge.)*
- [ ] `vendor/bin/pint --test` reports no style issues *(same reason; written to the `=>`-aligned house style)*
- [x] Tailwind classes are reordered *(no Tailwind changes)*
- [x] New user-facing strings use translation keys (all 33 locales) *(no new user-facing strings)*
- [x] Target branch is `3.x`, the current release line (`master` targets the next major)

## Documentation
- [x] My pull request requires an update on the documentation repository.

One new key, `products.search_fields`. Worth documenting: the default; text-only with skip-and-fallback; the ten-code cap and its cost without Elasticsearch; that `is_filterable` is not consulted; that Elasticsearch matches from the start of a word while the database matches anywhere in the value; and that `config:cache` installations must re-cache after editing. Happy to write that PR once the shape here is agreed.

---

*Disclosure: this patch was written by Claude Opus 5 (Anthropic), reviewed against the 3.x source and a running 3.1.0 instance before filing. The commits carry a `Co-Authored-By` trailer to the same effect. Review it as you would any outside contribution — and please do let CI be the judge of the two unchecked boxes above.*
